### PR TITLE
feat(pm+staff-inbox): add private messaging and staff inbox UI

### DIFF
--- a/src/components/admin/Toolbox.tsx
+++ b/src/components/admin/Toolbox.tsx
@@ -84,6 +84,21 @@ const sections: SectionProps[] = [
         permissions: ['forums_manage']
       }
     ]
+  },
+  {
+    title: 'Support',
+    links: [
+      {
+        label: 'Staff inbox',
+        to: '/private/staff/inbox',
+        permissions: ['staff', 'admin']
+      },
+      {
+        label: 'Canned responses',
+        to: '/private/staff/inbox/responses',
+        permissions: ['staff', 'admin']
+      }
+    ]
   }
 ];
 

--- a/src/components/messages/ComposeForm.tsx
+++ b/src/components/messages/ComposeForm.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useComposeMessageMutation } from '../../store/services/messagesApi';
+import { useAppDispatch } from '../../store/hooks';
+import { addAlert } from '../../store/slices/alertSlice';
+
+const ComposeForm = () => {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const dispatch = useAppDispatch();
+
+  const [toUserId, setToUserId] = useState(params.get('to') ?? '');
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+
+  const [compose, { isLoading }] = useComposeMessageMutation();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsedId = parseInt(toUserId, 10);
+    if (!parsedId || isNaN(parsedId)) {
+      dispatch(addAlert('Recipient user ID is required.', 'danger'));
+      return;
+    }
+    try {
+      const conv = await compose({
+        toUserId: parsedId,
+        subject,
+        body
+      }).unwrap();
+      navigate(`/private/messages/${conv.id}`);
+    } catch (err: unknown) {
+      const msg =
+        (err as { data?: { msg?: string } })?.data?.msg ??
+        'Failed to send message.';
+      dispatch(addAlert(msg, 'danger'));
+    }
+  };
+
+  return (
+    <div className="thin">
+      <h2 className="text-xl font-semibold mb-4">New Message</h2>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <label
+            htmlFor="compose-to"
+            className="block text-sm text-gray-400 mb-1"
+          >
+            To (user ID)
+          </label>
+          <input
+            id="compose-to"
+            type="number"
+            value={toUserId}
+            onChange={(e) => setToUserId(e.target.value)}
+            required
+            className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm focus:outline-none focus:border-blue-500"
+            placeholder="Enter user ID"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="compose-subject"
+            className="block text-sm text-gray-400 mb-1"
+          >
+            Subject
+          </label>
+          <input
+            id="compose-subject"
+            type="text"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            required
+            maxLength={255}
+            className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm focus:outline-none focus:border-blue-500"
+            placeholder="Subject"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="compose-body"
+            className="block text-sm text-gray-400 mb-1"
+          >
+            Message
+          </label>
+          <textarea
+            id="compose-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            required
+            rows={8}
+            className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm focus:outline-none focus:border-blue-500 resize-y"
+            placeholder="Write your message…"
+          />
+        </div>
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded disabled:opacity-50"
+          >
+            {isLoading ? 'Sending…' : 'Send'}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate('/private/messages')}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default ComposeForm;

