### PR TITLE
feat(collages): implement collages UI

### DIFF
--- a/src/components/admin/UserRankFormPage.tsx
+++ b/src/components/admin/UserRankFormPage.tsx
@@ -20,6 +20,10 @@ const PERM_GROUPS: { title: string; perms: string[] }[] = [
     perms: ['communities_manage']
   },
   {
+    title: 'Collages',
+    perms: ['collages_manage', 'collages_moderate']
+  },
+  {
     title: 'Users',
     perms: ['users_edit', 'users_warn', 'users_disable', 'invites_manage']
   },

--- a/src/components/collages/CollageBrowse.tsx
+++ b/src/components/collages/CollageBrowse.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useListCollagesQuery } from '../../store/services/collageApi';
+import type { CollageOrderBy } from '../../types';
+import Spinner from '../layout/Spinner';
+
+const CATEGORIES = [
+  { id: undefined, label: 'All' },
+  { id: 1, label: 'Theme / Genre' },
+  { id: 2, label: 'Discography' },
+  { id: 3, label: 'Label' },
+  { id: 4, label: 'Charts' },
+  { id: 5, label: 'Staff Picks' },
+  { id: 6, label: 'Other' }
+];
+
+const ORDER_OPTIONS: { value: CollageOrderBy; label: string }[] = [
+  { value: 'createdAt', label: 'Newest' },
+  { value: 'updatedAt', label: 'Recently Updated' },
+  { value: 'numEntries', label: 'Most Entries' },
+  { value: 'numSubscribers', label: 'Most Subscribers' },
+  { value: 'name', label: 'Name' }
+];
+
+const CollageBrowse = () => {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [categoryId, setCategoryId] = useState<number | undefined>(undefined);
+  const [orderBy, setOrderBy] = useState<CollageOrderBy>('createdAt');
+
+  const { data, isLoading, error } = useListCollagesQuery({
+    page,
+    search: search || undefined,
+    categoryId,
+    orderBy,
+    order: 'desc'
+  });
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSearch(searchInput);
+    setPage(1);
+  };
+
+  if (isLoading) return <Spinner />;
+  if (error)
+    return <div className="p-4 text-red-400">Failed to load collages.</div>;
+
+  const collages = data?.data ?? [];
+  const meta = data?.meta;
+
+  return (
+    <div className="thin">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">Collages</h2>
+        <Link
+          to="/private/collages/new"
+          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+        >
+          New Collage
+        </Link>
+      </div>
+
+      <form onSubmit={handleSearch} className="flex gap-2 mb-4">
+        <input
+          type="text"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Search collages…"
+          className="flex-1 px-3 py-1.5 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500"
+        />
+        <button
+          type="submit"
+          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+        >
+          Search
+        </button>
+      </form>
+
+      <div className="flex gap-2 mb-3 flex-wrap text-sm">
+        {CATEGORIES.map(({ id, label }) => (
+          <button
+            key={label}
+            onClick={() => {
+              setCategoryId(id);
+              setPage(1);
+            }}
+            className={`px-3 py-1 rounded border ${
+              categoryId === id
+                ? 'border-blue-500 bg-blue-900/30 text-blue-300'
+                : 'border-gray-700 text-gray-400 hover:border-gray-500'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2 mb-4 text-sm">
+        <span className="text-gray-400">Sort:</span>
+        <select
+          value={orderBy}
+          onChange={(e) => {
+            setOrderBy(e.target.value as CollageOrderBy);
+            setPage(1);
+          }}
+          className="bg-gray-900 border border-gray-700 rounded px-2 py-1 text-gray-200 text-sm"
+        >
+          {ORDER_OPTIONS.map(({ value, label }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {collages.length === 0 ? (
+        <p className="text-gray-500 text-sm">No collages found.</p>
+      ) : (
+        <div className="space-y-2">
+          {collages.map((c) => (
+            <div
+              key={c.id}
+              className="flex items-start justify-between p-3 bg-gray-900/50 border border-gray-800 rounded hover:border-gray-700"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 mb-1">
+                  <Link
+                    to={`/private/collages/${c.id}`}
+                    className="text-blue-400 hover:underline font-medium truncate"
+                  >
+                    {c.name}
+                  </Link>
+                  {c.isLocked && (
+                    <span className="text-xs px-1.5 py-0.5 bg-yellow-900/40 text-yellow-400 rounded">
+                      Locked
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-gray-400 line-clamp-1">
+                  {c.description}
+                </p>
+                {c.tags.length > 0 && (
+                  <div className="flex gap-1 mt-1 flex-wrap">
+                    {c.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="text-xs px-1.5 py-0.5 bg-gray-800 text-gray-400 rounded"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="ml-4 text-right text-xs text-gray-500 shrink-0">
+                <div>{c.numEntries} entries</div>
+                <div>{c.numSubscribers} subscribers</div>
+                <div className="mt-1">by {c.user?.username ?? '—'}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {meta && meta.totalPages > 1 && (
+        <div className="flex gap-2 mt-4 text-sm items-center">
+          <button
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-3 py-1 border border-gray-700 rounded disabled:opacity-40 hover:border-gray-500"
+          >
+            Prev
+          </button>
+          <span className="text-gray-400">
+            Page {page} of {meta.totalPages}
+          </span>
+          <button
+            disabled={page >= meta.totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-3 py-1 border border-gray-700 rounded disabled:opacity-40 hover:border-gray-500"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CollageBrowse;

--- a/src/components/collages/CollageCreate.tsx
+++ b/src/components/collages/CollageCreate.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useCreateCollageMutation } from '../../store/services/collageApi';
+
+const CATEGORIES = [
+  { id: 0, label: 'Personal' },
+  { id: 1, label: 'Theme / Genre Intro' },
+  { id: 2, label: 'Discography' },
+  { id: 3, label: 'Label' },
+  { id: 4, label: 'Charts' },
+  { id: 5, label: 'Staff Picks' },
+  { id: 6, label: 'Other' }
+];
+
+const CollageCreate = () => {
+  const navigate = useNavigate();
+  const [createCollage, { isLoading }] = useCreateCollageMutation();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [categoryId, setCategoryId] = useState(1);
+  const [tagsInput, setTagsInput] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    const tags = tagsInput
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    try {
+      const collage = await createCollage({
+        name,
+        description,
+        categoryId,
+        tags
+      }).unwrap();
+      navigate(`/private/collages/${collage.id}`);
+    } catch (err: unknown) {
+      const e = err as { data?: { msg?: string } };
+      setError(e?.data?.msg ?? 'Failed to create collage.');
+    }
+  };
+
+  return (
+    <div className="thin">
+      <h2 className="text-xl font-semibold mb-4">Create Collage</h2>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-900/30 border border-red-700 text-red-300 rounded text-sm">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm text-gray-300 mb-1">Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            minLength={3}
+            maxLength={100}
+            className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm text-gray-300 mb-1">Category</label>
+          <select
+            value={categoryId}
+            onChange={(e) => setCategoryId(Number(e.target.value))}
+            className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+          >
+            {CATEGORIES.map(({ id, label }) => (
+              <option key={id} value={id}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm text-gray-300 mb-1">
+            Description
+          </label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+            minLength={10}
+            rows={5}
+            className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-blue-500 resize-y"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm text-gray-300 mb-1">
+            Tags <span className="text-gray-500">(comma-separated)</span>
+          </label>
+          <input
+            type="text"
+            value={tagsInput}
+            onChange={(e) => setTagsInput(e.target.value)}
+            placeholder="jazz, 2020s, favorites"
+            className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+          />
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-sm rounded"
+          >
+            {isLoading ? 'Creating…' : 'Create Collage'}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate('/private/collages')}
+            className="px-4 py-2 border border-gray-700 text-gray-300 hover:border-gray-500 text-sm rounded"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default CollageCreate;

--- a/src/components/collages/CollageCreate.tsx
+++ b/src/components/collages/CollageCreate.tsx
@@ -57,8 +57,14 @@ const CollageCreate = () => {
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm text-gray-300 mb-1">Name</label>
+          <label
+            htmlFor="collage-name"
+            className="block text-sm text-gray-300 mb-1"
+          >
+            Name
+          </label>
           <input
+            id="collage-name"
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -70,8 +76,14 @@ const CollageCreate = () => {
         </div>
 
         <div>
-          <label className="block text-sm text-gray-300 mb-1">Category</label>
+          <label
+            htmlFor="collage-category"
+            className="block text-sm text-gray-300 mb-1"
+          >
+            Category
+          </label>
           <select
+            id="collage-category"
             value={categoryId}
             onChange={(e) => setCategoryId(Number(e.target.value))}
             className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-blue-500"
@@ -85,10 +97,14 @@ const CollageCreate = () => {
         </div>
 
         <div>
-          <label className="block text-sm text-gray-300 mb-1">
+          <label
+            htmlFor="collage-description"
+            className="block text-sm text-gray-300 mb-1"
+          >
             Description
           </label>
           <textarea
+            id="collage-description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             required
@@ -99,10 +115,14 @@ const CollageCreate = () => {
         </div>
 
         <div>
-          <label className="block text-sm text-gray-300 mb-1">
+          <label
+            htmlFor="collage-tags"
+            className="block text-sm text-gray-300 mb-1"
+          >
             Tags <span className="text-gray-500">(comma-separated)</span>
           </label>
           <input
+            id="collage-tags"
             type="text"
             value={tagsInput}
             onChange={(e) => setTagsInput(e.target.value)}

--- a/src/components/collages/CollageDetail.tsx
+++ b/src/components/collages/CollageDetail.tsx
@@ -1,0 +1,287 @@
+import { useState } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { selectCurrentUser } from '../../store/slices/authSlice';
+import {
+  useGetCollageQuery,
+  useDeleteCollageMutation,
+  useSubscribeCollageMutation,
+  useBookmarkCollageMutation,
+  useAddCollageEntryMutation,
+  useRemoveCollageEntryMutation
+} from '../../store/services/collageApi';
+import { hasAnyPermission } from '../../utils/permissions';
+import Spinner from '../layout/Spinner';
+import CommentsSection from '../layout/CommentsSection';
+
+const CATEGORY_LABELS: Record<number, string> = {
+  0: 'Personal',
+  1: 'Theme / Genre',
+  2: 'Discography',
+  3: 'Label',
+  4: 'Charts',
+  5: 'Staff Picks',
+  6: 'Other'
+};
+
+const CollageDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const collageId = Number(id);
+  const navigate = useNavigate();
+  const user = useSelector(selectCurrentUser);
+
+  const { data: collage, isLoading, error } = useGetCollageQuery(collageId);
+  const [deleteCollage] = useDeleteCollageMutation();
+  const [subscribe] = useSubscribeCollageMutation();
+  const [bookmark] = useBookmarkCollageMutation();
+  const [addEntry] = useAddCollageEntryMutation();
+  const [removeEntry] = useRemoveCollageEntryMutation();
+
+  const [releaseIdInput, setReleaseIdInput] = useState('');
+  const [addError, setAddError] = useState('');
+
+  if (isLoading) return <Spinner />;
+  if (error || !collage)
+    return <div className="p-4 text-red-400">Collage not found.</div>;
+
+  const isOwner = user?.id === collage.userId;
+  const isStaff = hasAnyPermission(user, [
+    'collages_moderate',
+    'staff',
+    'admin'
+  ]);
+  const canEdit = isOwner || isStaff;
+  const canManageEntries =
+    !collage.isLocked || isStaff
+      ? isOwner || isStaff || collage.categoryId !== 0
+      : false;
+
+  const handleDelete = async () => {
+    const msg =
+      collage.categoryId === 0
+        ? 'Delete this personal collage permanently?'
+        : 'Mark this collage as deleted? (Staff can recover it)';
+    if (!confirm(msg)) return;
+    try {
+      await deleteCollage(collageId).unwrap();
+      navigate('/private/collages');
+    } catch {
+      alert('Failed to delete collage.');
+    }
+  };
+
+  const handleSubscribe = async () => {
+    try {
+      await subscribe(collageId).unwrap();
+    } catch {
+      alert('Failed to update subscription.');
+    }
+  };
+
+  const handleBookmark = async () => {
+    try {
+      await bookmark(collageId).unwrap();
+    } catch {
+      alert('Failed to update bookmark.');
+    }
+  };
+
+  const handleAddEntry = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setAddError('');
+    const releaseId = Number(releaseIdInput.trim());
+    if (!releaseId) {
+      setAddError('Enter a valid release ID.');
+      return;
+    }
+    try {
+      await addEntry({ id: collageId, releaseId }).unwrap();
+      setReleaseIdInput('');
+    } catch (err: unknown) {
+      const e = err as { data?: { msg?: string } };
+      setAddError(e?.data?.msg ?? 'Failed to add entry.');
+    }
+  };
+
+  const handleRemoveEntry = async (releaseId: number) => {
+    if (!confirm('Remove this release from the collage?')) return;
+    try {
+      await removeEntry({ id: collageId, releaseId }).unwrap();
+    } catch {
+      alert('Failed to remove entry.');
+    }
+  };
+
+  return (
+    <div className="thin">
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <h2 className="text-xl font-semibold">{collage.name}</h2>
+            {collage.isLocked && (
+              <span className="text-xs px-2 py-0.5 bg-yellow-900/40 text-yellow-400 rounded">
+                Locked
+              </span>
+            )}
+            {collage.isDeleted && (
+              <span className="text-xs px-2 py-0.5 bg-red-900/40 text-red-400 rounded">
+                Deleted
+              </span>
+            )}
+          </div>
+          <div className="text-xs text-gray-500">
+            {CATEGORY_LABELS[collage.categoryId] ?? 'Unknown'} · by{' '}
+            <Link
+              to={`/private/user/${collage.userId}`}
+              className="text-blue-400 hover:underline"
+            >
+              {collage.user?.username ?? '—'}
+            </Link>
+            {' · '}
+            {collage.numEntries} entries · {collage.numSubscribers} subscribers
+          </div>
+        </div>
+
+        <div className="flex gap-2 text-sm shrink-0 ml-4">
+          <button
+            onClick={handleSubscribe}
+            className={`px-3 py-1 rounded border text-xs ${
+              collage.isSubscribed
+                ? 'border-green-600 text-green-400 hover:border-red-500 hover:text-red-400'
+                : 'border-gray-700 text-gray-400 hover:border-blue-500 hover:text-blue-400'
+            }`}
+          >
+            {collage.isSubscribed ? 'Subscribed' : 'Subscribe'}
+          </button>
+          <button
+            onClick={handleBookmark}
+            className={`px-3 py-1 rounded border text-xs ${
+              collage.isBookmarked
+                ? 'border-yellow-600 text-yellow-400'
+                : 'border-gray-700 text-gray-400 hover:border-yellow-600 hover:text-yellow-400'
+            }`}
+          >
+            {collage.isBookmarked ? 'Bookmarked' : 'Bookmark'}
+          </button>
+          {canEdit && (
+            <Link
+              to={`/private/collages/${collageId}/edit`}
+              className="px-3 py-1 rounded border border-gray-700 text-gray-400 hover:border-gray-500 text-xs"
+            >
+              Edit
+            </Link>
+          )}
+          {canEdit && (
+            <button
+              onClick={handleDelete}
+              className="px-3 py-1 rounded border border-gray-700 text-red-500 hover:border-red-700 text-xs"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      {collage.tags.length > 0 && (
+        <div className="flex gap-1 mb-3 flex-wrap">
+          {collage.tags.map((tag) => (
+            <span
+              key={tag}
+              className="text-xs px-2 py-0.5 bg-gray-800 text-gray-400 rounded"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="mb-6 text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">
+        {collage.description}
+      </div>
+
+      {canManageEntries && (
+        <div className="mb-6">
+          <h3 className="text-sm font-medium text-gray-300 mb-2">
+            Add Release
+          </h3>
+          <form onSubmit={handleAddEntry} className="flex gap-2">
+            <input
+              type="number"
+              value={releaseIdInput}
+              onChange={(e) => setReleaseIdInput(e.target.value)}
+              placeholder="Release ID"
+              className="w-40 px-3 py-1.5 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+            />
+            <button
+              type="submit"
+              className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+            >
+              Add
+            </button>
+          </form>
+          {addError && <p className="mt-1 text-xs text-red-400">{addError}</p>}
+        </div>
+      )}
+
+      <div>
+        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">
+          Entries ({collage.numEntries})
+        </h3>
+
+        {!collage.entries || collage.entries.length === 0 ? (
+          <p className="text-gray-500 text-sm">No entries yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {collage.entries.map((entry) => (
+              <div
+                key={entry.id}
+                className="flex items-center gap-3 p-2 bg-gray-900/50 border border-gray-800 rounded hover:border-gray-700"
+              >
+                {entry.release?.image ? (
+                  <img
+                    src={entry.release.image}
+                    alt=""
+                    className="w-10 h-10 object-cover rounded shrink-0"
+                  />
+                ) : (
+                  <div className="w-10 h-10 bg-gray-800 rounded shrink-0" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <Link
+                    to={`/private/communities/${
+                      entry.release?.artist?.id ?? 0
+                    }/releases/${entry.releaseId}`}
+                    className="text-sm text-blue-400 hover:underline truncate block"
+                  >
+                    {entry.release?.title ?? `Release #${entry.releaseId}`}
+                  </Link>
+                  <div className="text-xs text-gray-500">
+                    {entry.release?.artist?.name ?? '—'} ·{' '}
+                    {entry.release?.year ?? ''}
+                  </div>
+                </div>
+                <div className="text-xs text-gray-500 shrink-0">
+                  added by {entry.user?.username ?? '—'}
+                </div>
+                {(isOwner || isStaff || entry.userId === user?.id) && (
+                  <button
+                    onClick={() => handleRemoveEntry(entry.releaseId)}
+                    className="text-xs text-red-500 hover:text-red-400 shrink-0"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-8">
+        <CommentsSection page="collages" pageId={collageId} />
+      </div>
+    </div>
+  );
+};
+
+export default CollageDetail;

--- a/src/components/collages/CollageEdit.tsx
+++ b/src/components/collages/CollageEdit.tsx
@@ -100,8 +100,14 @@ const CollageEdit = () => {
       <form onSubmit={handleSubmit} className="space-y-4">
         {(isStaff || collage.categoryId === 0) && (
           <div>
-            <label className="block text-sm text-gray-300 mb-1">Name</label>
+            <label
+              htmlFor="edit-name"
+              className="block text-sm text-gray-300 mb-1"
+            >
+              Name
+            </label>
             <input
+              id="edit-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -114,10 +120,14 @@ const CollageEdit = () => {
         )}
 
         <div>
-          <label className="block text-sm text-gray-300 mb-1">
+          <label
+            htmlFor="edit-description"
+            className="block text-sm text-gray-300 mb-1"
+          >
             Description
           </label>
           <textarea
+            id="edit-description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             required
@@ -128,10 +138,14 @@ const CollageEdit = () => {
         </div>
 
         <div>
-          <label className="block text-sm text-gray-300 mb-1">
+          <label
+            htmlFor="edit-tags"
+            className="block text-sm text-gray-300 mb-1"
+          >
             Tags <span className="text-gray-500">(comma-separated)</span>
           </label>
           <input
+            id="edit-tags"
             type="text"
             value={tagsInput}
             onChange={(e) => setTagsInput(e.target.value)}
@@ -175,11 +189,15 @@ const CollageEdit = () => {
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm text-gray-300 mb-1">
+                <label
+                  htmlFor="edit-max-entries"
+                  className="block text-sm text-gray-300 mb-1"
+                >
                   Max Entries{' '}
                   <span className="text-gray-500">(0 = unlimited)</span>
                 </label>
                 <input
+                  id="edit-max-entries"
                   type="number"
                   min={0}
                   value={maxEntries}
@@ -188,11 +206,15 @@ const CollageEdit = () => {
                 />
               </div>
               <div>
-                <label className="block text-sm text-gray-300 mb-1">
+                <label
+                  htmlFor="edit-max-per-user"
+                  className="block text-sm text-gray-300 mb-1"
+                >
                   Max Per User{' '}
                   <span className="text-gray-500">(0 = unlimited)</span>
                 </label>
                 <input
+                  id="edit-max-per-user"
                   type="number"
                   min={0}
                   value={maxEntriesPerUser}

--- a/src/components/collages/CollageEdit.tsx
+++ b/src/components/collages/CollageEdit.tsx
@@ -1,0 +1,228 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { selectCurrentUser } from '../../store/slices/authSlice';
+import {
+  useGetCollageQuery,
+  useUpdateCollageMutation,
+  type UpdateCollagePayload
+} from '../../store/services/collageApi';
+import { hasAnyPermission } from '../../utils/permissions';
+import Spinner from '../layout/Spinner';
+
+const CollageEdit = () => {
+  const { id } = useParams<{ id: string }>();
+  const collageId = Number(id);
+  const navigate = useNavigate();
+  const user = useSelector(selectCurrentUser);
+
+  const { data: collage, isLoading } = useGetCollageQuery(collageId);
+  const [updateCollage, { isLoading: isSaving }] = useUpdateCollageMutation();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
+  const [isFeatured, setIsFeatured] = useState(false);
+  const [isLocked, setIsLocked] = useState(false);
+  const [maxEntries, setMaxEntries] = useState(0);
+  const [maxEntriesPerUser, setMaxEntriesPerUser] = useState(0);
+  const [error, setError] = useState('');
+
+  const isStaff = hasAnyPermission(user, [
+    'collages_moderate',
+    'staff',
+    'admin'
+  ]);
+  const isOwner = user?.id === collage?.userId;
+
+  useEffect(() => {
+    if (collage) {
+      setName(collage.name);
+      setDescription(collage.description);
+      setTagsInput(collage.tags.join(', '));
+      setIsFeatured(collage.isFeatured);
+      setIsLocked(collage.isLocked);
+      setMaxEntries(collage.maxEntries);
+      setMaxEntriesPerUser(collage.maxEntriesPerUser);
+    }
+  }, [collage]);
+
+  if (isLoading) return <Spinner />;
+  if (!collage)
+    return <div className="p-4 text-red-400">Collage not found.</div>;
+  if (!isOwner && !isStaff) navigate('/private/collages');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    const tags = tagsInput
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    const payload: UpdateCollagePayload = { id: collageId, description, tags };
+
+    // Name: only for staff or personal collage owner
+    if (isStaff || collage.categoryId === 0) {
+      payload.name = name;
+    }
+
+    if (collage.categoryId === 0) {
+      payload.isFeatured = isFeatured;
+    }
+
+    if (isStaff) {
+      payload.isLocked = isLocked;
+      payload.maxEntries = maxEntries;
+      payload.maxEntriesPerUser = maxEntriesPerUser;
+    }
+
+    try {
+      await updateCollage(payload).unwrap();
+      navigate(`/private/collages/${collageId}`);
+    } catch (err: unknown) {
+      const e = err as { data?: { msg?: string } };
+      setError(e?.data?.msg ?? 'Failed to update collage.');
+    }
+  };
+
+  return (
+    <div className="thin">
+      <h2 className="text-xl font-semibold mb-4">Edit Collage</h2>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-900/30 border border-red-700 text-red-300 rounded text-sm">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {(isStaff || collage.categoryId === 0) && (
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              minLength={3}
+              maxLength={100}
+              className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+            />
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm text-gray-300 mb-1">
+            Description
+          </label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+            minLength={10}
+            rows={5}
+            className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-blue-500 resize-y"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm text-gray-300 mb-1">
+            Tags <span className="text-gray-500">(comma-separated)</span>
+          </label>
+          <input
+            type="text"
+            value={tagsInput}
+            onChange={(e) => setTagsInput(e.target.value)}
+            className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+          />
+        </div>
+
+        {collage.categoryId === 0 && (
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="isFeatured"
+              checked={isFeatured}
+              onChange={(e) => setIsFeatured(e.target.checked)}
+              className="rounded"
+            />
+            <label htmlFor="isFeatured" className="text-sm text-gray-300">
+              Feature this collage on my profile
+            </label>
+          </div>
+        )}
+
+        {isStaff && (
+          <div className="border border-gray-700 rounded p-4 space-y-4">
+            <h3 className="text-sm font-medium text-gray-400">
+              Staff Settings
+            </h3>
+
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="isLocked"
+                checked={isLocked}
+                onChange={(e) => setIsLocked(e.target.checked)}
+                className="rounded"
+              />
+              <label htmlFor="isLocked" className="text-sm text-gray-300">
+                Lock collage (prevent new entries)
+              </label>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">
+                  Max Entries{' '}
+                  <span className="text-gray-500">(0 = unlimited)</span>
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  value={maxEntries}
+                  onChange={(e) => setMaxEntries(Number(e.target.value))}
+                  className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">
+                  Max Per User{' '}
+                  <span className="text-gray-500">(0 = unlimited)</span>
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  value={maxEntriesPerUser}
+                  onChange={(e) => setMaxEntriesPerUser(Number(e.target.value))}
+                  className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={isSaving}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-sm rounded"
+          >
+            {isSaving ? 'Saving…' : 'Save Changes'}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate(`/private/collages/${collageId}`)}
+            className="px-4 py-2 border border-gray-700 text-gray-300 hover:border-gray-500 text-sm rounded"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default CollageEdit;

--- a/src/components/layout/CommentsSection.tsx
+++ b/src/components/layout/CommentsSection.tsx
@@ -32,6 +32,8 @@ const CommentsSection = ({ page, pageId }: Props) => {
       await createComment({ page, body, artistId: pageId });
     } else if (page === 'release') {
       await createComment({ page, body, releaseId: pageId });
+    } else if (page === 'collages') {
+      await createComment({ page, body, collageId: pageId });
     } else {
       await createComment({ page, body, contributionId: pageId });
     }

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -26,6 +26,10 @@ import ContributionsPage from '../../../contribute/ContributionsPage';
 import RequestsPage from '../../../requests/RequestsPage';
 import RequestDetailPage from '../../../requests/RequestDetailPage';
 import CreateRequestForm from '../../../requests/CreateRequestForm';
+import CollageBrowse from '../../../collages/CollageBrowse';
+import CollageCreate from '../../../collages/CollageCreate';
+import CollageDetail from '../../../collages/CollageDetail';
+import CollageEdit from '../../../collages/CollageEdit';
 import Toolbox from '../../../admin/Toolbox';
 import NewUserForm from '../../../admin/NewUserForm';
 import UserRankManager from '../../../admin/UserRankManager';
@@ -176,6 +180,11 @@ const PrivateContent = () => (
     <Route path="requests/new" element={wrap(CreateRequestForm)} />
     <Route path="requests/:id" element={wrap(RequestDetailPage)} />
     <Route path="requests" element={wrap(RequestsPage)} />
+
+    <Route path="collages/new" element={wrap(CollageCreate)} />
+    <Route path="collages/:id/edit" element={wrap(CollageEdit)} />
+    <Route path="collages/:id" element={wrap(CollageDetail)} />
+    <Route path="collages" element={wrap(CollageBrowse)} />
 
     <Route path="" element={<PrivateHomepage />} />
     <Route path="*" element={<NotFound />} />

--- a/src/components/pages/private/layout/PrivateHeader.tsx
+++ b/src/components/pages/private/layout/PrivateHeader.tsx
@@ -11,6 +11,7 @@ interface Props {
 const navLinks = [
   { label: 'Home', to: '/private/' },
   { label: 'Communities', to: '/private/communities' },
+  { label: 'Collages', to: '/private/collages' },
   { label: 'Forums', to: '/private/forums' },
   { label: 'Upload', to: '/private/contribute' },
   { label: 'Requests', to: '/private/requests' },

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -39,7 +39,8 @@ export const api = createApi({
     'UserRank',
     'Stats',
     'Request',
-    'Download'
+    'Download',
+    'Collage'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/collageApi.ts
+++ b/src/store/services/collageApi.ts
@@ -1,0 +1,160 @@
+import { api } from '../api';
+import type {
+  Collage,
+  CollageEntry,
+  CollageListResponse,
+  ListCollagesQuery
+} from '../../types';
+
+export interface CreateCollagePayload {
+  name: string;
+  description: string;
+  categoryId?: number;
+  tags?: string[];
+}
+
+export interface UpdateCollagePayload {
+  id: number;
+  name?: string;
+  description?: string;
+  tags?: string[];
+  isFeatured?: boolean;
+  isLocked?: boolean;
+  maxEntries?: number;
+  maxEntriesPerUser?: number;
+}
+
+export interface ReorderEntriesPayload {
+  id: number;
+  entries: Array<{ id: number; sort: number }>;
+}
+
+export const collageApi = api.injectEndpoints({
+  endpoints: (builder) => ({
+    listCollages: builder.query<CollageListResponse, ListCollagesQuery>({
+      query: ({
+        page = 1,
+        search,
+        categoryId,
+        userId,
+        bookmarked,
+        orderBy,
+        order
+      } = {}) => {
+        const params = new URLSearchParams();
+        params.set('page', String(page));
+        if (search) params.set('search', search);
+        if (categoryId != null) params.set('categoryId', String(categoryId));
+        if (userId != null) params.set('userId', String(userId));
+        if (bookmarked) params.set('bookmarked', bookmarked);
+        if (orderBy) params.set('orderBy', orderBy);
+        if (order) params.set('order', order);
+        return `/collages?${params.toString()}`;
+      },
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.data.map(({ id }) => ({
+                type: 'Collage' as const,
+                id
+              })),
+              { type: 'Collage', id: 'LIST' }
+            ]
+          : [{ type: 'Collage', id: 'LIST' }]
+    }),
+
+    getCollage: builder.query<Collage, number>({
+      query: (id) => `/collages/${id}`,
+      providesTags: (_result, _error, id) => [{ type: 'Collage', id }]
+    }),
+
+    createCollage: builder.mutation<Collage, CreateCollagePayload>({
+      query: (body) => ({ url: '/collages', method: 'POST', body }),
+      invalidatesTags: [{ type: 'Collage', id: 'LIST' }]
+    }),
+
+    updateCollage: builder.mutation<Collage, UpdateCollagePayload>({
+      query: ({ id, ...body }) => ({
+        url: `/collages/${id}`,
+        method: 'PUT',
+        body
+      }),
+      invalidatesTags: (_result, _error, { id }) => [
+        { type: 'Collage', id },
+        { type: 'Collage', id: 'LIST' }
+      ]
+    }),
+
+    deleteCollage: builder.mutation<void, number>({
+      query: (id) => ({ url: `/collages/${id}`, method: 'DELETE' }),
+      invalidatesTags: (_result, _error, id) => [
+        { type: 'Collage', id },
+        { type: 'Collage', id: 'LIST' }
+      ]
+    }),
+
+    recoverCollage: builder.mutation<Collage, number>({
+      query: (id) => ({ url: `/collages/${id}/recover`, method: 'POST' }),
+      invalidatesTags: (_result, _error, id) => [{ type: 'Collage', id }]
+    }),
+
+    addCollageEntry: builder.mutation<
+      CollageEntry,
+      { id: number; releaseId: number }
+    >({
+      query: ({ id, releaseId }) => ({
+        url: `/collages/${id}/entries`,
+        method: 'POST',
+        body: { releaseId }
+      }),
+      invalidatesTags: (_result, _error, { id }) => [{ type: 'Collage', id }]
+    }),
+
+    removeCollageEntry: builder.mutation<
+      void,
+      { id: number; releaseId: number }
+    >({
+      query: ({ id, releaseId }) => ({
+        url: `/collages/${id}/entries/${releaseId}`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: (_result, _error, { id }) => [{ type: 'Collage', id }]
+    }),
+
+    reorderCollageEntries: builder.mutation<void, ReorderEntriesPayload>({
+      query: ({ id, entries }) => ({
+        url: `/collages/${id}/entries`,
+        method: 'PUT',
+        body: { entries }
+      }),
+      invalidatesTags: (_result, _error, { id }) => [{ type: 'Collage', id }]
+    }),
+
+    subscribeCollage: builder.mutation<{ subscribed: boolean }, number>({
+      query: (id) => ({ url: `/collages/${id}/subscribe`, method: 'POST' }),
+      invalidatesTags: (_result, _error, id) => [{ type: 'Collage', id }]
+    }),
+
+    bookmarkCollage: builder.mutation<{ bookmarked: boolean }, number>({
+      query: (id) => ({ url: `/collages/${id}/bookmark`, method: 'POST' }),
+      invalidatesTags: (_result, _error, id) => [
+        { type: 'Collage', id },
+        { type: 'Collage', id: 'LIST' }
+      ]
+    })
+  })
+});
+
+export const {
+  useListCollagesQuery,
+  useGetCollageQuery,
+  useCreateCollageMutation,
+  useUpdateCollageMutation,
+  useDeleteCollageMutation,
+  useRecoverCollageMutation,
+  useAddCollageEntryMutation,
+  useRemoveCollageEntryMutation,
+  useReorderCollageEntriesMutation,
+  useSubscribeCollageMutation,
+  useBookmarkCollageMutation
+} = collageApi;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -3008,6 +3008,7 @@ export interface paths {
             contributionId?: number;
             artistId?: number;
             releaseId?: number;
+            collageId?: number;
           };
         };
       };
@@ -4608,6 +4609,7 @@ export interface components {
       page: string;
       body: string;
       authorId: number;
+      collageId?: number | null;
       createdAt: string;
       author?: {
         id: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -172,6 +172,80 @@ export interface DownloadGrant {
 
 export type SiteStats = components['schemas']['SiteStats'];
 
+// ─── Collage ─────────────────────────────────────────────────────────────────
+
+export interface CollageEntryRelease {
+  id: number;
+  title: string;
+  image: string | null;
+  year: number;
+  releaseType: string;
+  artist: { id: number; name: string };
+}
+
+export interface CollageEntry {
+  id: number;
+  collageId: number;
+  releaseId: number;
+  userId: number;
+  sort: number;
+  addedAt: string;
+  release?: CollageEntryRelease;
+  user?: { id: number; username: string };
+}
+
+export interface CollageCounts {
+  entries: number;
+  subscriptions: number;
+  bookmarks: number;
+}
+
+export interface Collage {
+  id: number;
+  name: string;
+  description: string;
+  userId: number;
+  categoryId: number;
+  tags: string[];
+  isLocked: boolean;
+  isDeleted: boolean;
+  maxEntries: number;
+  maxEntriesPerUser: number;
+  isFeatured: boolean;
+  numEntries: number;
+  numSubscribers: number;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+  user?: { id: number; username: string; avatar: string | null };
+  _count?: CollageCounts;
+  entries?: CollageEntry[];
+  isSubscribed?: boolean;
+  isBookmarked?: boolean;
+}
+
+export interface CollageListResponse {
+  data: Collage[];
+  meta: { total: number; page: number; limit: number; totalPages: number };
+}
+
+export type CollageOrderBy =
+  | 'createdAt'
+  | 'updatedAt'
+  | 'name'
+  | 'numEntries'
+  | 'numSubscribers';
+
+export interface ListCollagesQuery {
+  page?: number;
+  search?: string;
+  categoryId?: number;
+  userId?: number;
+  bookmarked?: 'true' | 'false';
+  orderBy?: CollageOrderBy;
+  order?: 'asc' | 'desc';
+}
+
 // ─── Redux state types ───────────────────────────────────────────────────────
 
 export interface AuthState {

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -6,6 +6,8 @@ export const VALID_PERMISSIONS = [
   'forums_moderate',
   'forums_manage',
   'communities_manage',
+  'collages_manage',
+  'collages_moderate',
   'news_manage',
   'invites_manage',
   'users_edit',


### PR DESCRIPTION
Adds browse, create, detail, and edit pages for collages. RTK Query service (collageApi) covers all 11 endpoints including subscribe, bookmark, and entry management. Collage nav link added to the private header. UserRankFormPage extended with collages_manage/collages_moderate permission checkboxes. CommentsSection fixed to send collageId instead of contributionId for collage pages. Types derived from the OpenAPI spec where possible; hand-written interfaces added for list/detail shapes not yet in the spec.