### PR TITLE
feat(wiki): wiki UI with list, view, edit, history, and compare

### DIFF
--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -59,6 +59,10 @@ import MassPmPage from '../../../staff/MassPmPage';
 import DonorRanksPage from '../../../staff/DonorRanksPage';
 import SnatchList from '../snatch/SnatchList';
 import BookmarksPage from '../bookmarks/BookmarksPage';
+import WikiListPage from '../../../wiki/WikiListPage';
+import WikiViewPage from '../../../wiki/WikiViewPage';
+import WikiEditPage from '../../../wiki/WikiEditPage';
+import WikiHistoryPage from '../../../wiki/WikiHistoryPage';
 import DraftsPage from '../../../messages/DraftsPage';
 import { useGetMeQuery } from '../../../../store/services/authApi';
 import {
@@ -306,6 +310,12 @@ const PrivateContent = () => (
     <Route path="reports/new" element={wrap(ReportForm)} />
     <Route path="reports/mine" element={wrap(MyReportsPage)} />
     <Route path="reports/:id" element={wrap(ReportDetailPage)} />
+
+    <Route path="wiki/new" element={wrap(WikiEditPage)} />
+    <Route path="wiki/:id/edit" element={wrap(WikiEditPage)} />
+    <Route path="wiki/:id/history" element={wrap(WikiHistoryPage)} />
+    <Route path="wiki/:id" element={wrap(WikiViewPage)} />
+    <Route path="wiki" element={wrap(WikiListPage)} />
 
     <Route path="" element={<PrivateHomepage />} />
     <Route path="*" element={<NotFound />} />

--- a/src/components/pages/private/layout/PrivateHeader.tsx
+++ b/src/components/pages/private/layout/PrivateHeader.tsx
@@ -17,7 +17,8 @@ const navLinks = [
   { label: 'Communities', to: '/private/communities' },
   { label: 'Collages', to: '/private/collages' },
   { label: 'Requests', to: '/private/requests' },
-  { label: 'Forums', to: '/private/forums' }
+  { label: 'Forums', to: '/private/forums' },
+  { label: 'Wiki', to: '/private/wiki' }
 ];
 
 const PrivateHeader = ({ user }: Props) => {

--- a/src/components/wiki/WikiEditPage.tsx
+++ b/src/components/wiki/WikiEditPage.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import {
+  useGetWikiPageQuery,
+  useCreateWikiPageMutation,
+  useUpdateWikiPageMutation
+} from '../../store/services/wikiApi';
+import { useGetMeQuery } from '../../store/services/authApi';
+import { hasAnyPermission } from '../../utils/permissions';
+import { addAlert } from '../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../utils/apiError';
+import Spinner from '../layout/Spinner';
+
+const WikiEditPage = () => {
+  const { id } = useParams<{ id?: string }>();
+  const isNew = !id;
+  const pageId = id ? Number(id) : undefined;
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { data: user } = useGetMeQuery();
+
+  const { data: existing, isLoading: isLoadingPage } = useGetWikiPageQuery(
+    pageId!,
+    { skip: isNew }
+  );
+
+  const [createPage, { isLoading: isCreating }] = useCreateWikiPageMutation();
+  const [updatePage, { isLoading: isUpdating }] = useUpdateWikiPageMutation();
+
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [slug, setSlug] = useState('');
+  const [minReadLevel, setMinReadLevel] = useState(0);
+  const [minEditLevel, setMinEditLevel] = useState(0);
+
+  const canManage = hasAnyPermission(user, ['wiki_manage', 'admin', 'staff']);
+
+  useEffect(() => {
+    if (existing) {
+      setTitle(existing.title);
+      setBody(existing.body);
+      setSlug(existing.slug);
+      setMinReadLevel(existing.minReadLevel);
+      setMinEditLevel(existing.minEditLevel);
+    }
+  }, [existing]);
+
+  if (!isNew && isLoadingPage) return <Spinner />;
+
+  const isSaving = isCreating || isUpdating;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (isNew) {
+        const page = await createPage({
+          title,
+          body,
+          slug: slug || undefined,
+          ...(canManage ? { minReadLevel, minEditLevel } : {})
+        }).unwrap();
+        dispatch(addAlert('Page created.', 'success'));
+        navigate(`/private/wiki/${page.id}`);
+      } else {
+        await updatePage({
+          id: pageId!,
+          title,
+          body,
+          ...(canManage ? { minReadLevel, minEditLevel } : {})
+        }).unwrap();
+        dispatch(addAlert('Page updated.', 'success'));
+        navigate(`/private/wiki/${pageId}`);
+      }
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to save.', 'danger')
+      );
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6">
+      <div className="mb-4">
+        <Link
+          to={isNew ? '/private/wiki' : `/private/wiki/${pageId}`}
+          className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+        >
+          ← {isNew ? 'Wiki' : existing?.title ?? 'Back'}
+        </Link>
+        <h1 className="text-xl font-bold text-white mt-1">
+          {isNew ? 'New Wiki Page' : `Edit: ${existing?.title}`}
+        </h1>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="bg-gray-900 border border-gray-700 rounded-lg p-5 space-y-4">
+          <div>
+            <label
+              htmlFor="wiki-title"
+              className="block text-sm text-gray-300 mb-1"
+            >
+              Title
+            </label>
+            <input
+              id="wiki-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              minLength={3}
+              maxLength={100}
+              className="w-full rounded-lg bg-gray-800 border border-gray-700 text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+
+          {isNew && (
+            <div>
+              <label
+                htmlFor="wiki-slug"
+                className="block text-sm text-gray-300 mb-1"
+              >
+                Slug{' '}
+                <span className="text-gray-500 text-xs">
+                  (optional — derived from title if blank)
+                </span>
+              </label>
+              <input
+                id="wiki-slug"
+                type="text"
+                value={slug}
+                onChange={(e) =>
+                  setSlug(
+                    e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '')
+                  )
+                }
+                maxLength={50}
+                placeholder="my-page-slug"
+                pattern="[a-z0-9-]*"
+                className="w-full rounded-lg bg-gray-800 border border-gray-700 text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono"
+              />
+            </div>
+          )}
+
+          <div>
+            <label
+              htmlFor="wiki-body"
+              className="block text-sm text-gray-300 mb-1"
+            >
+              Body{' '}
+              <span className="text-gray-500 text-xs">
+                (HTML supported: b, i, a, ul, code, pre, blockquote…)
+              </span>
+            </label>
+            <textarea
+              id="wiki-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              required
+              rows={20}
+              className="w-full rounded-lg bg-gray-800 border border-gray-700 text-white px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+
+          {canManage && (
+            <div className="grid grid-cols-2 gap-4 border-t border-gray-700 pt-4">
+              <div>
+                <label
+                  htmlFor="wiki-min-read"
+                  className="block text-sm text-gray-300 mb-1"
+                >
+                  Min rank level to read
+                </label>
+                <input
+                  id="wiki-min-read"
+                  type="number"
+                  min={0}
+                  max={1000}
+                  value={minReadLevel}
+                  onChange={(e) => setMinReadLevel(Number(e.target.value))}
+                  className="w-full rounded-lg bg-gray-800 border border-gray-700 text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="wiki-min-edit"
+                  className="block text-sm text-gray-300 mb-1"
+                >
+                  Min rank level to edit
+                </label>
+                <input
+                  id="wiki-min-edit"
+                  type="number"
+                  min={0}
+                  max={1000}
+                  value={minEditLevel}
+                  onChange={(e) => setMinEditLevel(Number(e.target.value))}
+                  className="w-full rounded-lg bg-gray-800 border border-gray-700 text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <p className="col-span-2 text-xs text-gray-500">
+                Set to 0 for no restriction. minEditLevel is automatically
+                clamped to at least minReadLevel.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-3 justify-end">
+          <Link
+            to={isNew ? '/private/wiki' : `/private/wiki/${pageId}`}
+            className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={isSaving}
+            className="px-5 py-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm rounded-lg transition-colors"
+          >
+            {isSaving ? 'Saving…' : isNew ? 'Create Page' : 'Save Changes'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default WikiEditPage;

--- a/src/components/wiki/WikiEditPage.tsx
+++ b/src/components/wiki/WikiEditPage.tsx
@@ -79,6 +79,9 @@ const WikiEditPage = () => {
     }
   };
 
+  // prettier-ignore
+  const backLabel = isNew ? 'Wiki' : (existing?.title ?? 'Back');
+
   return (
     <div className="max-w-4xl mx-auto px-4 py-6">
       <div className="mb-4">
@@ -86,7 +89,7 @@ const WikiEditPage = () => {
           to={isNew ? '/private/wiki' : `/private/wiki/${pageId}`}
           className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
         >
-          ← {isNew ? 'Wiki' : existing?.title ?? 'Back'}
+          ← {backLabel}
         </Link>
         <h1 className="text-xl font-bold text-white mt-1">
           {isNew ? 'New Wiki Page' : `Edit: ${existing?.title}`}

--- a/src/components/wiki/WikiHistoryPage.tsx
+++ b/src/components/wiki/WikiHistoryPage.tsx
@@ -35,6 +35,17 @@ const ALLOWED_WIKI_TAGS = [
   'h3'
 ];
 
+const DIFF_CLASS: Record<string, string> = {
+  deleted: 'bg-red-900/40 text-red-300',
+  added: 'bg-green-900/40 text-green-300',
+  unchanged: 'text-gray-400'
+};
+const DIFF_PREFIX: Record<string, string> = {
+  deleted: '−',
+  added: '+',
+  unchanged: ' '
+};
+
 // Compute a simple line-level diff to mirror Gazelle's compare.php output.
 function diffLines(
   oldText: string,
@@ -114,22 +125,9 @@ const CompareModal = ({
         {data && (
           <div className="p-5 font-mono text-xs overflow-x-auto">
             {lines.map((line, i) => (
-              <div
-                key={i}
-                className={
-                  line.type === 'deleted'
-                    ? 'bg-red-900/40 text-red-300'
-                    : line.type === 'added'
-                    ? 'bg-green-900/40 text-green-300'
-                    : 'text-gray-400'
-                }
-              >
+              <div key={i} className={DIFF_CLASS[line.type]}>
                 <span className="select-none mr-2">
-                  {line.type === 'deleted'
-                    ? '−'
-                    : line.type === 'added'
-                    ? '+'
-                    : ' '}
+                  {DIFF_PREFIX[line.type]}
                 </span>
                 {line.text || ' '}
               </div>

--- a/src/components/wiki/WikiHistoryPage.tsx
+++ b/src/components/wiki/WikiHistoryPage.tsx
@@ -1,0 +1,400 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import DOMPurify from 'dompurify';
+import {
+  useGetWikiRevisionsQuery,
+  useGetWikiRevisionQuery,
+  useCompareWikiRevisionsQuery,
+  useRollbackWikiPageMutation
+} from '../../store/services/wikiApi';
+import { useGetMeQuery } from '../../store/services/authApi';
+import { hasAnyPermission } from '../../utils/permissions';
+import { addAlert } from '../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../utils/apiError';
+import Spinner from '../layout/Spinner';
+
+const ALLOWED_WIKI_TAGS = [
+  'b',
+  'i',
+  'u',
+  'em',
+  'strong',
+  'a',
+  'p',
+  'br',
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'code',
+  'pre',
+  'span',
+  'h1',
+  'h2',
+  'h3'
+];
+
+// Compute a simple line-level diff to mirror Gazelle's compare.php output.
+function diffLines(
+  oldText: string,
+  newText: string
+): Array<{ type: 'unchanged' | 'deleted' | 'added'; text: string }> {
+  const oldLines = oldText.split('\n');
+  const newLines = newText.split('\n');
+  const result: Array<{
+    type: 'unchanged' | 'deleted' | 'added';
+    text: string;
+  }> = [];
+
+  let oi = 0;
+  let ni = 0;
+  while (oi < oldLines.length || ni < newLines.length) {
+    if (oi >= oldLines.length) {
+      result.push({ type: 'added', text: newLines[ni++] });
+    } else if (ni >= newLines.length) {
+      result.push({ type: 'deleted', text: oldLines[oi++] });
+    } else if (oldLines[oi] === newLines[ni]) {
+      result.push({ type: 'unchanged', text: oldLines[oi] });
+      oi++;
+      ni++;
+    } else {
+      result.push({ type: 'deleted', text: oldLines[oi++] });
+      result.push({ type: 'added', text: newLines[ni++] });
+    }
+  }
+  return result;
+}
+
+const CompareModal = ({
+  pageId,
+  oldRev,
+  newRev,
+  onClose
+}: {
+  pageId: number;
+  oldRev: number;
+  newRev: number;
+  onClose: () => void;
+}) => {
+  const { data, isLoading, error } = useCompareWikiRevisionsQuery({
+    id: pageId,
+    old: oldRev,
+    new: newRev
+  });
+
+  const lines = data ? diffLines(data.old.body, data.new.body) : [];
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-start justify-center z-50 p-4 overflow-y-auto">
+      <div className="bg-gray-800 rounded-xl border border-gray-700 w-full max-w-3xl my-8">
+        <div className="flex items-center justify-between px-5 py-3 border-b border-gray-700">
+          <h3 className="text-sm font-semibold text-white">
+            Compare r{oldRev} → r{newRev}
+            {data ? ` — ${data.title}` : ''}
+          </h3>
+          <button
+            onClick={onClose}
+            className="px-3 py-1 text-xs text-gray-400 hover:text-white transition-colors"
+          >
+            Close
+          </button>
+        </div>
+
+        {isLoading && (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        )}
+        {error && (
+          <div className="p-4 text-red-400 text-sm">
+            Failed to load comparison.
+          </div>
+        )}
+        {data && (
+          <div className="p-5 font-mono text-xs overflow-x-auto">
+            {lines.map((line, i) => (
+              <div
+                key={i}
+                className={
+                  line.type === 'deleted'
+                    ? 'bg-red-900/40 text-red-300'
+                    : line.type === 'added'
+                    ? 'bg-green-900/40 text-green-300'
+                    : 'text-gray-400'
+                }
+              >
+                <span className="select-none mr-2">
+                  {line.type === 'deleted'
+                    ? '−'
+                    : line.type === 'added'
+                    ? '+'
+                    : ' '}
+                </span>
+                {line.text || ' '}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const RevisionViewer = ({
+  pageId,
+  rev,
+  onClose
+}: {
+  pageId: number;
+  rev: number;
+  onClose: () => void;
+}) => {
+  const { data, isLoading } = useGetWikiRevisionQuery({ id: pageId, rev });
+  const dispatch = useDispatch();
+  const { data: user } = useGetMeQuery();
+  const [rollback, { isLoading: isRollingBack }] =
+    useRollbackWikiPageMutation();
+
+  const canEdit = hasAnyPermission(user, [
+    'wiki_edit',
+    'wiki_manage',
+    'admin',
+    'staff'
+  ]);
+
+  const handleRollback = async () => {
+    if (
+      !confirm(`Roll back to revision ${rev}? This will create a new revision.`)
+    )
+      return;
+    try {
+      await rollback({ id: pageId, rev }).unwrap();
+      dispatch(addAlert(`Rolled back to revision ${rev}.`, 'success'));
+      onClose();
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Rollback failed.', 'danger')
+      );
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-start justify-center z-50 p-4 overflow-y-auto">
+      <div className="bg-gray-800 rounded-xl border border-gray-700 w-full max-w-3xl my-8">
+        <div className="flex items-center justify-between px-5 py-3 border-b border-gray-700">
+          <h3 className="text-sm font-semibold text-white">
+            Revision {rev}
+            {isLoading ? '' : data ? ` — ${data.title}` : ''}
+          </h3>
+          <div className="flex gap-2">
+            {canEdit && data && (
+              <button
+                onClick={handleRollback}
+                disabled={isRollingBack}
+                className="px-3 py-1 text-xs bg-amber-600 hover:bg-amber-500 disabled:opacity-50 text-white rounded transition-colors"
+              >
+                {isRollingBack ? 'Rolling back…' : 'Rollback to this revision'}
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="px-3 py-1 text-xs text-gray-400 hover:text-white transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+
+        {isLoading && (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        )}
+
+        {data && (
+          <>
+            <div className="px-5 py-2 border-b border-gray-700 text-xs text-gray-400">
+              By {data.author.username} on{' '}
+              {new Date(data.createdAt).toLocaleString()}
+            </div>
+            <div
+              className="p-5 text-sm text-gray-200 prose prose-invert prose-sm max-w-none leading-relaxed"
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(data.body, {
+                  ALLOWED_TAGS: ALLOWED_WIKI_TAGS,
+                  ALLOWED_ATTR: ['href', 'class', 'rel', 'target']
+                })
+              }}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const WikiHistoryPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const pageId = Number(id);
+  const [viewingRev, setViewingRev] = useState<number | null>(null);
+  const [compareOld, setCompareOld] = useState<number | null>(null);
+  const [compareNew, setCompareNew] = useState<number | null>(null);
+  const [showCompare, setShowCompare] = useState(false);
+
+  const { data, isLoading, error } = useGetWikiRevisionsQuery(pageId);
+  const { data: user } = useGetMeQuery();
+
+  const canEdit = hasAnyPermission(user, [
+    'wiki_edit',
+    'wiki_manage',
+    'admin',
+    'staff'
+  ]);
+
+  if (isLoading) return <Spinner />;
+  if (error || !data)
+    return (
+      <div className="p-4 text-red-400">Failed to load revision history.</div>
+    );
+
+  const allRevNums = [
+    data.currentRevision,
+    ...data.revisions.map((r) => r.revision)
+  ].sort((a, b) => a - b);
+
+  const handleCompare = () => {
+    if (compareOld !== null && compareNew !== null && compareOld < compareNew) {
+      setShowCompare(true);
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-6">
+      {viewingRev !== null && !showCompare && (
+        <RevisionViewer
+          pageId={pageId}
+          rev={viewingRev}
+          onClose={() => setViewingRev(null)}
+        />
+      )}
+
+      {showCompare && compareOld !== null && compareNew !== null && (
+        <CompareModal
+          pageId={pageId}
+          oldRev={compareOld}
+          newRev={compareNew}
+          onClose={() => setShowCompare(false)}
+        />
+      )}
+
+      <div className="mb-4">
+        <Link
+          to={`/private/wiki/${pageId}`}
+          className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+        >
+          ← Back to page
+        </Link>
+        <h1 className="text-xl font-bold text-white mt-1">Revision History</h1>
+        <p className="text-sm text-gray-400">
+          Current revision: {data.currentRevision}
+        </p>
+      </div>
+
+      {/* Compare form */}
+      {canEdit && allRevNums.length >= 2 && (
+        <div className="bg-gray-900 border border-gray-700 rounded-lg p-4 mb-4 flex items-center gap-3 flex-wrap">
+          <span className="text-xs text-gray-400">Compare:</span>
+          <select
+            value={compareOld ?? ''}
+            onChange={(e) => setCompareOld(Number(e.target.value))}
+            className="rounded bg-gray-800 border border-gray-600 text-white text-xs px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          >
+            <option value="">Old rev…</option>
+            {allRevNums.map((r) => (
+              <option key={r} value={r}>
+                r{r}
+              </option>
+            ))}
+          </select>
+          <span className="text-gray-500 text-xs">→</span>
+          <select
+            value={compareNew ?? ''}
+            onChange={(e) => setCompareNew(Number(e.target.value))}
+            className="rounded bg-gray-800 border border-gray-600 text-white text-xs px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          >
+            <option value="">New rev…</option>
+            {allRevNums.map((r) => (
+              <option key={r} value={r}>
+                r{r}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={handleCompare}
+            disabled={
+              compareOld === null ||
+              compareNew === null ||
+              compareOld >= compareNew
+            }
+            className="px-3 py-1 text-xs bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 text-white rounded transition-colors"
+          >
+            Compare
+          </button>
+        </div>
+      )}
+
+      {data.revisions.length === 0 && (
+        <div className="bg-gray-900 border border-gray-700 rounded-lg px-6 py-10 text-center">
+          <p className="text-gray-500 text-sm">No prior revisions.</p>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {/* Current revision row */}
+        <div className="bg-gray-900 border border-indigo-700 rounded-lg px-4 py-3 flex items-center justify-between">
+          <div>
+            <span className="text-xs font-semibold text-indigo-400 mr-2">
+              Current (rev {data.currentRevision})
+            </span>
+          </div>
+          <button
+            onClick={() => setViewingRev(data.currentRevision)}
+            className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+          >
+            View
+          </button>
+        </div>
+
+        {data.revisions.map((rev) => (
+          <div
+            key={rev.id}
+            className="bg-gray-900 border border-gray-700 rounded-lg px-4 py-3 flex items-center justify-between"
+          >
+            <div>
+              <span className="text-sm text-gray-200">{rev.title}</span>
+              <div className="text-xs text-gray-500 mt-0.5">
+                Rev {rev.revision} · by{' '}
+                <Link
+                  to={`/private/user/${rev.author.id}`}
+                  className="text-indigo-400 hover:text-indigo-300"
+                >
+                  {rev.author.username}
+                </Link>{' '}
+                · {new Date(rev.createdAt).toLocaleString()}
+              </div>
+            </div>
+            <button
+              onClick={() => setViewingRev(rev.revision)}
+              className="text-xs text-gray-400 hover:text-white transition-colors"
+            >
+              View
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default WikiHistoryPage;

--- a/src/components/wiki/WikiListPage.tsx
+++ b/src/components/wiki/WikiListPage.tsx
@@ -147,7 +147,8 @@ const WikiListPage = () => {
       {/* Active filter indicator */}
       {q && (
         <p className="text-sm text-gray-400">
-          Showing results for <span className="text-white">&ldquo;{q}&rdquo;</span>
+          Showing results for{' '}
+          <span className="text-white">&ldquo;{q}&rdquo;</span>{' '}
           {type !== 'all' && (
             <span className="ml-1 text-gray-500">
               in {type === 'title' ? 'titles' : 'body text'}

--- a/src/components/wiki/WikiListPage.tsx
+++ b/src/components/wiki/WikiListPage.tsx
@@ -1,0 +1,242 @@
+import { useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useGetWikiPagesQuery } from '../../store/services/wikiApi';
+import { useGetMeQuery } from '../../store/services/authApi';
+import { hasAnyPermission } from '../../utils/permissions';
+import Spinner from '../layout/Spinner';
+
+const WikiListPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchInput, setSearchInput] = useState(searchParams.get('q') ?? '');
+  const { data: user } = useGetMeQuery();
+
+  const q = searchParams.get('q') ?? undefined;
+  const type = (searchParams.get('type') ?? 'all') as 'title' | 'body' | 'all';
+  const order = (searchParams.get('order') ?? 'title') as
+    | 'title'
+    | 'created'
+    | 'edited';
+  const way = (searchParams.get('way') ?? 'asc') as 'asc' | 'desc';
+  const page = Number(searchParams.get('page') ?? 1);
+
+  const { data, isLoading, error } = useGetWikiPagesQuery({
+    q,
+    type,
+    order,
+    way,
+    page
+  });
+
+  const canCreate = hasAnyPermission(user, [
+    'wiki_edit',
+    'wiki_manage',
+    'admin',
+    'staff'
+  ]);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    const next = new URLSearchParams();
+    if (searchInput.trim()) next.set('q', searchInput.trim());
+    if (type !== 'all') next.set('type', type);
+    if (order !== 'title') next.set('order', order);
+    if (way !== 'asc') next.set('way', way);
+    next.set('page', '1');
+    setSearchParams(next);
+  };
+
+  const setSort = (newOrder: string, newWay: string) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('order', newOrder);
+    next.set('way', newWay);
+    next.set('page', '1');
+    setSearchParams(next);
+  };
+
+  const clearFilters = () => {
+    setSearchInput('');
+    setSearchParams(new URLSearchParams());
+  };
+
+  const SortButton = ({
+    label,
+    field
+  }: {
+    label: string;
+    field: 'title' | 'created' | 'edited';
+  }) => {
+    const isActive = order === field;
+    const nextWay = isActive && way === 'asc' ? 'desc' : 'asc';
+    return (
+      <button
+        onClick={() => setSort(field, nextWay)}
+        className={`text-xs px-2 py-1 rounded transition-colors ${
+          isActive
+            ? 'bg-indigo-700 text-white'
+            : 'bg-gray-800 text-gray-400 hover:text-white hover:bg-gray-700'
+        }`}
+      >
+        {label} {isActive ? (way === 'asc' ? '↑' : '↓') : ''}
+      </button>
+    );
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-white">Wiki</h1>
+        {canCreate && (
+          <Link
+            to="/private/wiki/new"
+            className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded-lg transition-colors"
+          >
+            + New Page
+          </Link>
+        )}
+      </div>
+
+      {/* Search */}
+      <form onSubmit={handleSearch} className="space-y-2">
+        <div className="flex gap-2">
+          <input
+            type="search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search wiki pages…"
+            className="flex-1 rounded-lg bg-gray-800 border border-gray-700 text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+          <button
+            type="submit"
+            className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded-lg transition-colors"
+          >
+            Search
+          </button>
+          {q && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+        {/* Search type filter */}
+        <div className="flex items-center gap-2 text-xs text-gray-400">
+          <span>Search in:</span>
+          {(['all', 'title', 'body'] as const).map((t) => (
+            <label key={t} className="flex items-center gap-1 cursor-pointer">
+              <input
+                type="radio"
+                name="searchType"
+                value={t}
+                checked={type === t}
+                onChange={() => {
+                  const next = new URLSearchParams(searchParams);
+                  next.set('type', t);
+                  setSearchParams(next);
+                }}
+                className="accent-indigo-500"
+              />
+              <span className="capitalize">{t}</span>
+            </label>
+          ))}
+        </div>
+      </form>
+
+      {/* Active filter indicator */}
+      {q && (
+        <p className="text-sm text-gray-400">
+          Showing results for <span className="text-white">&ldquo;{q}&rdquo;</span>
+          {type !== 'all' && (
+            <span className="ml-1 text-gray-500">
+              in {type === 'title' ? 'titles' : 'body text'}
+            </span>
+          )}
+        </p>
+      )}
+
+      {/* Sort controls */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-gray-500">Sort:</span>
+        <SortButton label="Title" field="title" />
+        <SortButton label="Created" field="created" />
+        <SortButton label="Last edited" field="edited" />
+      </div>
+
+      {isLoading && <Spinner />}
+      {error && (
+        <div className="p-4 text-red-400">Failed to load wiki pages.</div>
+      )}
+
+      {data && data.data.length === 0 && (
+        <div className="bg-gray-900 border border-gray-700 rounded-lg px-6 py-10 text-center">
+          <p className="text-gray-500 text-sm">No pages found.</p>
+        </div>
+      )}
+
+      {data && data.data.length > 0 && (
+        <div className="space-y-2">
+          {data.data.map((p) => (
+            <div
+              key={p.id}
+              className="bg-gray-900 border border-gray-700 rounded-lg px-4 py-3 flex items-center justify-between hover:border-gray-600 transition-colors"
+            >
+              <div>
+                <Link
+                  to={`/private/wiki/${p.id}`}
+                  className="text-indigo-400 hover:text-indigo-300 font-medium transition-colors"
+                >
+                  {p.title}
+                </Link>
+                <div className="text-xs text-gray-500 mt-0.5">
+                  rev {p.revision} · edited{' '}
+                  {new Date(p.updatedAt).toLocaleDateString()} by{' '}
+                  {p.author.username}
+                  {p.minReadLevel > 0 && (
+                    <span className="ml-2 text-amber-500">
+                      restricted (level {p.minReadLevel})
+                    </span>
+                  )}
+                </div>
+              </div>
+              <Link
+                to={`/private/wiki/${p.id}/history`}
+                className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              >
+                History
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {data && data.meta.totalPages > 1 && (
+        <div className="flex gap-2 justify-center">
+          {Array.from({ length: data.meta.totalPages }, (_, i) => i + 1).map(
+            (p) => (
+              <button
+                key={p}
+                onClick={() => {
+                  const next = new URLSearchParams(searchParams);
+                  next.set('page', String(p));
+                  setSearchParams(next);
+                }}
+                className={`px-3 py-1 text-sm rounded transition-colors ${
+                  p === page
+                    ? 'bg-indigo-600 text-white'
+                    : 'bg-gray-800 text-gray-400 hover:text-white'
+                }`}
+              >
+                {p}
+              </button>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WikiListPage;

--- a/src/components/wiki/WikiViewPage.tsx
+++ b/src/components/wiki/WikiViewPage.tsx
@@ -1,0 +1,238 @@
+import { useState } from 'react';
+import { Link, useParams, useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import DOMPurify from 'dompurify';
+import {
+  useGetWikiPageQuery,
+  useDeleteWikiPageMutation,
+  useAddWikiAliasMutation,
+  useDeleteWikiAliasMutation
+} from '../../store/services/wikiApi';
+import { useGetMeQuery } from '../../store/services/authApi';
+import { hasAnyPermission } from '../../utils/permissions';
+import { addAlert } from '../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../utils/apiError';
+import Spinner from '../layout/Spinner';
+
+const ALLOWED_WIKI_TAGS = [
+  'b',
+  'i',
+  'u',
+  'em',
+  'strong',
+  'a',
+  'p',
+  'br',
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'code',
+  'pre',
+  'span',
+  'h1',
+  'h2',
+  'h3'
+];
+
+const WikiViewPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const pageId = Number(id);
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { data: user } = useGetMeQuery();
+  const { data: page, isLoading, error } = useGetWikiPageQuery(pageId);
+
+  const [deletePage, { isLoading: isDeleting }] = useDeleteWikiPageMutation();
+  const [addAlias, { isLoading: isAddingAlias }] = useAddWikiAliasMutation();
+  const [deleteAlias] = useDeleteWikiAliasMutation();
+  const [aliasInput, setAliasInput] = useState('');
+  const [showAliasForm, setShowAliasForm] = useState(false);
+
+  if (isLoading) return <Spinner />;
+  if (error || !page)
+    return <div className="p-4 text-red-400">Page not found.</div>;
+
+  const userRankLevel =
+    (user as { userRankLevel?: number } | undefined)?.userRankLevel ?? 0;
+  const canManage = hasAnyPermission(user, ['wiki_manage', 'admin', 'staff']);
+  const canEdit =
+    canManage ||
+    (hasAnyPermission(user, ['wiki_edit']) &&
+      userRankLevel >= page.minEditLevel);
+
+  const renderedBody = DOMPurify.sanitize(page.body, {
+    ALLOWED_TAGS: ALLOWED_WIKI_TAGS,
+    ALLOWED_ATTR: ['href', 'class', 'rel', 'target']
+  });
+
+  const handleDelete = async () => {
+    if (!confirm(`Delete "${page.title}"? This cannot be undone.`)) return;
+    try {
+      await deletePage(pageId).unwrap();
+      dispatch(addAlert('Page deleted.', 'success'));
+      navigate('/private/wiki');
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to delete.', 'danger')
+      );
+    }
+  };
+
+  const handleAddAlias = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await addAlias({ id: pageId, alias: aliasInput.trim() }).unwrap();
+      dispatch(addAlert('Alias added.', 'success'));
+      setAliasInput('');
+      setShowAliasForm(false);
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to add alias.', 'danger')
+      );
+    }
+  };
+
+  const handleDeleteAlias = async (alias: string) => {
+    if (!confirm(`Remove alias "${alias}"?`)) return;
+    try {
+      await deleteAlias({ id: pageId, alias }).unwrap();
+      dispatch(addAlert('Alias removed.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to remove alias.', 'danger')
+      );
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6">
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <Link
+            to="/private/wiki"
+            className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            ← Wiki
+          </Link>
+          <h1 className="text-2xl font-bold text-white mt-1">{page.title}</h1>
+          <p className="text-xs text-gray-500 mt-1">
+            Revision {page.revision} · Last edited{' '}
+            {new Date(page.updatedAt).toLocaleDateString()} by{' '}
+            <Link
+              to={`/private/user/${page.author.id}`}
+              className="text-indigo-400 hover:text-indigo-300"
+            >
+              {page.author.username}
+            </Link>
+            {page.minReadLevel > 0 && (
+              <span className="ml-2 text-amber-500">
+                · Requires level {page.minReadLevel} to read
+              </span>
+            )}
+          </p>
+        </div>
+        <div className="flex gap-2 mt-1">
+          <Link
+            to={`/private/wiki/${pageId}/history`}
+            className="px-3 py-1.5 text-sm text-gray-400 hover:text-white bg-gray-800 hover:bg-gray-700 rounded-lg transition-colors"
+          >
+            History
+          </Link>
+          {canEdit && (
+            <Link
+              to={`/private/wiki/${pageId}/edit`}
+              className="px-3 py-1.5 text-sm text-white bg-indigo-600 hover:bg-indigo-500 rounded-lg transition-colors"
+            >
+              Edit
+            </Link>
+          )}
+          {canManage && (
+            <button
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="px-3 py-1.5 text-sm text-white bg-red-700 hover:bg-red-600 disabled:opacity-50 rounded-lg transition-colors"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div
+        className="prose prose-invert prose-sm max-w-none bg-gray-900 border border-gray-700 rounded-lg p-6 text-gray-200 leading-relaxed"
+        dangerouslySetInnerHTML={{ __html: renderedBody }}
+      />
+
+      {/* Aliases */}
+      <div className="mt-6 bg-gray-900 border border-gray-700 rounded-lg p-4">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-semibold text-gray-300">Aliases</h3>
+          {canEdit && !showAliasForm && (
+            <button
+              onClick={() => setShowAliasForm(true)}
+              className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+            >
+              + Add alias
+            </button>
+          )}
+        </div>
+
+        {page.aliases.length === 0 && !showAliasForm && (
+          <p className="text-xs text-gray-600">No aliases.</p>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          {page.aliases.map((a) => (
+            <span
+              key={a.alias}
+              className="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-800 text-gray-300 text-xs rounded"
+            >
+              {a.alias}
+              {canEdit && a.alias !== page.slug && (
+                <button
+                  onClick={() => handleDeleteAlias(a.alias)}
+                  className="text-gray-500 hover:text-red-400 transition-colors ml-1"
+                  title="Remove alias"
+                >
+                  ×
+                </button>
+              )}
+            </span>
+          ))}
+        </div>
+
+        {showAliasForm && (
+          <form onSubmit={handleAddAlias} className="flex gap-2 mt-3">
+            <input
+              type="text"
+              value={aliasInput}
+              onChange={(e) => setAliasInput(e.target.value)}
+              placeholder="new-alias"
+              pattern="[a-z0-9-]+"
+              required
+              className="flex-1 rounded bg-gray-800 border border-gray-600 text-white px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+            <button
+              type="submit"
+              disabled={isAddingAlias}
+              className="px-3 py-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-xs rounded transition-colors"
+            >
+              Add
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAliasForm(false)}
+              className="px-3 py-1 text-xs text-gray-400 hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WikiViewPage;

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -50,7 +50,8 @@ export const api = createApi({
     'RatioPolicy',
     'Bookmark',
     'SiteHistory',
-    'Draft'
+    'Draft',
+    'WikiPage'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/wikiApi.ts
+++ b/src/store/services/wikiApi.ts
@@ -1,0 +1,190 @@
+import { api } from '../api';
+
+export interface WikiAlias {
+  alias: string;
+  userId: number;
+  createdAt: string;
+}
+
+export interface WikiAuthor {
+  id: number;
+  username: string;
+}
+
+export interface WikiPage {
+  id: number;
+  title: string;
+  slug: string;
+  revision: number;
+  minReadLevel: number;
+  minEditLevel: number;
+  authorId: number;
+  author: WikiAuthor;
+  createdAt: string;
+  updatedAt: string;
+  aliases: WikiAlias[];
+}
+
+export interface WikiPageWithBody extends WikiPage {
+  body: string;
+}
+
+export interface WikiRevisionSummary {
+  id: number;
+  revision: number;
+  title: string;
+  authorId: number;
+  author: WikiAuthor;
+  createdAt: string;
+}
+
+export interface WikiRevisionContent {
+  revision: number;
+  title: string;
+  body: string;
+  authorId: number;
+  author: WikiAuthor;
+  createdAt: string;
+}
+
+export interface WikiListResponse {
+  data: WikiPage[];
+  meta: { total: number; page: number; limit: number; totalPages: number };
+}
+
+export interface WikiRevisionsResponse {
+  currentRevision: number;
+  revisions: WikiRevisionSummary[];
+}
+
+export interface WikiSearchParams {
+  q?: string;
+  type?: 'title' | 'body' | 'all';
+  order?: 'title' | 'created' | 'edited';
+  way?: 'asc' | 'desc';
+  page?: number;
+  limit?: number;
+}
+
+export interface WikiCompareResponse {
+  pageId: number;
+  title: string;
+  old: { revision: number; body: string };
+  new: { revision: number; body: string };
+}
+
+export interface CreateWikiPageArgs {
+  title: string;
+  body: string;
+  slug?: string;
+  minReadLevel?: number;
+  minEditLevel?: number;
+}
+
+export interface UpdateWikiPageArgs {
+  id: number;
+  title?: string;
+  body?: string;
+  minReadLevel?: number;
+  minEditLevel?: number;
+}
+
+export const wikiApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getWikiPages: build.query<WikiListResponse, WikiSearchParams>({
+      query: (params) => ({ url: '/wiki', params }),
+      providesTags: ['WikiPage']
+    }),
+
+    getWikiPage: build.query<WikiPageWithBody, number>({
+      query: (id) => `/wiki/${id}`,
+      providesTags: (_, __, id) => [{ type: 'WikiPage', id }]
+    }),
+
+    getWikiPageByAlias: build.query<WikiPageWithBody, string>({
+      query: (alias) => `/wiki/by-alias/${encodeURIComponent(alias)}`,
+      providesTags: (result) =>
+        result ? [{ type: 'WikiPage', id: result.id }] : ['WikiPage']
+    }),
+
+    getWikiRevisions: build.query<WikiRevisionsResponse, number>({
+      query: (id) => `/wiki/${id}/revisions`,
+      providesTags: (_, __, id) => [{ type: 'WikiPage', id }]
+    }),
+
+    getWikiRevision: build.query<
+      WikiRevisionContent,
+      { id: number; rev: number }
+    >({
+      query: ({ id, rev }) => `/wiki/${id}/revisions/${rev}`
+    }),
+
+    createWikiPage: build.mutation<WikiPageWithBody, CreateWikiPageArgs>({
+      query: (body) => ({ url: '/wiki', method: 'POST', body }),
+      invalidatesTags: ['WikiPage']
+    }),
+
+    updateWikiPage: build.mutation<WikiPageWithBody, UpdateWikiPageArgs>({
+      query: ({ id, ...body }) => ({ url: `/wiki/${id}`, method: 'PUT', body }),
+      invalidatesTags: (_, __, { id }) => [{ type: 'WikiPage', id }, 'WikiPage']
+    }),
+
+    deleteWikiPage: build.mutation<void, number>({
+      query: (id) => ({ url: `/wiki/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['WikiPage']
+    }),
+
+    addWikiAlias: build.mutation<
+      { alias: string },
+      { id: number; alias: string }
+    >({
+      query: ({ id, alias }) => ({
+        url: `/wiki/${id}/aliases`,
+        method: 'POST',
+        body: { alias }
+      }),
+      invalidatesTags: (_, __, { id }) => [{ type: 'WikiPage', id }]
+    }),
+
+    deleteWikiAlias: build.mutation<void, { id: number; alias: string }>({
+      query: ({ id, alias }) => ({
+        url: `/wiki/${id}/aliases/${encodeURIComponent(alias)}`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: (_, __, { id }) => [{ type: 'WikiPage', id }]
+    }),
+
+    rollbackWikiPage: build.mutation<
+      WikiPageWithBody,
+      { id: number; rev: number }
+    >({
+      query: ({ id, rev }) => ({
+        url: `/wiki/${id}/rollback/${rev}`,
+        method: 'POST'
+      }),
+      invalidatesTags: (_, __, { id }) => [{ type: 'WikiPage', id }, 'WikiPage']
+    }),
+
+    compareWikiRevisions: build.query<
+      WikiCompareResponse,
+      { id: number; old: number; new: number }
+    >({
+      query: ({ id, old: o, new: n }) => `/wiki/${id}/compare?old=${o}&new=${n}`
+    })
+  })
+});
+
+export const {
+  useGetWikiPagesQuery,
+  useGetWikiPageQuery,
+  useGetWikiPageByAliasQuery,
+  useGetWikiRevisionsQuery,
+  useGetWikiRevisionQuery,
+  useCreateWikiPageMutation,
+  useUpdateWikiPageMutation,
+  useDeleteWikiPageMutation,
+  useAddWikiAliasMutation,
+  useDeleteWikiAliasMutation,
+  useRollbackWikiPageMutation,
+  useCompareWikiRevisionsQuery
+} = wikiApi;

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -13,6 +13,8 @@ export const VALID_PERMISSIONS = [
   'users_edit',
   'users_warn',
   'users_disable',
+  'wiki_edit',
+  'wiki_manage',
   'staff',
   'admin'
 ] as const;


### PR DESCRIPTION
## Summary

- Adds four wiki page components: `WikiListPage`, `WikiViewPage`, `WikiEditPage`, `WikiHistoryPage`
- Full RTK Query service (`wikiApi.ts`) covering all API endpoints
- `WikiListPage`: full-text search (title/body/all), sort by title/created/edited, pagination — alphabet browse filter removed in favor of search
- `WikiViewPage`: sanitized HTML rendering (DOMPurify allowlist), alias management, edit/delete controls
- `WikiEditPage`: create and edit form with optional slug, access level controls gated to `wiki_manage`
- `WikiHistoryPage`: revision list, view historical revision in modal, compare any two revisions with line-level diff, rollback for permitted users
- Adds Wiki nav link to `PrivateHeader` and routes to `PrivateContent`
- Adds `WikiPage` RTK tag and `wiki_edit`/`wiki_manage` to permissions utils

## Test plan

- [ ] Navigate to `/private/wiki` — list page loads
- [ ] Create a new page via "+ New Page"
- [ ] Edit the page; confirm new revision appears in history
- [ ] Compare two revisions — diff shows added/removed lines
- [ ] Roll back to a previous revision
- [ ] Add and remove an alias
- [ ] Confirm read-restricted page returns 403 for low-rank users

🤖 Generated with [Claude Code](https://claude.com/claude-code)