--- a/src/components/messages/ConversationView.tsx
+++ b/src/components/messages/ConversationView.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import {
+  useGetConversationQuery,
+  useReplyToConversationMutation,
+  useUpdateConversationFlagsMutation,
+  useDeleteConversationMutation
+} from '../../store/services/messagesApi';
+import { selectCurrentUser } from '../../store/slices/authSlice';
+import { useAppDispatch } from '../../store/hooks';
+import { addAlert } from '../../store/slices/alertSlice';
+import Spinner from '../layout/Spinner';
+
+const ConversationView = () => {
+  const { id } = useParams<{ id: string }>();
+  const convId = Number(id);
+  const dispatch = useAppDispatch();
+  const currentUser = useSelector(selectCurrentUser);
+
+  const { data: conv, isLoading, error } = useGetConversationQuery(convId);
+  const [reply, { isLoading: replying }] = useReplyToConversationMutation();
+  const [updateFlags] = useUpdateConversationFlagsMutation();
+  const [deleteConv] = useDeleteConversationMutation();
+
+  const [replyBody, setReplyBody] = useState('');
+
+  const handleReply = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!replyBody.trim()) return;
+    try {
+      await reply({ id: convId, body: replyBody }).unwrap();
+      setReplyBody('');
+    } catch {
+      dispatch(addAlert('Failed to send reply.', 'danger'));
+    }
+  };
+
+  const handleSticky = () =>
+    updateFlags({
+      id: convId,
+      isSticky: !conv?.participants?.find((p) => p.userId === currentUser?.id)
+        ?.isSticky
+    });
+
+  const handleMarkUnread = () => updateFlags({ id: convId, isRead: false });
+
+  const handleDelete = async () => {
+    await deleteConv(convId);
+    window.history.back();
+  };
+
+  if (isLoading) return <Spinner />;
+  if (error || !conv)
+    return <div className="p-4 text-red-400">Conversation not found.</div>;
+
+  const myParticipant = conv.participants?.find(
+    (p) => p.userId === currentUser?.id
+  );
+  const otherParticipants =
+    conv.participants?.filter((p) => p.userId !== currentUser?.id) ?? [];
+
+  return (
+    <div className="thin">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <Link
+            to="/private/messages"
+            className="text-blue-400 text-sm hover:underline"
+          >
+            ← Inbox
+          </Link>
+          <h2 className="text-xl font-semibold mt-1">{conv.subject}</h2>
+          {otherParticipants.length > 0 && (
+            <p className="text-sm text-gray-400">
+              With:{' '}
+              {otherParticipants.map((p) => (
+                <Link
+                  key={p.userId}
+                  to={`/private/user/${p.userId}`}
+                  className="text-blue-400 hover:underline"
+                >
+                  {p.user?.username ?? `User ${p.userId}`}
+                </Link>
+              ))}
+            </p>
+          )}
+        </div>
+        <div className="flex gap-2 text-sm">
+          <button
+            onClick={handleSticky}
+            className={`px-2 py-1 rounded ${
+              myParticipant?.isSticky
+                ? 'bg-yellow-700 text-yellow-200'
+                : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+            }`}
+            title="Toggle sticky"
+          >
+            ★
+          </button>
+          <button
+            onClick={handleMarkUnread}
+            className="px-2 py-1 rounded bg-gray-700 text-gray-300 hover:bg-gray-600"
+            title="Mark unread"
+          >
+            Unread
+          </button>
+          <button
+            onClick={handleDelete}
+            className="px-2 py-1 rounded bg-gray-700 text-red-400 hover:bg-gray-600"
+            title="Delete conversation"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-4 mb-6">
+        {(conv.messages ?? []).map((msg) => {
+          const isMine = msg.sender?.id === currentUser?.id;
+          return (
+            <div
+              key={msg.id}
+              className={`rounded p-3 ${
+                isMine
+                  ? 'bg-gray-800 ml-8'
+                  : 'bg-gray-850 border border-gray-700 mr-8'
+              }`}
+            >
+              <div className="flex items-center gap-2 mb-2 text-sm">
+                {msg.sender ? (
+                  <Link
+                    to={`/private/user/${msg.sender.id}`}
+                    className="font-medium text-blue-400 hover:underline"
+                  >
+                    {msg.sender.username}
+                  </Link>
+                ) : (
+                  <span className="font-medium text-gray-400">System</span>
+                )}
+                <span className="text-gray-600 text-xs">
+                  {new Date(msg.createdAt).toLocaleString()}
+                </span>
+              </div>
+              <p className="text-gray-200 text-sm whitespace-pre-wrap">
+                {msg.body}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <form onSubmit={handleReply} className="flex flex-col gap-3">
+        <label htmlFor="conv-reply" className="text-sm text-gray-400">
+          Reply
+        </label>
+        <textarea
+          id="conv-reply"
+          value={replyBody}
+          onChange={(e) => setReplyBody(e.target.value)}
+          rows={5}
+          required
+          className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm focus:outline-none focus:border-blue-500 resize-y"
+          placeholder="Write a reply…"
+        />
+        <button
+          type="submit"
+          disabled={replying}
+          className="self-start px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded disabled:opacity-50"
+        >
+          {replying ? 'Sending…' : 'Send Reply'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ConversationView;

--- a/src/components/messages/InboxPage.tsx
+++ b/src/components/messages/InboxPage.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetInboxQuery,
+  useDeleteConversationMutation,
+  useBulkUpdateConversationsMutation
+} from '../../store/services/messagesApi';
+import Spinner from '../layout/Spinner';
+
+const InboxPage = () => {
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<number[]>([]);
+
+  const { data, isLoading, error } = useGetInboxQuery({ page });
+  const [deleteConversation] = useDeleteConversationMutation();
+  const [bulkUpdate] = useBulkUpdateConversationsMutation();
+
+  const conversations = data?.conversations ?? [];
+  const total = data?.total ?? 0;
+  const pageSize = data?.pageSize ?? 25;
+  const totalPages = Math.ceil(total / pageSize);
+
+  const toggleSelect = (id: number) =>
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+
+  const toggleAll = () =>
+    setSelected(
+      selected.length === conversations.length
+        ? []
+        : conversations.map((c) => c.id)
+    );
+
+  const handleBulk = async (action: 'delete' | 'markRead' | 'markUnread') => {
+    if (selected.length === 0) return;
+    await bulkUpdate({ ids: selected, action });
+    setSelected([]);
+  };
+
+  if (isLoading) return <Spinner />;
+  if (error)
+    return <div className="p-4 text-red-400">Failed to load inbox.</div>;
+
+  return (
+    <div className="thin">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">Inbox</h2>
+        <div className="flex gap-2">
+          <Link
+            to="/private/messages/new"
+            className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+          >
+            Compose
+          </Link>
+          <Link
+            to="/private/messages/sent"
+            className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded"
+          >
+            Sent
+          </Link>
+        </div>
+      </div>
+
+      {selected.length > 0 && (
+        <div className="flex gap-2 mb-3 p-2 bg-gray-800 rounded text-sm">
+          <span className="text-gray-400">{selected.length} selected</span>
+          <button
+            onClick={() => handleBulk('markRead')}
+            className="text-blue-400 hover:text-blue-300"
+          >
+            Mark read
+          </button>
+          <button
+            onClick={() => handleBulk('markUnread')}
+            className="text-blue-400 hover:text-blue-300"
+          >
+            Mark unread
+          </button>
+          <button
+            onClick={() => handleBulk('delete')}
+            className="text-red-400 hover:text-red-300"
+          >
+            Delete
+          </button>
+        </div>
+      )}
+
+      {conversations.length === 0 ? (
+        <p className="text-gray-500 text-sm">Your inbox is empty.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-700 text-left text-gray-400">
+              <th className="pb-2 pr-3 w-6">
+                <input
+                  type="checkbox"
+                  checked={
+                    selected.length === conversations.length &&
+                    conversations.length > 0
+                  }
+                  onChange={toggleAll}
+                  className="accent-blue-500"
+                />
+              </th>
+              <th className="pb-2 pr-3">Subject</th>
+              <th className="pb-2 pr-3">From</th>
+              <th className="pb-2">Received</th>
+              <th className="pb-2 w-8"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {conversations.map((conv) => {
+              const userPart = conv.participants?.[0];
+              const lastMsg = conv.messages?.[0];
+              const isUnread = !userPart?.isRead;
+              return (
+                <tr
+                  key={conv.id}
+                  className={`border-b border-gray-800 ${
+                    isUnread ? 'font-semibold' : ''
+                  }`}
+                >
+                  <td className="py-2 pr-3">
+                    <input
+                      type="checkbox"
+                      checked={selected.includes(conv.id)}
+                      onChange={() => toggleSelect(conv.id)}
+                      className="accent-blue-500"
+                    />
+                  </td>
+                  <td className="py-2 pr-3">
+                    <Link
+                      to={`/private/messages/${conv.id}`}
+                      className="hover:underline text-blue-400"
+                    >
+                      {userPart?.isSticky && (
+                        <span className="mr-1 text-yellow-400 text-xs">★</span>
+                      )}
+                      {conv.subject}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-3 text-gray-300">
+                    {lastMsg?.sender?.username ?? 'System'}
+                  </td>
+                  <td className="py-2 text-gray-500 text-xs whitespace-nowrap">
+                    {userPart?.receivedAt
+                      ? new Date(userPart.receivedAt).toLocaleDateString()
+                      : '—'}
+                  </td>
+                  <td className="py-2">
+                    <button
+                      onClick={() => deleteConversation(conv.id)}
+                      className="text-gray-600 hover:text-red-400 text-xs"
+                      title="Delete"
+                    >
+                      ✕
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2 mt-4 text-sm">
+          <button
+            disabled={page === 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <span className="px-3 py-1 text-gray-400">
+            {page} / {totalPages}
+          </span>
+          <button
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InboxPage;

--- a/src/components/messages/SentboxPage.tsx
+++ b/src/components/messages/SentboxPage.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetSentboxQuery } from '../../store/services/messagesApi';
+import Spinner from '../layout/Spinner';
+
+const SentboxPage = () => {
+  const [page, setPage] = useState(1);
+  const { data, isLoading, error } = useGetSentboxQuery({ page });
+
+  const conversations = data?.conversations ?? [];
+  const total = data?.total ?? 0;
+  const pageSize = data?.pageSize ?? 25;
+  const totalPages = Math.ceil(total / pageSize);
+
+  if (isLoading) return <Spinner />;
+  if (error)
+    return (
+      <div className="p-4 text-red-400">Failed to load sent messages.</div>
+    );
+
+  return (
+    <div className="thin">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">Sent</h2>
+        <div className="flex gap-2">
+          <Link
+            to="/private/messages/new"
+            className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+          >
+            Compose
+          </Link>
+          <Link
+            to="/private/messages"
+            className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded"
+          >
+            Inbox
+          </Link>
+        </div>
+      </div>
+
+      {conversations.length === 0 ? (
+        <p className="text-gray-500 text-sm">No sent messages.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-700 text-left text-gray-400">
+              <th className="pb-2 pr-3">Subject</th>
+              <th className="pb-2 pr-3">Last message</th>
+              <th className="pb-2">Sent</th>
+            </tr>
+          </thead>
+          <tbody>
+            {conversations.map((conv) => {
+              const userPart = conv.participants?.[0];
+              const lastMsg = conv.messages?.[0];
+              return (
+                <tr key={conv.id} className="border-b border-gray-800">
+                  <td className="py-2 pr-3">
+                    <Link
+                      to={`/private/messages/${conv.id}`}
+                      className="hover:underline text-blue-400"
+                    >
+                      {conv.subject}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-3 text-gray-400 max-w-xs truncate">
+                    {lastMsg?.body.slice(0, 80) ?? '—'}
+                  </td>
+                  <td className="py-2 text-gray-500 text-xs whitespace-nowrap">
+                    {userPart?.sentAt
+                      ? new Date(userPart.sentAt).toLocaleDateString()
+                      : '—'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2 mt-4 text-sm">
+          <button
+            disabled={page === 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <span className="px-3 py-1 text-gray-400">
+            {page} / {totalPages}
+          </span>
+          <button
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SentboxPage;

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -30,6 +30,15 @@ import CollageBrowse from '../../../collages/CollageBrowse';
 import CollageCreate from '../../../collages/CollageCreate';
 import CollageDetail from '../../../collages/CollageDetail';
 import CollageEdit from '../../../collages/CollageEdit';
+import InboxPage from '../../../messages/InboxPage';
+import SentboxPage from '../../../messages/SentboxPage';
+import ComposeForm from '../../../messages/ComposeForm';
+import ConversationView from '../../../messages/ConversationView';
+import MyTicketsPage from '../../../staffInbox/MyTicketsPage';
+import NewTicketForm from '../../../staffInbox/NewTicketForm';
+import TicketView from '../../../staffInbox/TicketView';
+import StaffInboxPage from '../../../staffInbox/StaffInboxPage';
+import CannedResponsesPage from '../../../staffInbox/CannedResponsesPage';
 import Toolbox from '../../../admin/Toolbox';
 import NewUserForm from '../../../admin/NewUserForm';
 import UserRankManager from '../../../admin/UserRankManager';
@@ -185,6 +194,31 @@ const PrivateContent = () => (
     <Route path="collages/:id/edit" element={wrap(CollageEdit)} />
     <Route path="collages/:id" element={wrap(CollageDetail)} />
     <Route path="collages" element={wrap(CollageBrowse)} />
+
+    <Route path="messages/new" element={wrap(ComposeForm)} />
+    <Route path="messages/sent" element={wrap(SentboxPage)} />
+    <Route path="messages/:id" element={wrap(ConversationView)} />
+    <Route path="messages" element={wrap(InboxPage)} />
+
+    <Route path="staff/inbox/new" element={wrap(NewTicketForm)} />
+    <Route
+      path="staff/inbox/responses"
+      element={
+        <StaffGate permissions={['staff', 'admin']}>
+          <CannedResponsesPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/inbox"
+      element={
+        <StaffGate permissions={['staff', 'admin']}>
+          <StaffInboxPage />
+        </StaffGate>
+      }
+    />
+    <Route path="staff/inbox/my-tickets" element={wrap(MyTicketsPage)} />
+    <Route path="staff/inbox/:id" element={wrap(TicketView)} />
 
     <Route path="" element={<PrivateHomepage />} />
     <Route path="*" element={<NotFound />} />

--- a/src/components/staffInbox/CannedResponsesPage.tsx
+++ b/src/components/staffInbox/CannedResponsesPage.tsx
@@ -1,0 +1,227 @@
+import { useState } from 'react';
+import {
+  useGetCannedResponsesQuery,
+  useCreateCannedResponseMutation,
+  useUpdateCannedResponseMutation,
+  useDeleteCannedResponseMutation
+} from '../../store/services/staffInboxApi';
+import { useAppDispatch } from '../../store/hooks';
+import { addAlert } from '../../store/slices/alertSlice';
+import Spinner from '../layout/Spinner';
+
+type CannedResponse = {
+  id: number;
+  name: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const CannedResponsesPage = () => {
+  const dispatch = useAppDispatch();
+  const { data: responses, isLoading } = useGetCannedResponsesQuery();
+  const [createResponse] = useCreateCannedResponseMutation();
+  const [updateResponse] = useUpdateCannedResponseMutation();
+  const [deleteResponse] = useDeleteCannedResponseMutation();
+
+  const [editing, setEditing] = useState<CannedResponse | null>(null);
+  const [newName, setNewName] = useState('');
+  const [newBody, setNewBody] = useState('');
+  const [showForm, setShowForm] = useState(false);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createResponse({ name: newName, body: newBody }).unwrap();
+      setNewName('');
+      setNewBody('');
+      setShowForm(false);
+    } catch {
+      dispatch(addAlert('Failed to create response.', 'danger'));
+    }
+  };
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editing) return;
+    try {
+      await updateResponse({
+        id: editing.id,
+        name: editing.name,
+        body: editing.body
+      }).unwrap();
+      setEditing(null);
+    } catch {
+      dispatch(addAlert('Failed to update response.', 'danger'));
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Delete this canned response?')) return;
+    try {
+      await deleteResponse(id).unwrap();
+    } catch {
+      dispatch(addAlert('Failed to delete response.', 'danger'));
+    }
+  };
+
+  if (isLoading) return <Spinner />;
+
+  return (
+    <div className="thin">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">Canned Responses</h2>
+        <button
+          onClick={() => setShowForm((v) => !v)}
+          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+        >
+          {showForm ? 'Cancel' : 'New Response'}
+        </button>
+      </div>
+
+      {showForm && (
+        <form
+          onSubmit={handleCreate}
+          className="mb-6 p-4 bg-gray-800 rounded flex flex-col gap-3"
+        >
+          <h3 className="text-sm font-semibold text-gray-300">
+            New Canned Response
+          </h3>
+          <div>
+            <label
+              htmlFor="new-resp-name"
+              className="block text-xs text-gray-400 mb-1"
+            >
+              Name
+            </label>
+            <input
+              id="new-resp-name"
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              required
+              maxLength={255}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-sm focus:outline-none focus:border-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="new-resp-body"
+              className="block text-xs text-gray-400 mb-1"
+            >
+              Body
+            </label>
+            <textarea
+              id="new-resp-body"
+              value={newBody}
+              onChange={(e) => setNewBody(e.target.value)}
+              required
+              rows={4}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-sm focus:outline-none focus:border-blue-500 resize-y"
+            />
+          </div>
+          <button
+            type="submit"
+            className="self-start px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+          >
+            Create
+          </button>
+        </form>
+      )}
+
+      {(responses ?? []).length === 0 ? (
+        <p className="text-gray-500 text-sm">No canned responses yet.</p>
+      ) : (
+        <div className="space-y-4">
+          {(responses ?? []).map((resp) =>
+            editing?.id === resp.id ? (
+              <form
+                key={resp.id}
+                onSubmit={handleUpdate}
+                className="p-4 bg-gray-800 rounded flex flex-col gap-3"
+              >
+                <div>
+                  <label
+                    htmlFor={`edit-name-${resp.id}`}
+                    className="block text-xs text-gray-400 mb-1"
+                  >
+                    Name
+                  </label>
+                  <input
+                    id={`edit-name-${resp.id}`}
+                    type="text"
+                    value={editing.name}
+                    onChange={(e) =>
+                      setEditing({ ...editing, name: e.target.value })
+                    }
+                    required
+                    maxLength={255}
+                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-sm focus:outline-none focus:border-blue-500"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor={`edit-body-${resp.id}`}
+                    className="block text-xs text-gray-400 mb-1"
+                  >
+                    Body
+                  </label>
+                  <textarea
+                    id={`edit-body-${resp.id}`}
+                    value={editing.body}
+                    onChange={(e) =>
+                      setEditing({ ...editing, body: e.target.value })
+                    }
+                    required
+                    rows={4}
+                    className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-sm focus:outline-none focus:border-blue-500 resize-y"
+                  />
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="submit"
+                    className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+                  >
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditing(null)}
+                    className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <div key={resp.id} className="p-4 bg-gray-800 rounded">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="font-medium text-gray-200">{resp.name}</span>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setEditing(resp)}
+                      className="text-blue-400 hover:text-blue-300 text-sm"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(resp.id)}
+                      className="text-red-400 hover:text-red-300 text-sm"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+                <p className="text-gray-400 text-sm whitespace-pre-wrap">
+                  {resp.body}
+                </p>
+              </div>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CannedResponsesPage;

--- a/src/components/staffInbox/MyTicketsPage.tsx
+++ b/src/components/staffInbox/MyTicketsPage.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetMyTicketsQuery } from '../../store/services/staffInboxApi';
+import Spinner from '../layout/Spinner';
+
+const STATUS_BADGE: Record<string, string> = {
+  Unanswered: 'bg-yellow-800 text-yellow-200',
+  Open: 'bg-blue-800 text-blue-200',
+  Resolved: 'bg-gray-700 text-gray-400'
+};
+
+const MyTicketsPage = () => {
+  const [page, setPage] = useState(1);
+  const { data, isLoading, error } = useGetMyTicketsQuery({ page });
+
+  const tickets = data?.conversations ?? [];
+  const total = data?.total ?? 0;
+  const pageSize = data?.pageSize ?? 25;
+  const totalPages = Math.ceil(total / pageSize);
+
+  if (isLoading) return <Spinner />;
+  if (error)
+    return <div className="p-4 text-red-400">Failed to load tickets.</div>;
+
+  return (
+    <div className="thin">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">My Support Tickets</h2>
+        <Link
+          to="/private/staff/inbox/new"
+          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+        >
+          New Ticket
+        </Link>
+      </div>
+
+      {tickets.length === 0 ? (
+        <p className="text-gray-500 text-sm">You have no support tickets.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-700 text-left text-gray-400">
+              <th className="pb-2 pr-3">Subject</th>
+              <th className="pb-2 pr-3">Status</th>
+              <th className="pb-2 pr-3">Assigned</th>
+              <th className="pb-2">Last updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tickets.map((ticket) => (
+              <tr key={ticket.id} className="border-b border-gray-800">
+                <td className="py-2 pr-3">
+                  <Link
+                    to={`/private/staff/inbox/${ticket.id}`}
+                    className="hover:underline text-blue-400"
+                  >
+                    {!ticket.isReadByUser && ticket.status !== 'Unanswered' && (
+                      <span className="mr-1 font-bold text-blue-300">●</span>
+                    )}
+                    {ticket.subject}
+                  </Link>
+                </td>
+                <td className="py-2 pr-3">
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded ${
+                      STATUS_BADGE[ticket.status] ?? 'bg-gray-700 text-gray-400'
+                    }`}
+                  >
+                    {ticket.status}
+                  </span>
+                </td>
+                <td className="py-2 pr-3 text-gray-400">
+                  {ticket.assignedUser?.username ?? '—'}
+                </td>
+                <td className="py-2 text-gray-500 text-xs">
+                  {new Date(ticket.updatedAt).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2 mt-4 text-sm">
+          <button
+            disabled={page === 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <span className="px-3 py-1 text-gray-400">
+            {page} / {totalPages}
+          </span>
+          <button
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MyTicketsPage;

--- a/src/components/staffInbox/NewTicketForm.tsx
+++ b/src/components/staffInbox/NewTicketForm.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useCreateTicketMutation } from '../../store/services/staffInboxApi';
+import { useAppDispatch } from '../../store/hooks';
+import { addAlert } from '../../store/slices/alertSlice';
+
+const NewTicketForm = () => {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [createTicket, { isLoading }] = useCreateTicketMutation();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const ticket = await createTicket({ subject, body }).unwrap();
+      navigate(`/private/staff/inbox/${ticket.id}`);
+    } catch (err: unknown) {
+      const msg =
+        (err as { data?: { msg?: string } })?.data?.msg ??
+        'Failed to create ticket.';
+      dispatch(addAlert(msg, 'danger'));
+    }
+  };
+
+  return (
+    <div className="thin">
+      <h2 className="text-xl font-semibold mb-4">Contact Staff</h2>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <label
+            htmlFor="ticket-subject"
+            className="block text-sm text-gray-400 mb-1"
+          >
+            Subject
+          </label>
+          <input
+            id="ticket-subject"
+            type="text"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            required
+            maxLength={255}
+            className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm focus:outline-none focus:border-blue-500"
+            placeholder="Brief description of your issue"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="ticket-body"
+            className="block text-sm text-gray-400 mb-1"
+          >
+            Message
+          </label>
+          <textarea
+            id="ticket-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            required
+            rows={8}
+            className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm focus:outline-none focus:border-blue-500 resize-y"
+            placeholder="Describe your issue in detail…"
+          />
+        </div>
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded disabled:opacity-50"
+          >
+            {isLoading ? 'Submitting…' : 'Submit Ticket'}
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate('/private/staff/inbox/my-tickets')}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default NewTicketForm;

--- a/src/components/staffInbox/StaffInboxPage.tsx
+++ b/src/components/staffInbox/StaffInboxPage.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetStaffTicketsQuery,
+  useBulkResolveTicketsMutation
+} from '../../store/services/staffInboxApi';
+import Spinner from '../layout/Spinner';
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'All' },
+  { value: 'Unanswered', label: 'Unanswered' },
+  { value: 'Open', label: 'Open' },
+  { value: 'Resolved', label: 'Resolved' }
+];
+
+const STATUS_BADGE: Record<string, string> = {
+  Unanswered: 'bg-yellow-800 text-yellow-200',
+  Open: 'bg-blue-800 text-blue-200',
+  Resolved: 'bg-gray-700 text-gray-400'
+};
+
+const StaffInboxPage = () => {
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState('all');
+  const [assignedToMe, setAssignedToMe] = useState(false);
+  const [selected, setSelected] = useState<number[]>([]);
+
+  const { data, isLoading, error } = useGetStaffTicketsQuery({
+    page,
+    status,
+    assignedToMe
+  });
+  const [bulkResolve] = useBulkResolveTicketsMutation();
+
+  const tickets = data?.conversations ?? [];
+  const total = data?.total ?? 0;
+  const pageSize = data?.pageSize ?? 25;
+  const totalPages = Math.ceil(total / pageSize);
+
+  const toggleSelect = (id: number) =>
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+
+  const toggleAll = () =>
+    setSelected(
+      selected.length === tickets.length ? [] : tickets.map((t) => t.id)
+    );
+
+  const handleBulkResolve = async () => {
+    if (selected.length === 0) return;
+    const result = await bulkResolve({ ids: selected }).unwrap();
+    setSelected([]);
+    alert(`Resolved ${result.resolved} ticket(s).`);
+  };
+
+  if (isLoading) return <Spinner />;
+  if (error)
+    return <div className="p-4 text-red-400">Failed to load staff inbox.</div>;
+
+  return (
+    <div className="thin">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">Staff Inbox</h2>
+        <Link
+          to="/private/staff/inbox/responses"
+          className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded"
+        >
+          Canned Responses
+        </Link>
+      </div>
+
+      <div className="flex flex-wrap gap-3 mb-4 text-sm">
+        <div className="flex items-center gap-2">
+          <label htmlFor="status-filter" className="text-gray-400">
+            Status:
+          </label>
+          <select
+            id="status-filter"
+            value={status}
+            onChange={(e) => {
+              setStatus(e.target.value);
+              setPage(1);
+            }}
+            className="px-2 py-1 bg-gray-800 border border-gray-700 rounded focus:outline-none focus:border-blue-500"
+          >
+            {STATUS_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <label className="flex items-center gap-2 text-gray-400 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={assignedToMe}
+            onChange={(e) => {
+              setAssignedToMe(e.target.checked);
+              setPage(1);
+            }}
+            className="accent-blue-500"
+          />
+          Assigned to me
+        </label>
+      </div>
+
+      {selected.length > 0 && (
+        <div className="flex gap-3 mb-3 p-2 bg-gray-800 rounded text-sm">
+          <span className="text-gray-400">{selected.length} selected</span>
+          <button
+            onClick={handleBulkResolve}
+            className="text-green-400 hover:text-green-300"
+          >
+            Resolve all
+          </button>
+        </div>
+      )}
+
+      {tickets.length === 0 ? (
+        <p className="text-gray-500 text-sm">No tickets match this filter.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-700 text-left text-gray-400">
+              <th className="pb-2 pr-3 w-6">
+                <input
+                  type="checkbox"
+                  checked={
+                    selected.length === tickets.length && tickets.length > 0
+                  }
+                  onChange={toggleAll}
+                  className="accent-blue-500"
+                />
+              </th>
+              <th className="pb-2 pr-3">Subject</th>
+              <th className="pb-2 pr-3">From</th>
+              <th className="pb-2 pr-3">Status</th>
+              <th className="pb-2 pr-3">Assigned</th>
+              <th className="pb-2">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tickets.map((ticket) => (
+              <tr key={ticket.id} className="border-b border-gray-800">
+                <td className="py-2 pr-3">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(ticket.id)}
+                    onChange={() => toggleSelect(ticket.id)}
+                    className="accent-blue-500"
+                  />
+                </td>
+                <td className="py-2 pr-3">
+                  <Link
+                    to={`/private/staff/inbox/${ticket.id}`}
+                    className="hover:underline text-blue-400"
+                  >
+                    {ticket.status === 'Unanswered' && (
+                      <span className="mr-1 text-yellow-400">●</span>
+                    )}
+                    {ticket.subject}
+                  </Link>
+                </td>
+                <td className="py-2 pr-3 text-gray-300">
+                  {ticket.user.username}
+                </td>
+                <td className="py-2 pr-3">
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded ${
+                      STATUS_BADGE[ticket.status] ?? 'bg-gray-700 text-gray-400'
+                    }`}
+                  >
+                    {ticket.status}
+                  </span>
+                </td>
+                <td className="py-2 pr-3 text-gray-400">
+                  {ticket.assignedUser?.username ?? '—'}
+                </td>
+                <td className="py-2 text-gray-500 text-xs whitespace-nowrap">
+                  {new Date(ticket.updatedAt).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2 mt-4 text-sm">
+          <button
+            disabled={page === 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <span className="px-3 py-1 text-gray-400">
+            {page} / {totalPages}
+          </span>
+          <button
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StaffInboxPage;

--- a/src/components/staffInbox/TicketView.tsx
+++ b/src/components/staffInbox/TicketView.tsx
@@ -1,0 +1,283 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import {
+  useGetTicketQuery,
+  useReplyToTicketMutation,
+  useResolveTicketMutation,
+  useUnresolveTicketMutation,
+  useAssignTicketMutation,
+  useGetCannedResponsesQuery
+} from '../../store/services/staffInboxApi';
+import { selectCurrentUser } from '../../store/slices/authSlice';
+import { hasAnyPermission } from '../../utils/permissions';
+import { useAppDispatch } from '../../store/hooks';
+import { addAlert } from '../../store/slices/alertSlice';
+import Spinner from '../layout/Spinner';
+
+const STATUS_BADGE: Record<string, string> = {
+  Unanswered: 'bg-yellow-800 text-yellow-200',
+  Open: 'bg-blue-800 text-blue-200',
+  Resolved: 'bg-gray-700 text-gray-400'
+};
+
+const TicketView = () => {
+  const { id } = useParams<{ id: string }>();
+  const ticketId = Number(id);
+  const dispatch = useAppDispatch();
+  const currentUser = useSelector(selectCurrentUser);
+  const isStaff = hasAnyPermission(currentUser, ['staff', 'admin']);
+
+  const { data: ticket, isLoading, error } = useGetTicketQuery(ticketId);
+  const { data: cannedResponses } = useGetCannedResponsesQuery(undefined, {
+    skip: !isStaff
+  });
+  const [replyToTicket, { isLoading: replying }] = useReplyToTicketMutation();
+  const [resolveTicket, { isLoading: resolving }] = useResolveTicketMutation();
+  const [unresolveTicket] = useUnresolveTicketMutation();
+  const [assignTicket] = useAssignTicketMutation();
+
+  const [replyBody, setReplyBody] = useState('');
+  const [selectedCanned, setSelectedCanned] = useState('');
+  const [assignUserId, setAssignUserId] = useState('');
+
+  const handleCannedSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    setSelectedCanned(val);
+    if (val) {
+      const resp = cannedResponses?.find((r) => r.id === Number(val));
+      if (resp) setReplyBody(resp.body);
+    }
+  };
+
+  const handleReply = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!replyBody.trim()) return;
+    try {
+      await replyToTicket({ id: ticketId, body: replyBody }).unwrap();
+      setReplyBody('');
+      setSelectedCanned('');
+    } catch {
+      dispatch(addAlert('Failed to send reply.', 'danger'));
+    }
+  };
+
+  const handleResolve = async () => {
+    try {
+      await resolveTicket(ticketId).unwrap();
+    } catch {
+      dispatch(addAlert('Failed to resolve ticket.', 'danger'));
+    }
+  };
+
+  const handleUnresolve = async () => {
+    try {
+      await unresolveTicket(ticketId).unwrap();
+    } catch {
+      dispatch(addAlert('Failed to unresolve ticket.', 'danger'));
+    }
+  };
+
+  const handleAssign = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = assignUserId ? parseInt(assignUserId, 10) : null;
+    try {
+      await assignTicket({ id: ticketId, assignedUserId: parsed }).unwrap();
+      setAssignUserId('');
+      dispatch(addAlert('Ticket assigned.', 'success'));
+    } catch {
+      dispatch(addAlert('Failed to assign ticket.', 'danger'));
+    }
+  };
+
+  if (isLoading) return <Spinner />;
+  if (error || !ticket)
+    return (
+      <div className="p-4 text-red-400">Ticket not found or access denied.</div>
+    );
+
+  const isResolved = ticket.status === 'Resolved';
+  const isOwner = ticket.user.id === currentUser?.id;
+
+  const backLink = isStaff
+    ? '/private/staff/inbox'
+    : '/private/staff/inbox/my-tickets';
+
+  return (
+    <div className="thin">
+      <div className="flex items-start justify-between mb-4 gap-4">
+        <div>
+          <Link to={backLink} className="text-blue-400 text-sm hover:underline">
+            ← {isStaff ? 'Staff Inbox' : 'My Tickets'}
+          </Link>
+          <h2 className="text-xl font-semibold mt-1">{ticket.subject}</h2>
+          <div className="flex items-center gap-3 mt-1 text-sm text-gray-400">
+            <span>
+              From:{' '}
+              <span className="text-gray-200">{ticket.user.username}</span>
+            </span>
+            <span
+              className={`text-xs px-2 py-0.5 rounded ${
+                STATUS_BADGE[ticket.status] ?? 'bg-gray-700 text-gray-400'
+              }`}
+            >
+              {ticket.status}
+            </span>
+            {ticket.assignedUser && (
+              <span>
+                Assigned to:{' '}
+                <span className="text-gray-200">
+                  {ticket.assignedUser.username}
+                </span>
+              </span>
+            )}
+            {ticket.resolver && (
+              <span>
+                Resolved by:{' '}
+                <span className="text-gray-200">
+                  {ticket.resolver.username}
+                </span>
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex gap-2 text-sm shrink-0">
+          {!isResolved && (isStaff || isOwner) && (
+            <button
+              onClick={handleResolve}
+              disabled={resolving}
+              className="px-3 py-1.5 bg-green-800 hover:bg-green-700 text-white rounded disabled:opacity-50"
+            >
+              Resolve
+            </button>
+          )}
+          {isResolved && isStaff && (
+            <button
+              onClick={handleUnresolve}
+              className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white rounded"
+            >
+              Unresolve
+            </button>
+          )}
+        </div>
+      </div>
+
+      {isStaff && (
+        <form
+          onSubmit={handleAssign}
+          className="flex gap-2 mb-6 p-3 bg-gray-800 rounded text-sm"
+        >
+          <label
+            htmlFor="assign-user"
+            className="self-center text-gray-400 whitespace-nowrap"
+          >
+            Assign to user ID:
+          </label>
+          <input
+            id="assign-user"
+            type="number"
+            value={assignUserId}
+            onChange={(e) => setAssignUserId(e.target.value)}
+            placeholder="User ID (blank to unassign)"
+            className="flex-1 px-2 py-1 bg-gray-700 border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+          />
+          <button
+            type="submit"
+            className="px-3 py-1 bg-blue-700 hover:bg-blue-600 text-white rounded"
+          >
+            Assign
+          </button>
+        </form>
+      )}
+
+      <div className="space-y-4 mb-6">
+        {(ticket.messages ?? []).map((msg) => {
+          const isMine = msg.sender.id === currentUser?.id;
+          const isStaffMsg = msg.sender.id !== ticket.user.id;
+          return (
+            <div
+              key={msg.id}
+              className={`rounded p-3 border ${
+                isStaffMsg
+                  ? 'bg-gray-800 border-blue-900 ml-4'
+                  : 'bg-gray-900 border-gray-700'
+              } ${isMine ? 'opacity-90' : ''}`}
+            >
+              <div className="flex items-center gap-2 mb-2 text-sm">
+                <span className="font-medium text-blue-400">
+                  {msg.sender.username}
+                </span>
+                {isStaffMsg && (
+                  <span className="text-xs px-1.5 py-0.5 bg-blue-900 text-blue-300 rounded">
+                    Staff
+                  </span>
+                )}
+                <span className="text-gray-600 text-xs">
+                  {new Date(msg.createdAt).toLocaleString()}
+                </span>
+              </div>
+              <p className="text-gray-200 text-sm whitespace-pre-wrap">
+                {msg.body}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      {!isResolved && (
+        <form onSubmit={handleReply} className="flex flex-col gap-3">
+          {isStaff && cannedResponses && cannedResponses.length > 0 && (
+            <div>
+              <label
+                htmlFor="canned-select"
+                className="block text-sm text-gray-400 mb-1"
+              >
+                Use canned response
+              </label>
+              <select
+                id="canned-select"
+                value={selectedCanned}
+                onChange={handleCannedSelect}
+                className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm focus:outline-none focus:border-blue-500"
+              >
+                <option value="">— Select a template —</option>
+                {cannedResponses.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div>
+            <label
+              htmlFor="ticket-reply"
+              className="block text-sm text-gray-400 mb-1"
+            >
+              Reply
+            </label>
+            <textarea
+              id="ticket-reply"
+              value={replyBody}
+              onChange={(e) => setReplyBody(e.target.value)}
+              required
+              rows={5}
+              className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm focus:outline-none focus:border-blue-500 resize-y"
+              placeholder="Write a reply…"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={replying}
+            className="self-start px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded disabled:opacity-50"
+          >
+            {replying ? 'Sending…' : 'Send Reply'}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default TicketView;

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -40,7 +40,10 @@ export const api = createApi({
     'Stats',
     'Request',
     'Download',
-    'Collage'
+    'Collage',
+    'PrivateMessage',
+    'StaffInbox',
+    'StaffInboxResponse'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/messagesApi.ts
+++ b/src/store/services/messagesApi.ts
@@ -1,0 +1,112 @@
+import { api } from '../api';
+import type { paths } from '../../types/api';
+
+type InboxResponse =
+  paths['/messages']['get']['responses'][200]['content']['application/json'];
+type SentboxResponse =
+  paths['/messages/sent']['get']['responses'][200]['content']['application/json'];
+type ConversationResponse =
+  paths['/messages/{id}']['get']['responses'][200]['content']['application/json'];
+type ComposeBody = NonNullable<
+  paths['/messages']['post']['requestBody']
+>['content']['application/json'];
+type ReplyBody = NonNullable<
+  paths['/messages/{id}/reply']['post']['requestBody']
+>['content']['application/json'];
+type UpdateFlagsBody = NonNullable<
+  paths['/messages/{id}']['patch']['requestBody']
+>['content']['application/json'];
+type BulkBody = NonNullable<
+  paths['/messages/bulk']['post']['requestBody']
+>['content']['application/json'];
+type ReplyResponse =
+  paths['/messages/{id}/reply']['post']['responses'][201]['content']['application/json'];
+type UnreadCountResponse =
+  paths['/messages/unread-count']['get']['responses'][200]['content']['application/json'];
+
+export const messagesApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getInbox: build.query<InboxResponse, { page?: number; search?: string }>({
+      query: ({ page = 1, search } = {}) => ({
+        url: '/messages',
+        params: { page, ...(search ? { search } : {}) }
+      }),
+      providesTags: ['PrivateMessage']
+    }),
+
+    getSentbox: build.query<SentboxResponse, { page?: number }>({
+      query: ({ page = 1 } = {}) => ({
+        url: '/messages/sent',
+        params: { page }
+      }),
+      providesTags: ['PrivateMessage']
+    }),
+
+    getUnreadCount: build.query<UnreadCountResponse, void>({
+      query: () => '/messages/unread-count',
+      providesTags: ['PrivateMessage']
+    }),
+
+    getConversation: build.query<ConversationResponse, number>({
+      query: (id) => `/messages/${id}`,
+      providesTags: (_result, _err, id) => [{ type: 'PrivateMessage', id }]
+    }),
+
+    composeMessage: build.mutation<ConversationResponse, ComposeBody>({
+      query: (body) => ({ url: '/messages', method: 'POST', body }),
+      invalidatesTags: ['PrivateMessage']
+    }),
+
+    replyToConversation: build.mutation<
+      ReplyResponse,
+      { id: number } & ReplyBody
+    >({
+      query: ({ id, ...body }) => ({
+        url: `/messages/${id}/reply`,
+        method: 'POST',
+        body
+      }),
+      invalidatesTags: (_result, _err, { id }) => [
+        { type: 'PrivateMessage', id },
+        'PrivateMessage'
+      ]
+    }),
+
+    updateConversationFlags: build.mutation<
+      void,
+      { id: number } & UpdateFlagsBody
+    >({
+      query: ({ id, ...body }) => ({
+        url: `/messages/${id}`,
+        method: 'PATCH',
+        body
+      }),
+      invalidatesTags: (_result, _err, { id }) => [
+        { type: 'PrivateMessage', id },
+        'PrivateMessage'
+      ]
+    }),
+
+    deleteConversation: build.mutation<void, number>({
+      query: (id) => ({ url: `/messages/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['PrivateMessage']
+    }),
+
+    bulkUpdateConversations: build.mutation<void, BulkBody>({
+      query: (body) => ({ url: '/messages/bulk', method: 'POST', body }),
+      invalidatesTags: ['PrivateMessage']
+    })
+  })
+});
+
+export const {
+  useGetInboxQuery,
+  useGetSentboxQuery,
+  useGetUnreadCountQuery,
+  useGetConversationQuery,
+  useComposeMessageMutation,
+  useReplyToConversationMutation,
+  useUpdateConversationFlagsMutation,
+  useDeleteConversationMutation,
+  useBulkUpdateConversationsMutation
+} = messagesApi;

--- a/src/store/services/staffInboxApi.ts
+++ b/src/store/services/staffInboxApi.ts
@@ -1,0 +1,178 @@
+import { api } from '../api';
+import type { paths } from '../../types/api';
+
+type TicketListResponse =
+  paths['/staff-inbox']['get']['responses'][200]['content']['application/json'];
+type TicketResponse =
+  paths['/staff-inbox/{id}']['get']['responses'][200]['content']['application/json'];
+type CreateTicketBody = NonNullable<
+  paths['/staff-inbox']['post']['requestBody']
+>['content']['application/json'];
+type ReplyTicketBody = NonNullable<
+  paths['/staff-inbox/{id}/reply']['post']['requestBody']
+>['content']['application/json'];
+type ReplyTicketResponse =
+  paths['/staff-inbox/{id}/reply']['post']['responses'][201]['content']['application/json'];
+type AssignBody = NonNullable<
+  paths['/staff-inbox/{id}/assign']['post']['requestBody']
+>['content']['application/json'];
+type BulkResolveBody = NonNullable<
+  paths['/staff-inbox/bulk-resolve']['post']['requestBody']
+>['content']['application/json'];
+type ResponsesResponse =
+  paths['/staff-inbox/responses']['get']['responses'][200]['content']['application/json'];
+type CreateResponseBody = NonNullable<
+  paths['/staff-inbox/responses']['post']['requestBody']
+>['content']['application/json'];
+type UpdateResponseBody = NonNullable<
+  paths['/staff-inbox/responses/{id}']['put']['requestBody']
+>['content']['application/json'];
+type UnreadCountResponse =
+  paths['/staff-inbox/unread-count']['get']['responses'][200]['content']['application/json'];
+
+export const staffInboxApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getStaffTickets: build.query<
+      TicketListResponse,
+      { page?: number; status?: string; assignedToMe?: boolean }
+    >({
+      query: ({ page = 1, status = 'all', assignedToMe = false } = {}) => ({
+        url: '/staff-inbox',
+        params: { page, status, assignedToMe }
+      }),
+      providesTags: ['StaffInbox']
+    }),
+
+    getMyTickets: build.query<TicketListResponse, { page?: number }>({
+      query: ({ page = 1 } = {}) => ({
+        url: '/staff-inbox/mine',
+        params: { page }
+      }),
+      providesTags: ['StaffInbox']
+    }),
+
+    getStaffUnreadCount: build.query<UnreadCountResponse, void>({
+      query: () => '/staff-inbox/unread-count',
+      providesTags: ['StaffInbox']
+    }),
+
+    getTicket: build.query<TicketResponse, number>({
+      query: (id) => `/staff-inbox/${id}`,
+      providesTags: (_result, _err, id) => [{ type: 'StaffInbox', id }]
+    }),
+
+    createTicket: build.mutation<TicketResponse, CreateTicketBody>({
+      query: (body) => ({ url: '/staff-inbox', method: 'POST', body }),
+      invalidatesTags: ['StaffInbox']
+    }),
+
+    replyToTicket: build.mutation<
+      ReplyTicketResponse,
+      { id: number } & ReplyTicketBody
+    >({
+      query: ({ id, ...body }) => ({
+        url: `/staff-inbox/${id}/reply`,
+        method: 'POST',
+        body
+      }),
+      invalidatesTags: (_result, _err, { id }) => [
+        { type: 'StaffInbox', id },
+        'StaffInbox'
+      ]
+    }),
+
+    assignTicket: build.mutation<void, { id: number } & AssignBody>({
+      query: ({ id, ...body }) => ({
+        url: `/staff-inbox/${id}/assign`,
+        method: 'POST',
+        body
+      }),
+      invalidatesTags: (_result, _err, { id }) => [
+        { type: 'StaffInbox', id },
+        'StaffInbox'
+      ]
+    }),
+
+    resolveTicket: build.mutation<void, number>({
+      query: (id) => ({ url: `/staff-inbox/${id}/resolve`, method: 'POST' }),
+      invalidatesTags: (_result, _err, id) => [
+        { type: 'StaffInbox', id },
+        'StaffInbox'
+      ]
+    }),
+
+    unresolveTicket: build.mutation<void, number>({
+      query: (id) => ({ url: `/staff-inbox/${id}/unresolve`, method: 'POST' }),
+      invalidatesTags: (_result, _err, id) => [
+        { type: 'StaffInbox', id },
+        'StaffInbox'
+      ]
+    }),
+
+    bulkResolveTickets: build.mutation<
+      { ok: boolean; resolved: number },
+      BulkResolveBody
+    >({
+      query: (body) => ({
+        url: '/staff-inbox/bulk-resolve',
+        method: 'POST',
+        body
+      }),
+      invalidatesTags: ['StaffInbox']
+    }),
+
+    getCannedResponses: build.query<ResponsesResponse, void>({
+      query: () => '/staff-inbox/responses',
+      providesTags: ['StaffInboxResponse']
+    }),
+
+    createCannedResponse: build.mutation<
+      ResponsesResponse[number],
+      CreateResponseBody
+    >({
+      query: (body) => ({
+        url: '/staff-inbox/responses',
+        method: 'POST',
+        body
+      }),
+      invalidatesTags: ['StaffInboxResponse']
+    }),
+
+    updateCannedResponse: build.mutation<
+      ResponsesResponse[number],
+      { id: number } & UpdateResponseBody
+    >({
+      query: ({ id, ...body }) => ({
+        url: `/staff-inbox/responses/${id}`,
+        method: 'PUT',
+        body
+      }),
+      invalidatesTags: ['StaffInboxResponse']
+    }),
+
+    deleteCannedResponse: build.mutation<void, number>({
+      query: (id) => ({
+        url: `/staff-inbox/responses/${id}`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: ['StaffInboxResponse']
+    })
+  })
+});
+
+export const {
+  useGetStaffTicketsQuery,
+  useGetMyTicketsQuery,
+  useGetStaffUnreadCountQuery,
+  useGetTicketQuery,
+  useCreateTicketMutation,
+  useReplyToTicketMutation,
+  useAssignTicketMutation,
+  useResolveTicketMutation,
+  useUnresolveTicketMutation,
+  useBulkResolveTicketsMutation,
+  useGetCannedResponsesQuery,
+  useCreateCannedResponseMutation,
+  useUpdateCannedResponseMutation,
+  useDeleteCannedResponseMutation
+} = staffInboxApi;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -4,4715 +4,5563 @@
  */
 
 export interface paths {
-  '/auth': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Current user */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['AuthUser'];
-          };
+    "/auth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': components['schemas']['LoginBody'];
-        };
-      };
-      responses: {
-        /** @description JWT issued, user returned */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              user: components['schemas']['AuthUser'];
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-        /** @description Invalid credentials */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Account disabled */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/register': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': components['schemas']['RegisterBody'];
-        };
-      };
-      responses: {
-        /** @description Registered and logged in */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              user: components['schemas']['AuthUser'];
+            requestBody?: never;
+            responses: {
+                /** @description Current user */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AuthUser"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
             };
-          };
         };
-        /** @description User already exists */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/auth/logout': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Logged out */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/install': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Install status */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              installed: boolean;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            username: string;
-            /** Format: email */
-            email: string;
-            password: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Installation complete */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              user: components['schemas']['AuthUser'];
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["LoginBody"];
+                };
             };
-          };
-        };
-        /** @description Already installed or validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/users/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description User profile */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['PublicUser'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/users/settings': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Current user settings */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['UserSettings'];
-          };
-        };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            siteAppearance?: string;
-            externalStylesheet?: string | '';
-            styledTooltips?: boolean;
-            paranoia?: number;
-            avatar?: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Updated current user settings */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['UserSettings'] & {
-              avatar?: string;
+            responses: {
+                /** @description JWT issued, user returned */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            user: components["schemas"]["AuthUser"];
+                        };
+                    };
+                };
+                /** @description Invalid credentials */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Account disabled */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
             };
-          };
         };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/users': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            username: string;
-            /** Format: email */
-            email: string;
-            password: string;
-            userRankId?: number;
-          };
+    "/auth/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description Created user */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['AdminCreatedUser'];
-          };
-        };
-        /** @description User already exists */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/profile/me': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Current user profile */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MyProfile'];
-          };
-        };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Profile not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            avatar?: string | '';
-            avatarMouseoverText?: string;
-            profileTitle?: string;
-            profileInfo?: string;
-            siteAppearance?: string;
-            externalStylesheet?: string | '';
-            styledTooltips?: boolean;
-          };
-        };
-      };
-      responses: {
-        /** @description Updated current user profile */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MyProfile'];
-          };
-        };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Profile not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/profile/user/{userId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          userId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Public profile */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['PublicProfile'];
-          };
-        };
-        /** @description Profile not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/profile': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Account disabled */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/profile/referral/create-invite': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            /** Format: email */
-            email: string;
-            reason?: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Invite created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              inviteKey: string;
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-        /** @description No invites remaining */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Invite already exists */
-        409: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/home/featured': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Homepage featured content */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              albumOfTheMonth: components['schemas']['HomepageFeaturedAlbum'] &
-                unknown;
-              vanityHouse: components['schemas']['HomepageFeaturedRelease'] &
-                unknown;
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["RegisterBody"];
+                };
             };
-          };
-        };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/announcements': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description News and blog posts */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['AnnouncementsResponse'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            title: string;
-            body: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Announcement created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Announcement'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/announcements/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Announcement deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/announcements/blog': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            title: string;
-            body: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Blog post created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['BlogPost'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/announcements/blog/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Blog post deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/stats': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Site statistics */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['SiteStats'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/stylesheet': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Available stylesheets */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Stylesheet'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            name: string;
-            /** Format: uri */
-            cssUrl: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Stylesheet created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Stylesheet'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/stylesheet/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Stylesheet */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Stylesheet'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Stylesheet removed */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/notifications': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Notifications */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Notification'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/notifications/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Notification removed */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/subscriptions': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Forum subscriptions */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Subscription'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/subscriptions/subscribe': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            topicId: number;
-            /** @enum {string} */
-            action: 'subscribe' | 'unsubscribe';
-          };
-        };
-      };
-      responses: {
-        /** @description Subscription updated */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/subscriptions/subscribe-comments': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            /** @enum {string} */
-            page: 'forums' | 'artist' | 'collages' | 'requests' | 'communities';
-            pageId: number;
-            /** @enum {string} */
-            action: 'subscribe' | 'unsubscribe';
-          };
-        };
-      };
-      responses: {
-        /** @description Comment subscription updated */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/categories': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description All categories with forums */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumCategory'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            name: string;
-            sort?: number;
-          };
-        };
-      };
-      responses: {
-        /** @description Category created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumCategory'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/categories/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            name: string;
-            sort?: number;
-          };
-        };
-      };
-      responses: {
-        /** @description Category updated */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumCategory'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Category deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Forums */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Forum'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            forumCategoryId: number;
-            /** @default 0 */
-            sort?: number;
-            name: string;
-            description?: string;
-            /** @default 0 */
-            minClassRead?: number;
-            /** @default 0 */
-            minClassWrite?: number;
-            /** @default 0 */
-            minClassCreate?: number;
-            /** @default true */
-            autoLock?: boolean;
-            /** @default 4 */
-            autoLockWeeks?: number;
-          };
-        };
-      };
-      responses: {
-        /** @description Forum created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Forum'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Forum */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Forum'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            name?: string;
-            description?: string;
-            sort?: number;
-            minClassRead?: number;
-            minClassWrite?: number;
-            minClassCreate?: number;
-            autoLock?: boolean;
-            autoLockWeeks?: number;
-          };
-        };
-      };
-      responses: {
-        /** @description Forum updated */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Forum'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Forum deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/{forumId}/topics': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: {
-          page?: string;
-        };
-        header?: never;
-        path: {
-          forumId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Paginated topics */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['PaginatedForumTopics'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          forumId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            title: string;
-            body: string;
-            question?: string;
-            answers?: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Topic created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumTopic'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/{forumId}/topics/{topicId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          forumId: string;
-          topicId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Topic */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumTopic'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          forumId: string;
-          topicId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            title?: string;
-            isLocked?: boolean;
-            isSticky?: boolean;
-          };
-        };
-      };
-      responses: {
-        /** @description Topic updated */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumTopic'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          forumId: string;
-          topicId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Topic removed */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/{forumId}/topics/{topicId}/posts': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: {
-          page?: string;
-        };
-        header?: never;
-        path: {
-          forumId: string;
-          topicId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Paginated posts */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              data: components['schemas']['ForumPost'][];
-              meta: components['schemas']['PaginationMeta'];
+            responses: {
+                /** @description Registered and logged in */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            user: components["schemas"]["AuthUser"];
+                        };
+                    };
+                };
+                /** @description User already exists */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
             };
-          };
         };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          forumId: string;
-          topicId: string;
+    "/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            body: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Post created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumPost'];
-          };
-        };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Topic locked */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/{forumId}/topics/{topicId}/posts/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          forumId: string;
-          topicId: string;
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Post */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumPost'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          forumId: string;
-          topicId: string;
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            body: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Post updated */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumPost'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          forumId: string;
-          topicId: string;
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Post removed */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/polls/{topicId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          topicId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Poll */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumPoll'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/polls': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            forumTopicId: number;
-            question: string;
-            answers: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Poll created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumPoll'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/polls/{id}/close': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Poll closed */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumPoll'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/poll-votes': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            forumPollId: number;
-            vote: number;
-          };
-        };
-      };
-      responses: {
-        /** @description Vote recorded */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumPollVote'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/last-read': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Last-read markers */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumLastReadTopic'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            forumTopicId: number;
-            forumPostId: number;
-          };
-        };
-      };
-      responses: {
-        /** @description Last-read marker saved */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumLastReadTopic'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/communities': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Paginated communities */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              data: components['schemas']['Community'][];
-              meta: components['schemas']['PaginationMeta'];
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/communities/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Community */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Community'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/communities/{id}/releases': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Releases for community */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              data: components['schemas']['Release'][];
-              meta: components['schemas']['PaginationMeta'];
+            requestBody?: never;
+            responses: {
+                /** @description Logged out */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/communities/{communityId}/releases/{releaseId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          communityId: string;
-          releaseId: string;
+    "/install": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Release */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Release'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/communities/{communityId}/releases/{releaseId}/contributions': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          communityId: string;
-          releaseId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            /** @enum {string} */
-            fileType:
-              | 'mp3'
-              | 'flac'
-              | 'wav'
-              | 'ogg'
-              | 'aac'
-              | 'm4a'
-              | 'm4b'
-              | 'mp4'
-              | 'mkv'
-              | 'avi'
-              | 'mov'
-              | 'zip'
-              | 'exe'
-              | 'dmg'
-              | 'apk'
-              | 'pdf'
-              | 'epub'
-              | 'mobi'
-              | 'cbz'
-              | 'cbr'
-              | 'jpg'
-              | 'png'
-              | 'gif'
-              | 'txt';
-            /** Format: uri */
-            downloadUrl: string;
-            sizeInBytes?: number;
-            releaseDescription?: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Contribution created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Contribution'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-        /** @description Release not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/contributions': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Paginated contributions */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              data: components['schemas']['Contribution'][];
-              meta: components['schemas']['PaginationMeta'];
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            communityId: number;
-            /** @enum {string} */
-            type:
-              | 'Music'
-              | 'Applications'
-              | 'EBooks'
-              | 'ELearningVideos'
-              | 'Audiobooks'
-              | 'Comedy'
-              | 'Comics';
-            title: string;
-            year: number;
-            /** @enum {string} */
-            fileType:
-              | 'mp3'
-              | 'flac'
-              | 'wav'
-              | 'ogg'
-              | 'aac'
-              | 'm4a'
-              | 'm4b'
-              | 'mp4'
-              | 'mkv'
-              | 'avi'
-              | 'mov'
-              | 'zip'
-              | 'exe'
-              | 'dmg'
-              | 'apk'
-              | 'pdf'
-              | 'epub'
-              | 'mobi'
-              | 'cbz'
-              | 'cbr'
-              | 'jpg'
-              | 'png'
-              | 'gif'
-              | 'txt';
-            /** Format: uri */
-            downloadUrl: string;
-            sizeInBytes?: number;
-            tags?: string;
-            image?: string | '';
-            description?: string;
-            releaseDescription?: string;
-            collaborators: {
-              artist: string;
-              importance: string;
-            }[];
-          };
-        };
-      };
-      responses: {
-        /** @description Contribution submitted and release created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Contribution'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-        /** @description Community not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/tools/user-ranks': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description User ranks */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['UserRank'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            name: string;
-            level: number;
-            permissions?: {
-              [key: string]: boolean;
+            requestBody?: never;
+            responses: {
+                /** @description Install status */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            installed: boolean;
+                        };
+                    };
+                };
             };
-            color?: string;
-            badge?: string;
-          };
         };
-      };
-      responses: {
-        /** @description User rank created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['UserRank'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/tools/user-ranks/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description User rank */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['UserRank'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            name?: string;
-            level?: number;
-            permissions?: {
-              [key: string]: boolean;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-            color?: string;
-            badge?: string;
-          };
-        };
-      };
-      responses: {
-        /** @description User rank updated */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['UserRank'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description User rank deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Rank still assigned to users */
-        409: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/comments': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: {
-          page?: 'artist' | 'collages' | 'requests' | 'communities' | 'release';
-          pageId?: number;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Comments */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['PaginatedComments'];
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            /** @enum {string} */
-            page:
-              | 'artist'
-              | 'collages'
-              | 'requests'
-              | 'communities'
-              | 'release';
-            body: string;
-            communityId?: number;
-            contributionId?: number;
-            artistId?: number;
-            releaseId?: number;
-            collageId?: number;
-          };
-        };
-      };
-      responses: {
-        /** @description Comment created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Comment'];
-          };
-        };
-        /** @description Not authenticated */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/comments/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            body: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Comment updated */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Comment'];
-          };
-        };
-        /** @description Not authorized */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Comment deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not authorized */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/artists': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Paginated artists */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              data: components['schemas']['Artist'][];
-              meta: components['schemas']['PaginationMeta'];
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        username: string;
+                        /** Format: email */
+                        email: string;
+                        password: string;
+                    };
+                };
             };
-          };
-        };
-      };
-    };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            name: string;
-            vanityHouse?: boolean;
-          };
-        };
-      };
-      responses: {
-        /** @description Artist created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Artist'];
-          };
-        };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/artists/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Artist with releases and tags */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Artist'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            name: string;
-            vanityHouse?: boolean;
-          };
-        };
-      };
-      responses: {
-        /** @description Artist updated */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Artist'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Artist deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/artists/history/{artistId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          artistId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Artist history */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ArtistHistory'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/artists/revert/{historyId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          historyId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Artist reverted */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              msg: string;
-              artist: components['schemas']['Artist'];
+            responses: {
+                /** @description Installation complete */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            user: components["schemas"]["AuthUser"];
+                        };
+                    };
+                };
+                /** @description Already installed or validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
             };
-          };
         };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/artists/{id}/similar': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/users/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Similar artists */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['SimilarArtist'][];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/artists/similar': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            artistId: number;
-            similarArtistId: number;
-          };
-        };
-      };
-      responses: {
-        /** @description Similar artist link created */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              [key: string]: unknown;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
             };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/artists/alias': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            artistId: number;
-            redirectId: number;
-          };
-        };
-      };
-      responses: {
-        /** @description Artist alias created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              [key: string]: unknown;
+            requestBody?: never;
+            responses: {
+                /** @description User profile */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PublicUser"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
             };
-          };
         };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/artists/tag': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            artistId: number;
-            tagId: number;
-          };
+    "/users/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description Artist tagged */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': {
-              [key: string]: unknown;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
+            requestBody?: never;
+            responses: {
+                /** @description Current user settings */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserSettings"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
         };
-      };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        siteAppearance?: string;
+                        externalStylesheet?: string | "";
+                        styledTooltips?: boolean;
+                        paranoia?: number;
+                        avatar?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Updated current user settings */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserSettings"] & {
+                            avatar?: string;
+                        };
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/posts': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        username: string;
+                        /** Format: email */
+                        email: string;
+                        password: string;
+                        userRankId?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Created user */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminCreatedUser"];
+                    };
+                };
+                /** @description User already exists */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description All posts */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Post'][];
-          };
+    "/profile/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current user profile */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MyProfile"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Profile not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        avatar?: string | "";
+                        avatarMouseoverText?: string;
+                        profileTitle?: string;
+                        profileInfo?: string;
+                        siteAppearance?: string;
+                        externalStylesheet?: string | "";
+                        styledTooltips?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Updated current user profile */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MyProfile"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Profile not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            title: string;
-            text: string;
-            category: string;
-            tags?: string[];
-          };
+    "/profile/user/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description Post created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Post'];
-          };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Public profile */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PublicProfile"];
+                    };
+                };
+                /** @description Profile not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
         };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/posts/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Account disabled */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/profile/referral/create-invite": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Post */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['Post'];
-          };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** Format: email */
+                        email: string;
+                        reason?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Invite created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            inviteKey: string;
+                        };
+                    };
+                };
+                /** @description No invites remaining */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Invite already exists */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
         };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/home/featured": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Post deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Homepage featured content */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            albumOfTheMonth: components["schemas"]["HomepageFeaturedAlbum"] & unknown;
+                            vanityHouse: components["schemas"]["HomepageFeaturedRelease"] & unknown;
+                        };
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
         };
-        /** @description Not authorized */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/posts/{id}/comments': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/announcements": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description News and blog posts */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AnnouncementsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        title: string;
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Announcement created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Announcement"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/announcements/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            text: string;
-          };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Announcement deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
         };
-      };
-      responses: {
-        /** @description Comment created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['PostComment'];
-          };
-        };
-        /** @description Post not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/posts/{id}/comments/{commentId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/announcements/blog": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        title: string;
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Blog post created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BlogPost"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
-          commentId: string;
+    "/announcements/blog/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Comment deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Blog post deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
         };
-        /** @description Not authorized */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Comment not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/topic-notes/{topicId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Site statistics */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SiteStats"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          topicId: string;
+    "/stylesheet": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Topic notes (moderators only) */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumTopicNote'][];
-          };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Available stylesheets */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Stylesheet"][];
+                    };
+                };
+            };
         };
-        /** @description Not authorized */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        /** Format: uri */
+                        cssUrl: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Stylesheet created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Stylesheet"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
         };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/topic-notes': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/stylesheet/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Stylesheet */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Stylesheet"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Stylesheet removed */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            forumTopicId: number;
-            body: string;
-          };
+    "/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description Note created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ForumTopicNote'];
-          };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Notifications */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Notification"][];
+                    };
+                };
+            };
         };
-        /** @description Validation error */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['ValidationError'];
-          };
-        };
-        /** @description Not authorized */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/forums/topic-notes/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/notifications/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Notification removed */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Note deleted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Forum subscriptions */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Subscription"][];
+                    };
+                };
+            };
         };
-        /** @description Not authorized */
-        403: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-        /** @description Not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            'application/json': components['schemas']['MsgResponse'];
-          };
-        };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/requests': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/subscriptions/subscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        topicId: number;
+                        /** @enum {string} */
+                        action: "subscribe" | "unsubscribe";
+                    };
+                };
+            };
+            responses: {
+                /** @description Subscription updated */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List requests */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Success */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+    "/subscriptions/subscribe-comments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        page: "forums" | "artist" | "collages" | "requests" | "communities";
+                        pageId: number;
+                        /** @enum {string} */
+                        action: "subscribe" | "unsubscribe";
+                    };
+                };
+            };
+            responses: {
+                /** @description Comment subscription updated */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    /** Create a new request */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            communityId: number;
-            /** @enum {string} */
-            type:
-              | 'Music'
-              | 'Applications'
-              | 'EBooks'
-              | 'ELearningVideos'
-              | 'Audiobooks'
-              | 'Comedy'
-              | 'Comics';
-            title: string;
-            year?: number;
-            image?: string | '';
-            description: string;
-            bounty: string;
-            artists?: number[];
-          };
+    "/forums/categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-      responses: {
-        /** @description Created */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description All categories with forums */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumCategory"][];
+                    };
+                };
+            };
         };
-        /** @description Bad Request */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        sort?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Category created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumCategory"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
         };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/requests/{id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/forums/categories/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        sort?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Category updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumCategory"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Category deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get request details */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/forums": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Success */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Forums */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Forum"][];
+                    };
+                };
+            };
         };
-        /** @description Not Found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        forumCategoryId: number;
+                        /** @default 0 */
+                        sort?: number;
+                        name: string;
+                        description?: string;
+                        /** @default 0 */
+                        minClassRead?: number;
+                        /** @default 0 */
+                        minClassWrite?: number;
+                        /** @default 0 */
+                        minClassCreate?: number;
+                        /** @default true */
+                        autoLock?: boolean;
+                        /** @default 4 */
+                        autoLockWeeks?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Forum created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Forum"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
         };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/requests/{id}/bounty': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/forums/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Forum */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Forum"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        description?: string;
+                        sort?: number;
+                        minClassRead?: number;
+                        minClassWrite?: number;
+                        minClassCreate?: number;
+                        autoLock?: boolean;
+                        autoLockWeeks?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Forum updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Forum"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Forum deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Add bounty to request */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/forums/{forumId}/topics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            amount: string;
-          };
+        get: {
+            parameters: {
+                query?: {
+                    page?: string;
+                };
+                header?: never;
+                path: {
+                    forumId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated topics */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PaginatedForumTopics"];
+                    };
+                };
+            };
         };
-      };
-      responses: {
-        /** @description Success */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    forumId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        title: string;
+                        body: string;
+                        question?: string;
+                        answers?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Topic created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumTopic"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
         };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/requests/{id}/fill': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/forums/{forumId}/topics/{topicId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    forumId: string;
+                    topicId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Topic */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumTopic"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    forumId: string;
+                    topicId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        title?: string;
+                        isLocked?: boolean;
+                        isSticky?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Topic updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumTopic"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    forumId: string;
+                    topicId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Topic removed */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Fill request */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          id: string;
+    "/forums/{forumId}/topics/{topicId}/posts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          'application/json': {
-            contributionId: number;
-          };
+        get: {
+            parameters: {
+                query?: {
+                    page?: string;
+                };
+                header?: never;
+                path: {
+                    forumId: string;
+                    topicId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated posts */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: components["schemas"]["ForumPost"][];
+                            meta: components["schemas"]["PaginationMeta"];
+                        };
+                    };
+                };
+            };
         };
-      };
-      responses: {
-        /** @description Success */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    forumId: string;
+                    topicId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Post created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumPost"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Topic locked */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
         };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/forums/{forumId}/topics/{topicId}/posts/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    forumId: string;
+                    topicId: string;
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Post */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumPost"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    forumId: string;
+                    topicId: string;
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Post updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumPost"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    forumId: string;
+                    topicId: string;
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Post removed */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/forums/polls/{topicId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    topicId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Poll */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumPoll"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/forums/polls": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        forumTopicId: number;
+                        question: string;
+                        answers: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Poll created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumPoll"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/forums/polls/{id}/close": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Poll closed */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumPoll"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/forums/poll-votes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        forumPollId: number;
+                        vote: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Vote recorded */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumPollVote"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/forums/last-read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Last-read markers */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumLastReadTopic"][];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        forumTopicId: number;
+                        forumPostId: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Last-read marker saved */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumLastReadTopic"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/communities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated communities */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: components["schemas"]["Community"][];
+                            meta: components["schemas"]["PaginationMeta"];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/communities/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Community */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Community"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/communities/{id}/releases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Releases for community */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: components["schemas"]["Release"][];
+                            meta: components["schemas"]["PaginationMeta"];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/communities/{communityId}/releases/{releaseId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    communityId: string;
+                    releaseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Release */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Release"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/communities/{communityId}/releases/{releaseId}/contributions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    communityId: string;
+                    releaseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        fileType: "mp3" | "flac" | "wav" | "ogg" | "aac" | "m4a" | "m4b" | "mp4" | "mkv" | "avi" | "mov" | "zip" | "exe" | "dmg" | "apk" | "pdf" | "epub" | "mobi" | "cbz" | "cbr" | "jpg" | "png" | "gif" | "txt";
+                        /** Format: uri */
+                        downloadUrl: string;
+                        sizeInBytes?: number;
+                        releaseDescription?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Contribution created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Contribution"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+                /** @description Release not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/contributions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated contributions */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: components["schemas"]["Contribution"][];
+                            meta: components["schemas"]["PaginationMeta"];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        communityId: number;
+                        /** @enum {string} */
+                        type: "Music" | "Applications" | "EBooks" | "ELearningVideos" | "Audiobooks" | "Comedy" | "Comics";
+                        title: string;
+                        year: number;
+                        /** @enum {string} */
+                        fileType: "mp3" | "flac" | "wav" | "ogg" | "aac" | "m4a" | "m4b" | "mp4" | "mkv" | "avi" | "mov" | "zip" | "exe" | "dmg" | "apk" | "pdf" | "epub" | "mobi" | "cbz" | "cbr" | "jpg" | "png" | "gif" | "txt";
+                        /** Format: uri */
+                        downloadUrl: string;
+                        sizeInBytes?: number;
+                        tags?: string;
+                        image?: string | "";
+                        description?: string;
+                        releaseDescription?: string;
+                        collaborators: {
+                            artist: string;
+                            importance: string;
+                        }[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Contribution submitted and release created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Contribution"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+                /** @description Community not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/tools/user-ranks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description User ranks */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserRank"][];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        level: number;
+                        permissions?: {
+                            [key: string]: boolean;
+                        };
+                        color?: string;
+                        badge?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description User rank created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserRank"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/tools/user-ranks/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description User rank */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserRank"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        level?: number;
+                        permissions?: {
+                            [key: string]: boolean;
+                        };
+                        color?: string;
+                        badge?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description User rank updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserRank"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description User rank deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Rank still assigned to users */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/comments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    page?: "artist" | "collages" | "requests" | "communities" | "release";
+                    pageId?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Comments */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PaginatedComments"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        page: "artist" | "collages" | "requests" | "communities" | "release";
+                        body: string;
+                        communityId?: number;
+                        contributionId?: number;
+                        artistId?: number;
+                        releaseId?: number;
+                        collageId?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Comment created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Comment"];
+                    };
+                };
+                /** @description Not authenticated */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/comments/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Comment updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Comment"];
+                    };
+                };
+                /** @description Not authorized */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Comment deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not authorized */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artists": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated artists */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: components["schemas"]["Artist"][];
+                            meta: components["schemas"]["PaginationMeta"];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        vanityHouse?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Artist created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Artist"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artists/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Artist with releases and tags */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Artist"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        vanityHouse?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Artist updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Artist"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Artist deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artists/history/{artistId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    artistId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Artist history */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ArtistHistory"][];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artists/revert/{historyId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    historyId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Artist reverted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            msg: string;
+                            artist: components["schemas"]["Artist"];
+                        };
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artists/{id}/similar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Similar artists */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SimilarArtist"][];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artists/similar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        artistId: number;
+                        similarArtistId: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Similar artist link created */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artists/alias": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        artistId: number;
+                        redirectId: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Artist alias created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/artists/tag": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        artistId: number;
+                        tagId: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Artist tagged */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/posts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description All posts */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Post"][];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        title: string;
+                        text: string;
+                        category: string;
+                        tags?: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Post created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Post"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/posts/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Post */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Post"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Post deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not authorized */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/posts/{id}/comments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        text: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Comment created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PostComment"];
+                    };
+                };
+                /** @description Post not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/posts/{id}/comments/{commentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    commentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Comment deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not authorized */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Comment not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/forums/topic-notes/{topicId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    topicId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Topic notes (moderators only) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumTopicNote"][];
+                    };
+                };
+                /** @description Not authorized */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/forums/topic-notes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        forumTopicId: number;
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Note created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ForumTopicNote"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ValidationError"];
+                    };
+                };
+                /** @description Not authorized */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/forums/topic-notes/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Note deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not authorized */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List requests */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /** Create a new request */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        communityId: number;
+                        /** @enum {string} */
+                        type: "Music" | "Applications" | "EBooks" | "ELearningVideos" | "Audiobooks" | "Comedy" | "Comics";
+                        title: string;
+                        year?: number;
+                        image?: string | "";
+                        description: string;
+                        bounty: string;
+                        artists?: number[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Bad Request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/requests/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get request details */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/requests/{id}/bounty": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Add bounty to request */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        amount: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/requests/{id}/fill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Fill request */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        contributionId: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Success */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/messages": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    page?: number;
+                    search?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Inbox conversations */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PaginatedConversations"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        toUserId: number;
+                        subject: string;
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Conversation created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PrivateConversation"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/messages/unread-count": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Unread conversation count */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            count: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/messages/sent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Sent conversations */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PaginatedConversations"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/messages/bulk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        ids: number[];
+                        /** @enum {string} */
+                        action: "delete" | "markRead" | "markUnread";
+                    };
+                };
+            };
+            responses: {
+                /** @description Bulk action applied */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/messages/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Conversation with messages */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PrivateConversation"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Conversation soft-deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        isSticky?: boolean;
+                        isRead?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Flags updated */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/messages/{id}/reply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Reply sent */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PrivateMessage"];
+                    };
+                };
+                /** @description Not a participant */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    page?: number;
+                    status?: "Unanswered" | "Open" | "Resolved" | "all";
+                    assignedToMe?: boolean | null;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Staff ticket list */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PaginatedTickets"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        subject: string;
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Ticket created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["StaffInboxConversation"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/unread-count": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Open ticket count */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            count: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/mine": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description My tickets */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PaginatedTickets"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/responses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Canned responses */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["StaffInboxResponse"][];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Response created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["StaffInboxResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/responses/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        body?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Response updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["StaffInboxResponse"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Response deleted */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/bulk-resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        ids: number[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Tickets resolved */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok: boolean;
+                            resolved: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Ticket */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["StaffInboxConversation"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MsgResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/{id}/reply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        body: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Reply sent */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["StaffInboxMsg"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/{id}/assign": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        assignedUserId: number | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Assigned */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/{id}/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Resolved */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/staff-inbox/{id}/unresolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Unresolved */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    MsgResponse: {
-      msg: string;
-    };
-    ErrorResponse: {
-      error: string;
-    };
-    ValidationError: {
-      msg: string;
-      errors: {
-        [key: string]: string[];
-      };
-    };
-    PaginationMeta: {
-      total: number;
-      page: number;
-      limit: number;
-      totalPages: number;
-    };
-    LoginBody: {
-      /** Format: email */
-      email: string;
-      password: string;
-    };
-    RegisterBody: {
-      username: string;
-      /** Format: email */
-      email: string;
-      password: string;
-      inviteKey?: string;
-    };
-    AuthUser: {
-      id: number;
-      username: string;
-      /** Format: email */
-      email?: string;
-      avatar: string | null;
-      inviteCount?: number;
-      dateRegistered?: string;
-      lastLogin?: string | null;
-      isArtist?: boolean;
-      isDonor?: boolean;
-      canDownload?: boolean;
-      userRank: {
-        level: number;
-        name: string;
-        color: string;
-        badge?: string;
-        permissions?: {
-          [key: string]: boolean;
+    schemas: {
+        MsgResponse: {
+            msg: string;
         };
-      };
-    };
-    PublicUser: {
-      id: number;
-      username: string;
-      avatar: string | null;
-      dateRegistered: string;
-      isArtist: boolean;
-      isDonor: boolean;
-      userRank: {
-        name: string;
-        color: string;
-      };
-      profile: {
-        id: number;
-        avatar?: string | null;
-        avatarMouseoverText?: string | null;
-        profileTitle?: string | null;
-        profileInfo?: string | null;
-      };
-    };
-    ProfileDetails: {
-      id: number;
-      avatar?: string | null;
-      avatarMouseoverText?: string | null;
-      profileTitle?: string | null;
-      profileInfo?: string | null;
-    };
-    UserRankSummary: {
-      name: string;
-      color: string;
-      badge?: string;
-    };
-    UserSettings: {
-      id: number;
-      siteAppearance: string;
-      externalStylesheet?: string | null;
-      styledTooltips: boolean;
-      paranoia: number;
-    };
-    InviteNode: {
-      id: number;
-      username: string;
-      /** Format: email */
-      email: string;
-      joinedAt: string;
-      lastSeen?: string | null;
-      uploaded?: string;
-      downloaded?: string;
-      ratio?: string;
-      children?: components['schemas']['InviteNode'][];
-    };
-    PublicProfile: {
-      id: number;
-      username: string;
-      avatar: string | null;
-      dateRegistered: string;
-      isArtist: boolean;
-      isDonor: boolean;
-      userRank: components['schemas']['UserRankSummary'];
-      profile: components['schemas']['ProfileDetails'];
-      userSettings: {
-        siteAppearance?: string;
-        styledTooltips?: boolean;
-      };
-    };
-    MyProfile: {
-      id: number;
-      username: string;
-      avatar: string | null;
-      profile: components['schemas']['ProfileDetails'];
-      userSettings: components['schemas']['UserSettings'];
-      userRank: {
-        name: string;
-        color: string;
-      };
-      inviteTree: components['schemas']['InviteNode'][];
-    };
-    AdminCreatedUser: {
-      id: number;
-      username: string;
-      /** Format: email */
-      email: string;
-    };
-    HomepageFeaturedRelease: {
-      id: number;
-      title: string;
-      year?: number | null;
-      image?: string | null;
-      communityId: number;
-      artist?: {
-        id: number;
-        name: string;
-      } | null;
-    };
-    HomepageFeaturedAlbum: {
-      id: number;
-      title: string;
-      started: string;
-      ended: string;
-      threadId?: number | null;
-      release: components['schemas']['HomepageFeaturedRelease'];
-    };
-    Announcement: {
-      id: number;
-      title: string;
-      body: string;
-      createdAt: string;
-    };
-    BlogPost: {
-      id: number;
-      title: string;
-      body?: string;
-      createdAt: string;
-      user?: {
-        username: string;
-        avatar?: string | null;
-      };
-    };
-    AnnouncementsResponse: {
-      announcements: components['schemas']['Announcement'][];
-      blogPosts: components['schemas']['BlogPost'][];
-    };
-    SiteStats: {
-      totalUsers: number;
-      enabledUsers: number;
-      activeToday: number;
-      activeThisWeek: number;
-      activeThisMonth: number;
-      communities: number;
-      releases: number;
-      artists: number;
-      blogPosts: number;
-      announcements: number;
-      comments: number;
-      contributedLinks: number;
-      contributedLinkDownloads: number;
-    };
-    Notification: {
-      id: number;
-      page: string;
-      pageId: number;
-      postId: number;
-      createdAt: string;
-      quoter: {
-        id: number;
-        username: string;
-        avatar?: string | null;
-      };
-    };
-    Subscription: {
-      id: number;
-      topicId: number;
-    };
-    Stylesheet: {
-      id: number;
-      name: string;
-      cssUrl: string;
-      createdAt: string;
-    };
-    Forum: {
-      id: number;
-      sort: number;
-      name: string;
-      description: string;
-      minClassRead?: number;
-      minClassWrite?: number;
-      minClassCreate?: number;
-      numTopics: number;
-      numPosts: number;
-      forumCategory?: {
-        id: number;
-        name: string;
-      };
-      lastTopic?: {
-        id: number;
-        title: string;
-      };
-    };
-    ForumCategory: {
-      id: number;
-      name: string;
-      sort: number;
-      forums?: components['schemas']['Forum'][];
-    };
-    ForumTopic: {
-      id: number;
-      title: string;
-      forumId: number;
-      authorId: number;
-      isLocked: boolean;
-      isSticky: boolean;
-      numPosts: number;
-      author?: {
-        id: number;
-        username: string;
-        avatar?: string | null;
-      };
-      lastPost?: {
-        id: number;
-        createdAt: string;
-        author?: {
-          id: number;
-          username: string;
+        ErrorResponse: {
+            error: string;
         };
-      };
-      createdAt: string;
-      updatedAt: string;
-    };
-    ForumPostEdit: {
-      id: number;
-      forumPostId: number;
-      editorId: number;
-      previousBody: string;
-      editedAt: string;
-      editor?: {
-        id: number;
-        username: string;
-      };
-    };
-    ForumPost: {
-      id: number;
-      forumTopicId: number;
-      authorId: number;
-      body: string;
-      edits: components['schemas']['ForumPostEdit'][];
-      author?: {
-        id: number;
-        username: string;
-        avatar?: string | null;
-      };
-      createdAt: string;
-      updatedAt: string;
-    };
-    ForumPollVote: {
-      id: number;
-      forumPollId: number;
-      userId: number;
-      vote: number;
-    };
-    ForumPoll: {
-      id: number;
-      forumTopicId: number;
-      question: string;
-      answers: string;
-      /** Format: date-time */
-      featured?: string | null;
-      closed: boolean;
-      votes: components['schemas']['ForumPollVote'][];
-    };
-    ForumLastReadTopic: {
-      id: number;
-      userId: number;
-      forumTopicId: number;
-      forumPostId: number;
-    };
-    PaginatedForumTopics: {
-      data: components['schemas']['ForumTopic'][];
-      meta: components['schemas']['PaginationMeta'];
-    };
-    CommunityStaffMember: {
-      id: number;
-      username: string;
-    };
-    Community: {
-      id: number;
-      name: string;
-      description?: string | null;
-      type?: string | null;
-      registrationStatus?: string | null;
-      image?: string | null;
-      staff?: components['schemas']['CommunityStaffMember'][];
-      _count?: {
-        releases: number;
-        contributors: number;
-        consumers: number;
-      };
-    };
-    ReleaseTag: {
-      id: number;
-      name: string;
-    };
-    ReleaseArtist: {
-      id: number;
-      name: string;
-    };
-    ReleaseContribution: {
-      id: number;
-      user: {
-        id: number;
-        username: string;
-      };
-      type: string;
-      downloadUrl: string;
-      sizeInBytes?: number | null;
-      collaborators: {
-        id: number;
-        name: string;
-        vanityHouse?: boolean;
-      }[];
-      releaseDescription?: string | null;
-    };
-    Contribution: {
-      id: number;
-      user: {
-        id: number;
-        username: string;
-      };
-      release: {
-        id: number;
-        title: string;
-        communityId?: number | null;
-      };
-      type: string;
-      downloadUrl: string;
-      sizeInBytes?: number | null;
-      collaborators: {
-        id: number;
-        name: string;
-      }[];
-      releaseDescription?: string | null;
-      createdAt?: string;
-    };
-    Release: {
-      id: number;
-      title: string;
-      communityId: number | null;
-      year?: number | null;
-      type?: string | null;
-      image?: string | null;
-      description?: string | null;
-      createdAt?: string;
-      artist?: components['schemas']['ReleaseArtist'];
-      tags?: components['schemas']['ReleaseTag'][];
-      contributions?: components['schemas']['ReleaseContribution'][];
-    };
-    UserRank: {
-      id: number;
-      name: string;
-      level: number;
-      permissions?: {
-        [key: string]: boolean;
-      };
-      color?: string;
-      badge?: string;
-      userCount?: number;
-    };
-    Comment: {
-      id: number;
-      page: string;
-      body: string;
-      authorId: number;
-      collageId?: number | null;
-      createdAt: string;
-      author?: {
-        id: number;
-        username: string;
-        avatar?: string | null;
-      };
-    };
-    PaginatedComments: {
-      data: components['schemas']['Comment'][];
-      meta: components['schemas']['PaginationMeta'];
-    };
-    Artist: {
-      id: number;
-      name: string;
-      vanityHouse: boolean;
-      _count?: {
-        releases: number;
-      };
-      aliases?: {
-        redirect: {
-          id: number;
-          name: string;
+        ValidationError: {
+            msg: string;
+            errors: {
+                [key: string]: string[];
+            };
         };
-      }[];
-      tags?: {
-        tag: {
-          id: number;
-          name: string;
+        PaginationMeta: {
+            total: number;
+            page: number;
+            limit: number;
+            totalPages: number;
         };
-      }[];
-      similarTo?: {
-        similarArtist: {
-          id: number;
-          name: string;
+        LoginBody: {
+            /** Format: email */
+            email: string;
+            password: string;
         };
-      }[];
-      releases?: {
-        id: number;
-        title: string;
-        year?: number | null;
-      }[];
+        RegisterBody: {
+            username: string;
+            /** Format: email */
+            email: string;
+            password: string;
+            inviteKey?: string;
+        };
+        AuthUser: {
+            id: number;
+            username: string;
+            /** Format: email */
+            email?: string;
+            avatar: string | null;
+            inviteCount?: number;
+            dateRegistered?: string;
+            lastLogin?: string | null;
+            isArtist?: boolean;
+            isDonor?: boolean;
+            canDownload?: boolean;
+            userRank: {
+                level: number;
+                name: string;
+                color: string;
+                badge?: string;
+                permissions?: {
+                    [key: string]: boolean;
+                };
+            };
+        };
+        PublicUser: {
+            id: number;
+            username: string;
+            avatar: string | null;
+            dateRegistered: string;
+            isArtist: boolean;
+            isDonor: boolean;
+            userRank: {
+                name: string;
+                color: string;
+            };
+            profile: {
+                id: number;
+                avatar?: string | null;
+                avatarMouseoverText?: string | null;
+                profileTitle?: string | null;
+                profileInfo?: string | null;
+            };
+        };
+        ProfileDetails: {
+            id: number;
+            avatar?: string | null;
+            avatarMouseoverText?: string | null;
+            profileTitle?: string | null;
+            profileInfo?: string | null;
+        };
+        UserRankSummary: {
+            name: string;
+            color: string;
+            badge?: string;
+        };
+        UserSettings: {
+            id: number;
+            siteAppearance: string;
+            externalStylesheet?: string | null;
+            styledTooltips: boolean;
+            paranoia: number;
+        };
+        InviteNode: {
+            id: number;
+            username: string;
+            /** Format: email */
+            email: string;
+            joinedAt: string;
+            lastSeen?: string | null;
+            uploaded?: string;
+            downloaded?: string;
+            ratio?: string;
+            children?: components["schemas"]["InviteNode"][];
+        };
+        PublicProfile: {
+            id: number;
+            username: string;
+            avatar: string | null;
+            dateRegistered: string;
+            isArtist: boolean;
+            isDonor: boolean;
+            userRank: components["schemas"]["UserRankSummary"];
+            profile: components["schemas"]["ProfileDetails"];
+            userSettings: {
+                siteAppearance?: string;
+                styledTooltips?: boolean;
+            };
+        };
+        MyProfile: {
+            id: number;
+            username: string;
+            avatar: string | null;
+            profile: components["schemas"]["ProfileDetails"];
+            userSettings: components["schemas"]["UserSettings"];
+            userRank: {
+                name: string;
+                color: string;
+            };
+            inviteTree: components["schemas"]["InviteNode"][];
+        };
+        AdminCreatedUser: {
+            id: number;
+            username: string;
+            /** Format: email */
+            email: string;
+        };
+        HomepageFeaturedRelease: {
+            id: number;
+            title: string;
+            year?: number | null;
+            image?: string | null;
+            communityId: number;
+            artist?: {
+                id: number;
+                name: string;
+            } | null;
+        };
+        HomepageFeaturedAlbum: {
+            id: number;
+            title: string;
+            started: string;
+            ended: string;
+            threadId?: number | null;
+            release: components["schemas"]["HomepageFeaturedRelease"];
+        };
+        Announcement: {
+            id: number;
+            title: string;
+            body: string;
+            createdAt: string;
+        };
+        BlogPost: {
+            id: number;
+            title: string;
+            body?: string;
+            createdAt: string;
+            user?: {
+                username: string;
+                avatar?: string | null;
+            };
+        };
+        AnnouncementsResponse: {
+            announcements: components["schemas"]["Announcement"][];
+            blogPosts: components["schemas"]["BlogPost"][];
+        };
+        SiteStats: {
+            totalUsers: number;
+            enabledUsers: number;
+            activeToday: number;
+            activeThisWeek: number;
+            activeThisMonth: number;
+            communities: number;
+            releases: number;
+            artists: number;
+            blogPosts: number;
+            announcements: number;
+            comments: number;
+            contributedLinks: number;
+            contributedLinkDownloads: number;
+        };
+        Notification: {
+            id: number;
+            page: string;
+            pageId: number;
+            postId: number;
+            createdAt: string;
+            quoter: {
+                id: number;
+                username: string;
+                avatar?: string | null;
+            };
+        };
+        Subscription: {
+            id: number;
+            topicId: number;
+        };
+        Stylesheet: {
+            id: number;
+            name: string;
+            cssUrl: string;
+            createdAt: string;
+        };
+        Forum: {
+            id: number;
+            sort: number;
+            name: string;
+            description: string;
+            minClassRead?: number;
+            minClassWrite?: number;
+            minClassCreate?: number;
+            numTopics: number;
+            numPosts: number;
+            forumCategory?: {
+                id: number;
+                name: string;
+            };
+            lastTopic?: {
+                id: number;
+                title: string;
+            };
+        };
+        ForumCategory: {
+            id: number;
+            name: string;
+            sort: number;
+            forums?: components["schemas"]["Forum"][];
+        };
+        ForumTopic: {
+            id: number;
+            title: string;
+            forumId: number;
+            authorId: number;
+            isLocked: boolean;
+            isSticky: boolean;
+            numPosts: number;
+            author?: {
+                id: number;
+                username: string;
+                avatar?: string | null;
+            };
+            lastPost?: {
+                id: number;
+                createdAt: string;
+                author?: {
+                    id: number;
+                    username: string;
+                };
+            };
+            createdAt: string;
+            updatedAt: string;
+        };
+        ForumPostEdit: {
+            id: number;
+            forumPostId: number;
+            editorId: number;
+            previousBody: string;
+            editedAt: string;
+            editor?: {
+                id: number;
+                username: string;
+            };
+        };
+        ForumPost: {
+            id: number;
+            forumTopicId: number;
+            authorId: number;
+            body: string;
+            edits: components["schemas"]["ForumPostEdit"][];
+            author?: {
+                id: number;
+                username: string;
+                avatar?: string | null;
+            };
+            createdAt: string;
+            updatedAt: string;
+        };
+        ForumPollVote: {
+            id: number;
+            forumPollId: number;
+            userId: number;
+            vote: number;
+        };
+        ForumPoll: {
+            id: number;
+            forumTopicId: number;
+            question: string;
+            answers: string;
+            /** Format: date-time */
+            featured?: string | null;
+            closed: boolean;
+            votes: components["schemas"]["ForumPollVote"][];
+        };
+        ForumLastReadTopic: {
+            id: number;
+            userId: number;
+            forumTopicId: number;
+            forumPostId: number;
+        };
+        PaginatedForumTopics: {
+            data: components["schemas"]["ForumTopic"][];
+            meta: components["schemas"]["PaginationMeta"];
+        };
+        CommunityStaffMember: {
+            id: number;
+            username: string;
+        };
+        Community: {
+            id: number;
+            name: string;
+            description?: string | null;
+            type?: string | null;
+            registrationStatus?: string | null;
+            image?: string | null;
+            staff?: components["schemas"]["CommunityStaffMember"][];
+            _count?: {
+                releases: number;
+                contributors: number;
+                consumers: number;
+            };
+        };
+        ReleaseTag: {
+            id: number;
+            name: string;
+        };
+        ReleaseArtist: {
+            id: number;
+            name: string;
+        };
+        ReleaseContribution: {
+            id: number;
+            user: {
+                id: number;
+                username: string;
+            };
+            type: string;
+            downloadUrl: string;
+            sizeInBytes?: number | null;
+            collaborators: {
+                id: number;
+                name: string;
+                vanityHouse?: boolean;
+            }[];
+            releaseDescription?: string | null;
+        };
+        Contribution: {
+            id: number;
+            user: {
+                id: number;
+                username: string;
+            };
+            release: {
+                id: number;
+                title: string;
+                communityId?: number | null;
+            };
+            type: string;
+            downloadUrl: string;
+            sizeInBytes?: number | null;
+            collaborators: {
+                id: number;
+                name: string;
+            }[];
+            releaseDescription?: string | null;
+            createdAt?: string;
+        };
+        Release: {
+            id: number;
+            title: string;
+            communityId: number | null;
+            year?: number | null;
+            type?: string | null;
+            image?: string | null;
+            description?: string | null;
+            createdAt?: string;
+            artist?: components["schemas"]["ReleaseArtist"];
+            tags?: components["schemas"]["ReleaseTag"][];
+            contributions?: components["schemas"]["ReleaseContribution"][];
+        };
+        UserRank: {
+            id: number;
+            name: string;
+            level: number;
+            permissions?: {
+                [key: string]: boolean;
+            };
+            color?: string;
+            badge?: string;
+            userCount?: number;
+        };
+        Comment: {
+            id: number;
+            page: string;
+            body: string;
+            authorId: number;
+            createdAt: string;
+            author?: {
+                id: number;
+                username: string;
+                avatar?: string | null;
+            };
+        };
+        PaginatedComments: {
+            data: components["schemas"]["Comment"][];
+            meta: components["schemas"]["PaginationMeta"];
+        };
+        Artist: {
+            id: number;
+            name: string;
+            vanityHouse: boolean;
+            _count?: {
+                releases: number;
+            };
+            aliases?: {
+                redirect: {
+                    id: number;
+                    name: string;
+                };
+            }[];
+            tags?: {
+                tag: {
+                    id: number;
+                    name: string;
+                };
+            }[];
+            similarTo?: {
+                similarArtist: {
+                    id: number;
+                    name: string;
+                };
+            }[];
+            releases?: {
+                id: number;
+                title: string;
+                year?: number | null;
+            }[];
+        };
+        ArtistHistory: {
+            id: number;
+            artistId: number;
+            editedAt: string;
+            description?: string | null;
+            editedUser?: {
+                id: number;
+                username: string;
+            };
+        };
+        SimilarArtist: {
+            similarArtist: {
+                id: number;
+                name: string;
+            };
+        };
+        PostComment: {
+            id: number;
+            postId: number;
+            userId: number;
+            text: string;
+            createdAt: string;
+            user?: {
+                id: number;
+                username: string;
+                avatar?: string | null;
+            };
+        };
+        Post: {
+            id: number;
+            userId: number;
+            title: string;
+            text: string;
+            category: string;
+            tags: string[];
+            comments: components["schemas"]["PostComment"][];
+            createdAt: string;
+            user?: {
+                id: number;
+                username: string;
+                avatar?: string | null;
+            };
+        };
+        ForumTopicNote: {
+            id: number;
+            forumTopicId: number;
+            authorId: number;
+            body: string;
+            createdAt: string;
+            updatedAt: string;
+            author?: {
+                id: number;
+                username: string;
+            };
+        };
+        MessageUser: {
+            id: number;
+            username: string;
+            avatar?: string | null;
+        };
+        PrivateMessage: {
+            id: number;
+            conversationId: number;
+            body: string;
+            createdAt: string;
+            sender?: components["schemas"]["MessageUser"] & unknown;
+        };
+        PrivateConversationParticipant: {
+            userId: number;
+            conversationId: number;
+            inInbox: boolean;
+            inSentbox: boolean;
+            isRead: boolean;
+            isSticky: boolean;
+            sentAt?: string | null;
+            receivedAt?: string | null;
+            user?: components["schemas"]["MessageUser"];
+        };
+        PrivateConversation: {
+            id: number;
+            subject: string;
+            createdAt: string;
+            participants?: components["schemas"]["PrivateConversationParticipant"][];
+            messages?: components["schemas"]["PrivateMessage"][];
+        };
+        PaginatedConversations: {
+            total: number;
+            page: number;
+            pageSize: number;
+            conversations: components["schemas"]["PrivateConversation"][];
+        };
+        StaffInboxMessageUser: {
+            id: number;
+            username: string;
+            avatar?: string | null;
+        };
+        StaffInboxMsg: {
+            id: number;
+            conversationId: number;
+            body: string;
+            createdAt: string;
+            sender: components["schemas"]["StaffInboxMessageUser"];
+        };
+        StaffInboxConversation: {
+            id: number;
+            subject: string;
+            /** @enum {string} */
+            status: "Unanswered" | "Open" | "Resolved";
+            isReadByUser: boolean;
+            createdAt: string;
+            updatedAt: string;
+            user: components["schemas"]["StaffInboxMessageUser"];
+            assignedUser?: components["schemas"]["StaffInboxMessageUser"] & unknown;
+            resolver?: components["schemas"]["StaffInboxMessageUser"] & unknown;
+            messages?: components["schemas"]["StaffInboxMsg"][];
+        };
+        PaginatedTickets: {
+            total: number;
+            page: number;
+            pageSize: number;
+            conversations: components["schemas"]["StaffInboxConversation"][];
+        };
+        StaffInboxResponse: {
+            id: number;
+            name: string;
+            body: string;
+            createdAt: string;
+            updatedAt: string;
+        };
     };
-    ArtistHistory: {
-      id: number;
-      artistId: number;
-      editedAt: string;
-      description?: string | null;
-      editedUser?: {
-        id: number;
-        username: string;
-      };
-    };
-    SimilarArtist: {
-      similarArtist: {
-        id: number;
-        name: string;
-      };
-    };
-    PostComment: {
-      id: number;
-      postId: number;
-      userId: number;
-      text: string;
-      createdAt: string;
-      user?: {
-        id: number;
-        username: string;
-        avatar?: string | null;
-      };
-    };
-    Post: {
-      id: number;
-      userId: number;
-      title: string;
-      text: string;
-      category: string;
-      tags: string[];
-      comments: components['schemas']['PostComment'][];
-      createdAt: string;
-      user?: {
-        id: number;
-        username: string;
-        avatar?: string | null;
-      };
-    };
-    ForumTopicNote: {
-      id: number;
-      forumTopicId: number;
-      authorId: number;
-      body: string;
-      createdAt: string;
-      updatedAt: string;
-      author?: {
-        id: number;
-        username: string;
-      };
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;


### PR DESCRIPTION
Private messaging: inbox, sentbox, compose form, conversation view with per-user sticky/delete/mark-unread and bulk actions.

Staff inbox: user-facing ticket list, new ticket form, ticket view with canned response picker, staff assign/resolve/unresolve controls. Staff management surfaces: ticket list with status/assignee filters, bulk resolve, and canned responses CRUD page.

New RTK Query services: messagesApi and staffInboxApi. Tag types and routes registered. OpenAPI-generated types regenerated from updated stellar-api spec.