### PR TITLE
feat(parity): notification read state, request edit mutation, unread bell count

### DIFF
--- a/src/components/layout/NotificationCorner.tsx
+++ b/src/components/layout/NotificationCorner.tsx
@@ -2,6 +2,9 @@ import { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import {
   useGetNotificationsQuery,
+  useGetUnreadNotificationCountQuery,
+  useMarkNotificationReadMutation,
+  useMarkAllNotificationsReadMutation,
   useDeleteNotificationMutation,
   type Notification
 } from '../../store/services/notificationApi';
@@ -30,12 +33,15 @@ const NotificationCorner = () => {
   const panelRef = useRef<HTMLDivElement>(null);
 
   const { data: notifications } = useGetNotificationsQuery();
+  const { data: unreadNotifData } = useGetUnreadNotificationCountQuery();
+  const [markRead] = useMarkNotificationReadMutation();
+  const [markAllRead] = useMarkAllNotificationsReadMutation();
   const [deleteNotification] = useDeleteNotificationMutation();
   const { data: pmData } = useGetUnreadCountQuery();
 
   const pmCount = pmData?.count ?? 0;
-  const notifCount = notifications?.length ?? 0;
-  const totalCount = pmCount + notifCount;
+  const unreadNotifCount = unreadNotifData?.count ?? 0;
+  const totalCount = pmCount + unreadNotifCount;
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -49,6 +55,8 @@ const NotificationCorner = () => {
 
   if (totalCount === 0) return null;
 
+  const notifCount = notifications?.length ?? 0;
+
   return (
     <div
       ref={panelRef}
@@ -60,12 +68,22 @@ const NotificationCorner = () => {
             <span className="text-xs font-semibold uppercase tracking-wider text-gray-300">
               Notifications
             </span>
-            <button
-              onClick={() => setOpen(false)}
-              className="text-gray-500 hover:text-gray-300 transition-colors text-xs"
-            >
-              ✕
-            </button>
+            <div className="flex items-center gap-2">
+              {unreadNotifCount > 0 && (
+                <button
+                  onClick={() => markAllRead()}
+                  className="text-xs text-gray-400 hover:text-indigo-300 transition-colors"
+                >
+                  Mark all read
+                </button>
+              )}
+              <button
+                onClick={() => setOpen(false)}
+                className="text-gray-500 hover:text-gray-300 transition-colors text-xs"
+              >
+                ✕
+              </button>
+            </div>
           </div>
 
           {pmCount > 0 && (
@@ -89,34 +107,51 @@ const NotificationCorner = () => {
             </p>
           ) : notifCount > 0 ? (
             <ul className="max-h-64 overflow-y-auto divide-y divide-gray-700/50">
-              {notifications!.map((n) => (
-                <li
-                  key={n.id}
-                  className="flex items-start gap-2 px-3 py-2 hover:bg-gray-700/40 transition-colors"
-                >
-                  <span className="flex-1 text-sm text-gray-200 leading-snug">
-                    {n.quoter.username} quoted you in{' '}
-                    {n.source && sourcePath(n) ? (
-                      <Link
-                        to={sourcePath(n)!}
-                        onClick={() => setOpen(false)}
-                        className="text-indigo-400 hover:text-indigo-300 underline"
-                      >
-                        {n.source.title}
-                      </Link>
-                    ) : (
-                      `${n.page} #${n.pageId}`
-                    )}
-                  </span>
-                  <button
-                    onClick={() => deleteNotification(n.id)}
-                    className="text-gray-500 hover:text-red-400 transition-colors text-xs shrink-0 mt-0.5"
-                    aria-label="Dismiss"
+              {notifications!.map((n) => {
+                const isUnread = !n.readAt;
+                return (
+                  <li
+                    key={n.id}
+                    className={`flex items-start gap-2 px-3 py-2 transition-colors ${
+                      isUnread
+                        ? 'bg-indigo-950/30 hover:bg-indigo-950/50'
+                        : 'hover:bg-gray-700/40'
+                    }`}
                   >
-                    ✕
-                  </button>
-                </li>
-              ))}
+                    {isUnread && (
+                      <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-indigo-400 shrink-0" />
+                    )}
+                    <span
+                      className={`flex-1 text-sm leading-snug ${
+                        isUnread ? 'text-white' : 'text-gray-400'
+                      }`}
+                    >
+                      {n.quoter.username} quoted you in{' '}
+                      {n.source && sourcePath(n) ? (
+                        <Link
+                          to={sourcePath(n)!}
+                          onClick={() => {
+                            if (isUnread) markRead(n.id);
+                            setOpen(false);
+                          }}
+                          className="text-indigo-400 hover:text-indigo-300 underline"
+                        >
+                          {n.source.title}
+                        </Link>
+                      ) : (
+                        `${n.page} #${n.pageId}`
+                      )}
+                    </span>
+                    <button
+                      onClick={() => deleteNotification(n.id)}
+                      className="text-gray-500 hover:text-red-400 transition-colors text-xs shrink-0 mt-0.5"
+                      aria-label="Dismiss"
+                    >
+                      ✕
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           ) : null}
         </div>

--- a/src/store/services/notificationApi.ts
+++ b/src/store/services/notificationApi.ts
@@ -1,17 +1,51 @@
 import { api } from '../api';
-import type { paths, components } from '../../types/api';
 
-type NotificationsResponse =
-  paths['/notifications']['get']['responses'][200]['content']['application/json'];
+export interface NotificationQuoter {
+  id: number;
+  username: string;
+  avatar: string | null;
+}
 
-export type Notification = components['schemas']['Notification'];
+export interface NotificationSource {
+  title: string;
+  forumId?: number;
+}
+
+export interface Notification {
+  id: number;
+  userId: number;
+  quoterId: number;
+  quoter: NotificationQuoter;
+  page: string;
+  pageId: number;
+  postId: number;
+  readAt: string | null;
+  createdAt: string;
+  source: NotificationSource | null;
+}
 
 export const notificationApi = api.injectEndpoints({
   endpoints: (build) => ({
-    getNotifications: build.query<NotificationsResponse, void>({
+    getNotifications: build.query<Notification[], void>({
       query: () => '/notifications',
       providesTags: ['Notification']
     }),
+
+    getUnreadNotificationCount: build.query<{ count: number }, void>({
+      query: () => '/notifications/unread-count',
+      providesTags: ['Notification']
+    }),
+
+    markNotificationRead: build.mutation<void, number>({
+      query: (id) => ({ url: `/notifications/${id}/read`, method: 'POST' }),
+      invalidatesTags: ['Notification']
+    }),
+
+    markAllNotificationsRead: build.mutation<void, void>({
+      query: () => ({ url: '/notifications/read-all', method: 'POST' }),
+      invalidatesTags: ['Notification']
+    }),
+
     deleteNotification: build.mutation<void, number>({
       query: (id) => ({ url: `/notifications/${id}`, method: 'DELETE' }),
       invalidatesTags: ['Notification']
@@ -19,5 +53,10 @@ export const notificationApi = api.injectEndpoints({
   })
 });
 
-export const { useGetNotificationsQuery, useDeleteNotificationMutation } =
-  notificationApi;
+export const {
+  useGetNotificationsQuery,
+  useGetUnreadNotificationCountQuery,
+  useMarkNotificationReadMutation,
+  useMarkAllNotificationsReadMutation,
+  useDeleteNotificationMutation
+} = notificationApi;

--- a/src/store/services/requestApi.ts
+++ b/src/store/services/requestApi.ts
@@ -25,6 +25,15 @@ export interface CreateRequestPayload {
   artists?: number[];
 }
 
+export interface UpdateRequestPayload {
+  id: number;
+  title?: string;
+  description?: string;
+  type?: ReleaseType;
+  year?: number | null;
+  image?: string;
+}
+
 export interface ListRequestsQuery {
   page?: number;
   communityId?: number;
@@ -65,6 +74,18 @@ export const requestApi = api.injectEndpoints({
         body
       }),
       invalidatesTags: [{ type: 'Request', id: 'LIST' }]
+    }),
+
+    updateRequest: builder.mutation<RequestItem, UpdateRequestPayload>({
+      query: ({ id, ...body }) => ({
+        url: `/requests/${id}`,
+        method: 'PUT',
+        body
+      }),
+      invalidatesTags: (_result, _error, { id }) => [
+        { type: 'Request', id },
+        { type: 'Request', id: 'LIST' }
+      ]
     }),
 
     addBounty: builder.mutation<
@@ -147,6 +168,7 @@ export const {
   useListRequestsQuery,
   useGetRequestQuery,
   useCreateRequestMutation,
+  useUpdateRequestMutation,
   useAddBountyMutation,
   useFillRequestMutation,
   useUnfillRequestMutation,


### PR DESCRIPTION
## Summary

Frontend counterpart to the parity gap fixes in stellar-api.

**Notifications**
- `notificationApi` now exposes `getUnreadNotificationCount`, `markNotificationRead`, `markAllNotificationsRead`
- `NotificationCorner` badge uses the unread count (not total count), so read notifications don't inflate the number
- Unread items shown with indigo dot + white text; read items dimmed
- Clicking a notification link marks it read and navigates
- "Mark all read" button appears in the panel header when there are unread items

**Requests**
- Adds `updateRequest` mutation and `UpdateRequestPayload` type to `requestApi`
- `useUpdateRequestMutation` exported for use in request detail/edit UI

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] Open notification panel: unread items have blue dot, read items are grey
- [ ] Click a notification link → item turns grey, badge count drops
- [ ] "Mark all read" clears the badge entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)