### PR TITLE
feat(search): site-wide search bar, browse pages, and rip form fields

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,11 +7,11 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:react/recommended',
-    'plugin:prettier/recommended',
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended',
     'plugin:import/recommended',
-    'plugin:@typescript-eslint/recommended'
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended'
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "singleQuote": true,
   "trailingComma": "none",
-  "endOfLine": "auto",
+  "endOfLine": "lf",
   "overrides": [
     {
       "files": ["*.scss"],

--- a/src/components/admin/UserRankFormPage.tsx
+++ b/src/components/admin/UserRankFormPage.tsx
@@ -28,6 +28,10 @@ const PERM_GROUPS: { title: string; perms: string[] }[] = [
     perms: ['users_edit', 'users_warn', 'users_disable', 'invites_manage']
   },
   {
+    title: 'Search',
+    perms: ['advanced_search', 'users_search']
+  },
+  {
     title: 'System',
     perms: ['news_manage', 'staff', 'admin']
   }

--- a/src/components/artists/ArtistBrowsePage.tsx
+++ b/src/components/artists/ArtistBrowsePage.tsx
@@ -1,0 +1,269 @@
+import { useSearchParams, Link } from 'react-router-dom';
+import { useState } from 'react';
+import { useSearchArtistsQuery } from '../../store/services/searchApi';
+import { useGetMeQuery } from '../../store/services/authApi';
+import { hasPermission } from '../../utils/permissions';
+import Spinner from '../layout/Spinner';
+
+const inputCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 w-full';
+const labelCls = 'block text-xs font-medium text-gray-400 mb-1';
+const checkboxCls =
+  'rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-gray-800';
+
+const ArtistBrowsePage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const { data: user } = useGetMeQuery();
+  const canAdvanced = hasPermission(user, 'advanced_search');
+
+  const q = searchParams.get('q') ?? undefined;
+  const tags = searchParams.get('tags') ?? undefined;
+  const tagMode = (searchParams.get('tagMode') ?? 'any') as 'any' | 'all';
+  const orderBy = (searchParams.get('orderBy') ?? 'name') as 'name' | 'random';
+  const order = (searchParams.get('order') ?? 'asc') as 'asc' | 'desc';
+  const vanityHouse =
+    searchParams.get('vanityHouse') === 'true' ? true : undefined;
+  const page = Number(searchParams.get('page') ?? 1);
+
+  const { data, isLoading, error } = useSearchArtistsQuery({
+    q,
+    tags,
+    tagMode,
+    orderBy,
+    order,
+    vanityHouse,
+    page
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const next = new URLSearchParams();
+    const set = (k: string) => {
+      const v = fd.get(k);
+      if (v && String(v).trim()) next.set(k, String(v).trim());
+    };
+    set('q');
+    set('tags');
+    const tm = fd.get('tagMode');
+    if (tm && tm !== 'any') next.set('tagMode', String(tm));
+    const ob = fd.get('orderBy');
+    if (ob && ob !== 'name') next.set('orderBy', String(ob));
+    const od = fd.get('order');
+    if (od && od !== 'asc') next.set('order', String(od));
+    if (canAdvanced && fd.get('vanityHouse')) next.set('vanityHouse', 'true');
+    next.set('page', '1');
+    setSearchParams(next);
+  };
+
+  const setPage = (p: number) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('page', String(p));
+    setSearchParams(next);
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
+      <h1 className="text-2xl font-bold text-white">Artists</h1>
+
+      <div className="bg-gray-800 border border-gray-700 rounded-lg p-4 space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label htmlFor="artist-q" className={labelCls}>
+                Artist name
+              </label>
+              <input
+                id="artist-q"
+                name="q"
+                defaultValue={q}
+                className={inputCls}
+                placeholder="Search artists…"
+              />
+            </div>
+            <div>
+              <label htmlFor="artist-tags" className={labelCls}>
+                Tags (comma-separated)
+              </label>
+              <input
+                id="artist-tags"
+                name="tags"
+                defaultValue={tags}
+                className={inputCls}
+                placeholder="e.g. jazz, blues"
+              />
+            </div>
+            <div>
+              <label htmlFor="artist-orderBy" className={labelCls}>
+                Order
+              </label>
+              <div className="flex gap-2">
+                <select
+                  id="artist-orderBy"
+                  name="orderBy"
+                  defaultValue={orderBy}
+                  className={inputCls}
+                >
+                  <option value="name">Name</option>
+                  <option value="random">Random</option>
+                </select>
+                <select
+                  name="order"
+                  defaultValue={order}
+                  className="bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                >
+                  <option value="asc">Asc</option>
+                  <option value="desc">Desc</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4">
+            <div className="flex gap-3">
+              {(['any', 'all'] as const).map((v) => (
+                <label
+                  key={v}
+                  className="flex items-center gap-1.5 text-sm text-gray-300 cursor-pointer"
+                >
+                  <input
+                    type="radio"
+                    name="tagMode"
+                    value={v}
+                    defaultChecked={tagMode === v}
+                    className={checkboxCls}
+                  />
+                  Tags: {v === 'any' ? 'Any' : 'All'}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {canAdvanced && (
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((v) => !v)}
+              className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+            >
+              {showAdvanced ? '− Hide advanced options' : '+ Advanced options'}
+            </button>
+          )}
+          {canAdvanced && showAdvanced && (
+            <div className="border-t border-gray-700 pt-3">
+              <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="vanityHouse"
+                  defaultChecked={!!vanityHouse}
+                  className={checkboxCls}
+                />
+                Vanity House only
+              </label>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="px-4 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded transition-colors"
+            >
+              Search
+            </button>
+            <button
+              type="button"
+              onClick={() => setSearchParams(new URLSearchParams())}
+              className="px-4 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors"
+            >
+              Reset
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {isLoading && <Spinner />}
+      {error && <p className="text-red-400 text-sm">Failed to load results.</p>}
+      {data && (
+        <>
+          <p className="text-xs text-gray-500">
+            {data.meta.total} artist{data.meta.total !== 1 ? 's' : ''}
+          </p>
+          {data.data.length === 0 ? (
+            <p className="text-gray-400 text-sm">No artists found.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-gray-500 border-b border-gray-800">
+                    <th className="pb-2 font-medium">Name</th>
+                    <th className="pb-2 font-medium">Tags</th>
+                    <th className="pb-2 font-medium text-right">Releases</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.data.map((a) => (
+                    <tr
+                      key={a.id}
+                      className="border-b border-gray-800/50 hover:bg-gray-900/30"
+                    >
+                      <td className="py-2 pr-4">
+                        <Link
+                          to={`/private/artists/${a.id}`}
+                          className="text-indigo-400 hover:text-indigo-300 font-medium"
+                        >
+                          {a.name}
+                        </Link>
+                        {a.vanityHouse && (
+                          <span className="ml-2 text-xs text-amber-500">
+                            Vanity House
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-2 pr-4">
+                        <div className="flex flex-wrap gap-1">
+                          {a.tags.slice(0, 5).map(({ tag }) => (
+                            <span
+                              key={tag.id}
+                              className="px-1.5 py-0.5 bg-gray-700 text-gray-300 text-xs rounded"
+                            >
+                              {tag.name}
+                            </span>
+                          ))}
+                        </div>
+                      </td>
+                      <td className="py-2 text-gray-400 text-right">
+                        {a._count.releases}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {data.meta.totalPages > 1 && (
+            <div className="flex gap-1 flex-wrap">
+              {Array.from(
+                { length: data.meta.totalPages },
+                (_, i) => i + 1
+              ).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPage(p)}
+                  className={`px-2.5 py-1 text-xs rounded ${
+                    p === page
+                      ? 'bg-indigo-600 text-white'
+                      : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+                  }`}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ArtistBrowsePage;

--- a/src/components/communities/AddContributionForm.tsx
+++ b/src/components/communities/AddContributionForm.tsx
@@ -93,12 +93,7 @@ const AddContributionForm = () => {
         sizeInBytes: sizeMB
           ? Math.round(parseFloat(sizeMB) * 1_048_576)
           : undefined,
-        releaseDescription: releaseDescription || undefined,
-        bitrate: isAudio && bitrate ? bitrate : undefined,
-        media: isAudio && media ? media : undefined,
-        hasLog: isAudio ? hasLog : false,
-        hasCue: isAudio ? hasCue : false,
-        isScene: isAudio ? isScene : false
+        releaseDescription: releaseDescription || undefined
       }).unwrap();
       dispatch(addAlert('Contribution added.', 'success'));
       navigate(`/private/communities/${communityId}/releases/${releaseId}`);

--- a/src/components/communities/AddContributionForm.tsx
+++ b/src/components/communities/AddContributionForm.tsx
@@ -37,9 +37,20 @@ const FILE_TYPES = [
 ] as const;
 type FileType = (typeof FILE_TYPES)[number];
 
+const AUDIO_FILE_TYPES: FileType[] = [
+  'mp3',
+  'flac',
+  'wav',
+  'ogg',
+  'aac',
+  'm4a'
+];
+
 const inputClass =
   'w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-indigo-500';
 const labelClass = 'block text-sm text-gray-400 mb-1';
+const checkboxClass =
+  'rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-gray-800';
 
 const AddContributionForm = () => {
   const { communityId, releaseId } = useParams<{
@@ -63,6 +74,13 @@ const AddContributionForm = () => {
   const [downloadUrl, setDownloadUrl] = useState('');
   const [sizeMB, setSizeMB] = useState('');
   const [releaseDescription, setReleaseDescription] = useState('');
+  const [bitrate, setBitrate] = useState('');
+  const [media, setMedia] = useState('');
+  const [hasLog, setHasLog] = useState(false);
+  const [hasCue, setHasCue] = useState(false);
+  const [isScene, setIsScene] = useState(false);
+
+  const isAudio = AUDIO_FILE_TYPES.includes(fileType);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -75,7 +93,12 @@ const AddContributionForm = () => {
         sizeInBytes: sizeMB
           ? Math.round(parseFloat(sizeMB) * 1_048_576)
           : undefined,
-        releaseDescription: releaseDescription || undefined
+        releaseDescription: releaseDescription || undefined,
+        bitrate: isAudio && bitrate ? bitrate : undefined,
+        media: isAudio && media ? media : undefined,
+        hasLog: isAudio ? hasLog : false,
+        hasCue: isAudio ? hasCue : false,
+        isScene: isAudio ? isScene : false
       }).unwrap();
       dispatch(addAlert('Contribution added.', 'success'));
       navigate(`/private/communities/${communityId}/releases/${releaseId}`);
@@ -182,6 +205,72 @@ const AddContributionForm = () => {
             className={inputClass}
           />
         </div>
+
+        {/* Rip-specific fields — audio only */}
+        {isAudio && (
+          <div className="border-t border-gray-700 pt-4 space-y-4">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+              Rip details
+            </p>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="add-bitrate" className={labelClass}>
+                  Bitrate
+                </label>
+                <input
+                  id="add-bitrate"
+                  type="text"
+                  value={bitrate}
+                  onChange={(e) => setBitrate(e.target.value)}
+                  placeholder="e.g. 320, V0, Lossless"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label htmlFor="add-media" className={labelClass}>
+                  Media
+                </label>
+                <input
+                  id="add-media"
+                  type="text"
+                  value={media}
+                  onChange={(e) => setMedia(e.target.value)}
+                  placeholder="e.g. CD, Vinyl, WEB"
+                  className={inputClass}
+                />
+              </div>
+            </div>
+            <div className="flex gap-6">
+              <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={hasLog}
+                  onChange={(e) => setHasLog(e.target.checked)}
+                  className={checkboxClass}
+                />
+                Has log
+              </label>
+              <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={hasCue}
+                  onChange={(e) => setHasCue(e.target.checked)}
+                  className={checkboxClass}
+                />
+                Has cue
+              </label>
+              <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={isScene}
+                  onChange={(e) => setIsScene(e.target.checked)}
+                  className={checkboxClass}
+                />
+                Scene release
+              </label>
+            </div>
+          </div>
+        )}
 
         <div>
           <label htmlFor="add-notes" className={labelClass}>

--- a/src/components/layout/QuickSearch.tsx
+++ b/src/components/layout/QuickSearch.tsx
@@ -1,0 +1,40 @@
+import { useNavigate } from 'react-router-dom';
+
+const ENTITY_INPUTS = [
+  { label: 'Releases', path: '/private/releases' },
+  { label: 'Artists', path: '/private/artists' },
+  { label: 'Requests', path: '/private/requests' },
+  { label: 'Forums', path: '/private/forums' },
+  { label: 'Log', path: '/private/log' },
+  { label: 'Users', path: '/private/users' }
+];
+
+const QuickSearch = () => {
+  const navigate = useNavigate();
+
+  const handleKey =
+    (path: string) => (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== 'Enter') return;
+      const q = e.currentTarget.value.trim();
+      e.currentTarget.value = '';
+      navigate(q ? `${path}?q=${encodeURIComponent(q)}` : path);
+    };
+
+  return (
+    <div className="bg-gray-900 border-t border-gray-800/60">
+      <div className="max-w-7xl mx-auto px-4 py-1.5 flex items-center gap-3 overflow-x-auto">
+        {ENTITY_INPUTS.map(({ label, path }) => (
+          <input
+            key={path}
+            type="text"
+            onKeyDown={handleKey(path)}
+            placeholder={label}
+            className="bg-gray-800 border border-gray-700 text-gray-300 text-xs rounded px-2 py-0.5 w-24 focus:outline-none focus:ring-1 focus:ring-indigo-500 placeholder-gray-500 shrink-0"
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default QuickSearch;

--- a/src/components/log/LogBrowsePage.tsx
+++ b/src/components/log/LogBrowsePage.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams, Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useSearchLogQuery } from '../../store/services/searchApi';
 import type {
   LogSearchResponse,
@@ -14,11 +14,11 @@ const labelCls = 'block text-xs font-medium text-gray-400 mb-1';
 const checkboxCls =
   'rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-gray-800';
 
-function isSingleList(d: LogSearchResponse): d is {
-  data: (TopicSearchResult | PostSearchResult)[];
-  meta: PaginatedMeta;
+function hasSplitLists(d: LogSearchResponse): d is {
+  topics: { data: TopicSearchResult[]; meta: PaginatedMeta };
+  posts: { data: PostSearchResult[]; meta: PaginatedMeta };
 } {
-  return 'data' in d;
+  return 'topics' in d;
 }
 
 const LogBrowsePage = () => {
@@ -134,6 +134,29 @@ const LogBrowsePage = () => {
     </div>
   );
 
+  const renderResults = (results: LogSearchResponse) => {
+    if (hasSplitLists(results)) {
+      return (
+        <div className="space-y-8">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-300 mb-3">Topics</h2>
+            {renderTopics(results.topics.data, results.topics.meta)}
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold text-gray-300 mb-3">Posts</h2>
+            {renderPosts(results.posts.data, results.posts.meta)}
+          </div>
+        </div>
+      );
+    }
+
+    if (type === 'topic') {
+      return renderTopics(results.data as TopicSearchResult[], results.meta);
+    }
+
+    return renderPosts(results.data as PostSearchResult[], results.meta);
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
       <h1 className="text-2xl font-bold text-white">Forum Log</h1>
@@ -207,29 +230,7 @@ const LogBrowsePage = () => {
 
       {isLoading && <Spinner />}
       {error && <p className="text-red-400 text-sm">Failed to load results.</p>}
-      {data &&
-        (isSingleList(data) ? (
-          type === 'topic' ? (
-            renderTopics(data.data as TopicSearchResult[], data.meta)
-          ) : (
-            renderPosts(data.data as PostSearchResult[], data.meta)
-          )
-        ) : (
-          <div className="space-y-8">
-            <div>
-              <h2 className="text-sm font-semibold text-gray-300 mb-3">
-                Topics
-              </h2>
-              {renderTopics(data.topics.data, data.topics.meta)}
-            </div>
-            <div>
-              <h2 className="text-sm font-semibold text-gray-300 mb-3">
-                Posts
-              </h2>
-              {renderPosts(data.posts.data, data.posts.meta)}
-            </div>
-          </div>
-        ))}
+      {data && renderResults(data)}
     </div>
   );
 };

--- a/src/components/log/LogBrowsePage.tsx
+++ b/src/components/log/LogBrowsePage.tsx
@@ -1,0 +1,237 @@
+import { useSearchParams, Link } from 'react-router-dom';
+import { useSearchLogQuery } from '../../store/services/searchApi';
+import type {
+  LogSearchResponse,
+  TopicSearchResult,
+  PostSearchResult,
+  PaginatedMeta
+} from '../../store/services/searchApi';
+import Spinner from '../layout/Spinner';
+
+const inputCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 w-full';
+const labelCls = 'block text-xs font-medium text-gray-400 mb-1';
+const checkboxCls =
+  'rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-gray-800';
+
+function isSingleList(d: LogSearchResponse): d is {
+  data: (TopicSearchResult | PostSearchResult)[];
+  meta: PaginatedMeta;
+} {
+  return 'data' in d;
+}
+
+const LogBrowsePage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const q = searchParams.get('q') ?? undefined;
+  const type = (searchParams.get('type') ?? 'all') as 'topic' | 'post' | 'all';
+  const order = (searchParams.get('order') ?? 'desc') as 'asc' | 'desc';
+  const page = Number(searchParams.get('page') ?? 1);
+
+  const { data, isLoading, error } = useSearchLogQuery({
+    q,
+    type,
+    order,
+    page
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const next = new URLSearchParams();
+    const qv = fd.get('q');
+    if (qv && String(qv).trim()) next.set('q', String(qv).trim());
+    const tv = fd.get('type');
+    if (tv && tv !== 'all') next.set('type', String(tv));
+    const ov = fd.get('order');
+    if (ov && ov !== 'desc') next.set('order', String(ov));
+    next.set('page', '1');
+    setSearchParams(next);
+  };
+
+  const setPage = (p: number) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('page', String(p));
+    setSearchParams(next);
+  };
+
+  const renderTopics = (topics: TopicSearchResult[], meta: PaginatedMeta) => (
+    <div className="space-y-2">
+      <p className="text-xs text-gray-500">
+        {meta.total} topic{meta.total !== 1 ? 's' : ''}
+      </p>
+      {topics.map((t) => (
+        <div key={t.id} className="border-b border-gray-800/50 py-2">
+          <Link
+            to={`/private/forums/topics/${t.id}`}
+            className="text-indigo-400 hover:text-indigo-300 font-medium text-sm"
+          >
+            {t.title}
+          </Link>
+          <span className="text-gray-500 text-xs ml-3">
+            by {t.author.username} ·{' '}
+            {new Date(t.createdAt).toLocaleDateString()} · {t.numPosts} posts
+          </span>
+        </div>
+      ))}
+      {meta.totalPages > 1 && (
+        <div className="flex gap-1 flex-wrap pt-2">
+          {Array.from({ length: meta.totalPages }, (_, i) => i + 1).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPage(p)}
+              className={`px-2.5 py-1 text-xs rounded ${
+                p === page
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+              }`}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  const renderPosts = (posts: PostSearchResult[], meta: PaginatedMeta) => (
+    <div className="space-y-2">
+      <p className="text-xs text-gray-500">
+        {meta.total} post{meta.total !== 1 ? 's' : ''}
+      </p>
+      {posts.map((p) => (
+        <div key={p.id} className="border-b border-gray-800/50 py-2">
+          <Link
+            to={`/private/forums/topics/${p.forumTopicId}#post-${p.id}`}
+            className="text-indigo-400 hover:text-indigo-300 text-sm"
+          >
+            Post by {p.author.username}
+          </Link>
+          <span className="text-gray-500 text-xs ml-3">
+            {new Date(p.createdAt).toLocaleDateString()}
+          </span>
+          <p className="text-gray-400 text-xs mt-1 line-clamp-2">{p.body}</p>
+        </div>
+      ))}
+      {meta.totalPages > 1 && (
+        <div className="flex gap-1 flex-wrap pt-2">
+          {Array.from({ length: meta.totalPages }, (_, i) => i + 1).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPage(p)}
+              className={`px-2.5 py-1 text-xs rounded ${
+                p === page
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+              }`}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
+      <h1 className="text-2xl font-bold text-white">Forum Log</h1>
+
+      <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-wrap items-end gap-3"
+        >
+          <div className="flex-1 min-w-48">
+            <label htmlFor="log-q" className={labelCls}>
+              Search
+            </label>
+            <input
+              id="log-q"
+              name="q"
+              defaultValue={q}
+              className={inputCls}
+              placeholder="Search topics and posts…"
+            />
+          </div>
+          <fieldset>
+            <legend className={labelCls}>Type</legend>
+            <div className="flex gap-3 mt-1">
+              {(['all', 'topic', 'post'] as const).map((v) => (
+                <label
+                  key={v}
+                  className="flex items-center gap-1.5 text-sm text-gray-300 cursor-pointer"
+                >
+                  <input
+                    type="radio"
+                    name="type"
+                    value={v}
+                    defaultChecked={type === v}
+                    className={checkboxCls}
+                  />
+                  {v === 'all' ? 'All' : v === 'topic' ? 'Topics' : 'Posts'}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          <div>
+            <label htmlFor="log-order" className={labelCls}>
+              Order
+            </label>
+            <select
+              id="log-order"
+              name="order"
+              defaultValue={order}
+              className="bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              <option value="desc">Newest</option>
+              <option value="asc">Oldest</option>
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="px-4 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded transition-colors"
+          >
+            Search
+          </button>
+          <button
+            type="button"
+            onClick={() => setSearchParams(new URLSearchParams())}
+            className="px-4 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors"
+          >
+            Reset
+          </button>
+        </form>
+      </div>
+
+      {isLoading && <Spinner />}
+      {error && <p className="text-red-400 text-sm">Failed to load results.</p>}
+      {data &&
+        (isSingleList(data) ? (
+          type === 'topic' ? (
+            renderTopics(data.data as TopicSearchResult[], data.meta)
+          ) : (
+            renderPosts(data.data as PostSearchResult[], data.meta)
+          )
+        ) : (
+          <div className="space-y-8">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-300 mb-3">
+                Topics
+              </h2>
+              {renderTopics(data.topics.data, data.topics.meta)}
+            </div>
+            <div>
+              <h2 className="text-sm font-semibold text-gray-300 mb-3">
+                Posts
+              </h2>
+              {renderPosts(data.posts.data, data.posts.meta)}
+            </div>
+          </div>
+        ))}
+    </div>
+  );
+};
+
+export default LogBrowsePage;

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -63,6 +63,10 @@ import WikiListPage from '../../../wiki/WikiListPage';
 import WikiViewPage from '../../../wiki/WikiViewPage';
 import WikiEditPage from '../../../wiki/WikiEditPage';
 import WikiHistoryPage from '../../../wiki/WikiHistoryPage';
+import ReleaseBrowsePage from '../../../releases/ReleaseBrowsePage';
+import ArtistBrowsePage from '../../../artists/ArtistBrowsePage';
+import LogBrowsePage from '../../../log/LogBrowsePage';
+import UserBrowsePage from '../../../users/UserBrowsePage';
 import DraftsPage from '../../../messages/DraftsPage';
 import { useGetMeQuery } from '../../../../store/services/authApi';
 import {
@@ -316,6 +320,11 @@ const PrivateContent = () => (
     <Route path="wiki/:id/history" element={wrap(WikiHistoryPage)} />
     <Route path="wiki/:id" element={wrap(WikiViewPage)} />
     <Route path="wiki" element={wrap(WikiListPage)} />
+
+    <Route path="releases" element={wrap(ReleaseBrowsePage)} />
+    <Route path="artists" element={wrap(ArtistBrowsePage)} />
+    <Route path="log" element={wrap(LogBrowsePage)} />
+    <Route path="users" element={wrap(UserBrowsePage)} />
 
     <Route path="" element={<PrivateHomepage />} />
     <Route path="*" element={<NotFound />} />

--- a/src/components/pages/private/layout/PrivateHeader.tsx
+++ b/src/components/pages/private/layout/PrivateHeader.tsx
@@ -2,6 +2,7 @@ import { Link, NavLink } from 'react-router-dom';
 import UserMenu from '../../../layout/UserMenu';
 import Alert from '../../../layout/Alert';
 import ModBar from '../../../admin/ModBar';
+import QuickSearch from '../../../layout/QuickSearch';
 import type { AuthUser } from '../../../../types';
 import { isStaffUser } from '../../../../utils/permissions';
 import { formatBytes } from '../../../../utils';
@@ -131,6 +132,7 @@ const PrivateHeader = ({ user }: Props) => {
         </div>
       </nav>
 
+      <QuickSearch />
       {isStaff && <ModBar />}
       <Alert />
     </header>

--- a/src/components/releases/ReleaseBrowsePage.tsx
+++ b/src/components/releases/ReleaseBrowsePage.tsx
@@ -1,0 +1,623 @@
+import { useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchReleasesQuery } from '../../store/services/searchApi';
+import { useGetCommunitiesQuery } from '../../store/services/communityApi';
+import { useGetMeQuery } from '../../store/services/authApi';
+import { hasPermission } from '../../utils/permissions';
+import Spinner from '../layout/Spinner';
+import { RandomReleaseLink, RandomArtistLink } from '../search/RandomLinks';
+
+const RELEASE_TYPES = [
+  'Music',
+  'Applications',
+  'EBooks',
+  'ELearningVideos',
+  'Audiobooks',
+  'Comedy',
+  'Comics'
+];
+const RELEASE_CATEGORIES = [
+  'Album',
+  'Single',
+  'EP',
+  'Anthology',
+  'Compilation',
+  'DJMix',
+  'Live',
+  'Remix',
+  'Bootleg',
+  'Interview',
+  'Mixtape',
+  'Demo',
+  'ConcertRecording',
+  'Unknown'
+];
+const FILE_TYPES = ['mp3', 'flac', 'wav', 'ogg', 'aac', 'm4a'];
+const ORDER_BY_OPTIONS = [
+  { value: 'createdAt', label: 'Time Added' },
+  { value: 'year', label: 'Year' },
+  { value: 'consumers', label: 'Consumers' },
+  { value: 'contributors', label: 'Contributors' },
+  { value: 'random', label: 'Random' }
+];
+
+const inputCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 w-full';
+const labelCls = 'block text-xs font-medium text-gray-400 mb-1';
+const checkboxCls =
+  'rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-gray-800';
+
+const ReleaseBrowsePage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const { data: user } = useGetMeQuery();
+  const { data: communities } = useGetCommunitiesQuery(1);
+  const canAdvanced = hasPermission(user, 'advanced_search');
+
+  // Read params
+  const q = searchParams.get('q') ?? undefined;
+  const tags = searchParams.get('tags') ?? undefined;
+  const tagMode = (searchParams.get('tagMode') ?? 'any') as 'any' | 'all';
+  const orderBy = searchParams.get('orderBy') ?? 'createdAt';
+  const order = (searchParams.get('order') ?? 'desc') as 'asc' | 'desc';
+  const page = Number(searchParams.get('page') ?? 1);
+  const communityIds = searchParams
+    .getAll('communityId')
+    .map(Number)
+    .filter(Boolean);
+  // Advanced
+  const artist = searchParams.get('artist') ?? undefined;
+  const title = searchParams.get('title') ?? undefined;
+  const recordLabel = searchParams.get('recordLabel') ?? undefined;
+  const catalogueNumber = searchParams.get('catalogueNumber') ?? undefined;
+  const year = searchParams.get('year')
+    ? Number(searchParams.get('year'))
+    : undefined;
+  const yearTo = searchParams.get('yearTo')
+    ? Number(searchParams.get('yearTo'))
+    : undefined;
+  const description = searchParams.get('description') ?? undefined;
+  const type = searchParams.get('type') ?? undefined;
+  const releaseType = searchParams.get('releaseType') ?? undefined;
+  const format = searchParams.get('format') ?? undefined;
+  const bitrate = searchParams.get('bitrate') ?? undefined;
+  const media = searchParams.get('media') ?? undefined;
+  const hasLog =
+    searchParams.get('hasLog') === 'true'
+      ? true
+      : searchParams.get('hasLog') === 'false'
+      ? false
+      : undefined;
+  const hasCue =
+    searchParams.get('hasCue') === 'true'
+      ? true
+      : searchParams.get('hasCue') === 'false'
+      ? false
+      : undefined;
+  const isScene =
+    searchParams.get('isScene') === 'true'
+      ? true
+      : searchParams.get('isScene') === 'false'
+      ? false
+      : undefined;
+  const vanityHouse =
+    searchParams.get('vanityHouse') === 'true' ? true : undefined;
+
+  const { data, isLoading, error } = useSearchReleasesQuery({
+    q,
+    tags,
+    tagMode,
+    orderBy: orderBy as never,
+    order,
+    page,
+    communityId: communityIds.length ? communityIds : undefined,
+    artist,
+    title,
+    recordLabel,
+    catalogueNumber,
+    year,
+    yearTo,
+    description,
+    type,
+    releaseType,
+    format,
+    bitrate,
+    media,
+    hasLog,
+    hasCue,
+    isScene,
+    vanityHouse
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const next = new URLSearchParams();
+    const set = (k: string) => {
+      const v = fd.get(k);
+      if (v && String(v).trim()) next.set(k, String(v).trim());
+    };
+
+    set('q');
+    set('tags');
+    const tm = fd.get('tagMode');
+    if (tm && tm !== 'any') next.set('tagMode', String(tm));
+    const ob = fd.get('orderBy');
+    if (ob && ob !== 'createdAt') next.set('orderBy', String(ob));
+    const od = fd.get('order');
+    if (od && od !== 'desc') next.set('order', String(od));
+
+    const cids = fd.getAll('communityId');
+    cids.forEach((id) => next.append('communityId', String(id)));
+
+    if (canAdvanced) {
+      set('artist');
+      set('title');
+      set('recordLabel');
+      set('catalogueNumber');
+      set('year');
+      set('yearTo');
+      set('description');
+      set('type');
+      set('releaseType');
+      set('format');
+      set('bitrate');
+      set('media');
+      if (fd.get('hasLog')) next.set('hasLog', 'true');
+      if (fd.get('hasCue')) next.set('hasCue', 'true');
+      if (fd.get('isScene')) next.set('isScene', 'true');
+      if (fd.get('vanityHouse')) next.set('vanityHouse', 'true');
+    }
+
+    next.set('page', '1');
+    setSearchParams(next);
+  };
+
+  const setPage = (p: number) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('page', String(p));
+    setSearchParams(next);
+  };
+
+  const communityList = Array.isArray(communities)
+    ? communities
+    : (communities as { data?: { id: number; name: string }[] })?.data ?? [];
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-white">Releases</h1>
+        <div className="flex gap-4">
+          <RandomReleaseLink />
+          <RandomArtistLink />
+        </div>
+      </div>
+
+      {/* Search form */}
+      <div className="bg-gray-800 border border-gray-700 rounded-lg p-4 space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Basic row */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+            <div>
+              <label htmlFor="release-q" className={labelCls}>
+                Search terms
+              </label>
+              <input
+                id="release-q"
+                name="q"
+                defaultValue={q}
+                className={inputCls}
+                placeholder="Artist, title, description…"
+              />
+            </div>
+            <div>
+              <label htmlFor="release-tags" className={labelCls}>
+                Tags (comma-separated)
+              </label>
+              <input
+                id="release-tags"
+                name="tags"
+                defaultValue={tags}
+                className={inputCls}
+                placeholder="e.g. jazz, blues"
+              />
+            </div>
+            <div>
+              <label htmlFor="release-orderBy" className={labelCls}>
+                Order by
+              </label>
+              <div className="flex gap-2">
+                <select
+                  id="release-orderBy"
+                  name="orderBy"
+                  defaultValue={orderBy}
+                  className={inputCls}
+                >
+                  {ORDER_BY_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  name="order"
+                  defaultValue={order}
+                  className="bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                >
+                  <option value="desc">Desc</option>
+                  <option value="asc">Asc</option>
+                </select>
+              </div>
+            </div>
+            <fieldset>
+              <legend className={labelCls}>Tags match</legend>
+              <div className="flex gap-3 mt-2">
+                {(['any', 'all'] as const).map((v) => (
+                  <label
+                    key={v}
+                    className="flex items-center gap-1.5 text-sm text-gray-300 cursor-pointer"
+                  >
+                    <input
+                      type="radio"
+                      name="tagMode"
+                      value={v}
+                      defaultChecked={tagMode === v}
+                      className={checkboxCls}
+                    />
+                    {v === 'any' ? 'Any' : 'All'}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          </div>
+
+          {/* Community checkboxes */}
+          {communityList.length > 0 && (
+            <fieldset>
+              <legend className={labelCls}>Communities</legend>
+              <div className="flex flex-wrap gap-x-4 gap-y-1">
+                {communityList.map((c: { id: number; name: string }) => (
+                  <label
+                    key={c.id}
+                    className="flex items-center gap-1.5 text-sm text-gray-300 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      name="communityId"
+                      value={c.id}
+                      defaultChecked={communityIds.includes(c.id)}
+                      className={checkboxCls}
+                    />
+                    {c.name}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          )}
+
+          {/* Advanced toggle */}
+          {canAdvanced && (
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((v) => !v)}
+              className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+            >
+              {showAdvanced ? '− Hide advanced options' : '+ Advanced options'}
+            </button>
+          )}
+
+          {/* Advanced fields */}
+          {canAdvanced && showAdvanced && (
+            <div className="border-t border-gray-700 pt-4 space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+                <div>
+                  <label htmlFor="release-artist" className={labelCls}>
+                    Artist name
+                  </label>
+                  <input
+                    id="release-artist"
+                    name="artist"
+                    defaultValue={artist}
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="release-title" className={labelCls}>
+                    Album/release name
+                  </label>
+                  <input
+                    id="release-title"
+                    name="title"
+                    defaultValue={title}
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="release-recordLabel" className={labelCls}>
+                    Record label
+                  </label>
+                  <input
+                    id="release-recordLabel"
+                    name="recordLabel"
+                    defaultValue={recordLabel}
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="release-catalogueNumber" className={labelCls}>
+                    Catalogue number
+                  </label>
+                  <input
+                    id="release-catalogueNumber"
+                    name="catalogueNumber"
+                    defaultValue={catalogueNumber}
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="release-year" className={labelCls}>
+                    Year from
+                  </label>
+                  <input
+                    id="release-year"
+                    name="year"
+                    type="number"
+                    defaultValue={year}
+                    className={inputCls}
+                    placeholder="e.g. 1990"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="release-yearTo" className={labelCls}>
+                    Year to
+                  </label>
+                  <input
+                    id="release-yearTo"
+                    name="yearTo"
+                    type="number"
+                    defaultValue={yearTo}
+                    className={inputCls}
+                    placeholder="e.g. 2024"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="release-type" className={labelCls}>
+                    Release type
+                  </label>
+                  <select
+                    id="release-type"
+                    name="type"
+                    defaultValue={type ?? ''}
+                    className={inputCls}
+                  >
+                    <option value="">Any</option>
+                    {RELEASE_TYPES.map((t) => (
+                      <option key={t} value={t}>
+                        {t}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="release-releaseType" className={labelCls}>
+                    Release category
+                  </label>
+                  <select
+                    id="release-releaseType"
+                    name="releaseType"
+                    defaultValue={releaseType ?? ''}
+                    className={inputCls}
+                  >
+                    <option value="">Any</option>
+                    {RELEASE_CATEGORIES.map((t) => (
+                      <option key={t} value={t}>
+                        {t}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label htmlFor="release-description" className={labelCls}>
+                  Release description
+                </label>
+                <input
+                  id="release-description"
+                  name="description"
+                  defaultValue={description}
+                  className={inputCls}
+                />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <div>
+                  <label htmlFor="release-format" className={labelCls}>
+                    Format
+                  </label>
+                  <select
+                    id="release-format"
+                    name="format"
+                    defaultValue={format ?? ''}
+                    className={inputCls}
+                  >
+                    <option value="">Any</option>
+                    {FILE_TYPES.map((t) => (
+                      <option key={t} value={t}>
+                        {t.toUpperCase()}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="release-bitrate" className={labelCls}>
+                    Bitrate
+                  </label>
+                  <input
+                    id="release-bitrate"
+                    name="bitrate"
+                    defaultValue={bitrate}
+                    className={inputCls}
+                    placeholder="e.g. 320, V0, Lossless"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="release-media" className={labelCls}>
+                    Media
+                  </label>
+                  <input
+                    id="release-media"
+                    name="media"
+                    defaultValue={media}
+                    className={inputCls}
+                    placeholder="e.g. CD, Vinyl, WEB"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-4">
+                {[
+                  { name: 'hasLog', label: 'Has Log', checked: hasLog },
+                  { name: 'hasCue', label: 'Has Cue', checked: hasCue },
+                  { name: 'isScene', label: 'Scene', checked: isScene },
+                  {
+                    name: 'vanityHouse',
+                    label: 'Vanity House',
+                    checked: vanityHouse
+                  }
+                ].map(({ name, label, checked }) => (
+                  <label
+                    key={name}
+                    className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      name={name}
+                      defaultChecked={!!checked}
+                      className={checkboxCls}
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="px-4 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded transition-colors"
+            >
+              Search
+            </button>
+            <button
+              type="button"
+              onClick={() => setSearchParams(new URLSearchParams())}
+              className="px-4 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors"
+            >
+              Reset
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {/* Results */}
+      {isLoading && <Spinner />}
+      {error && <p className="text-red-400 text-sm">Failed to load results.</p>}
+      {data && (
+        <>
+          <p className="text-xs text-gray-500">
+            {data.meta.total} result{data.meta.total !== 1 ? 's' : ''}
+          </p>
+          {data.data.length === 0 ? (
+            <p className="text-gray-400 text-sm">No releases found.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-gray-500 border-b border-gray-800">
+                    <th className="pb-2 font-medium">Title / Artist</th>
+                    <th className="pb-2 font-medium">Year</th>
+                    <th className="pb-2 font-medium">Category</th>
+                    <th className="pb-2 font-medium">Tags</th>
+                    <th className="pb-2 font-medium">Added</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.data.map((r) => (
+                    <tr
+                      key={r.id}
+                      className="border-b border-gray-800/50 hover:bg-gray-900/30"
+                    >
+                      <td className="py-2 pr-4">
+                        {r.communityId ? (
+                          <Link
+                            to={`/private/communities/${r.communityId}/releases/${r.id}`}
+                            className="text-indigo-400 hover:text-indigo-300 font-medium"
+                          >
+                            {r.title}
+                          </Link>
+                        ) : (
+                          <span className="text-gray-200 font-medium">
+                            {r.title}
+                          </span>
+                        )}
+                        <span className="text-gray-500 mx-1">—</span>
+                        <Link
+                          to={`/private/artists/${r.artist.id}`}
+                          className="text-gray-400 hover:text-gray-200"
+                        >
+                          {r.artist.name}
+                        </Link>
+                      </td>
+                      <td className="py-2 pr-4 text-gray-400">{r.year}</td>
+                      <td className="py-2 pr-4 text-gray-400">
+                        {r.releaseType}
+                      </td>
+                      <td className="py-2 pr-4">
+                        <div className="flex flex-wrap gap-1">
+                          {r.tags.slice(0, 4).map((t) => (
+                            <span
+                              key={t.id}
+                              className="px-1.5 py-0.5 bg-gray-700 text-gray-300 text-xs rounded"
+                            >
+                              {t.name}
+                            </span>
+                          ))}
+                        </div>
+                      </td>
+                      <td className="py-2 text-gray-500 text-xs whitespace-nowrap">
+                        {new Date(r.createdAt).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {/* Pagination */}
+          {data.meta.totalPages > 1 && (
+            <div className="flex gap-1 flex-wrap">
+              {Array.from(
+                { length: data.meta.totalPages },
+                (_, i) => i + 1
+              ).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPage(p)}
+                  className={`px-2.5 py-1 text-xs rounded ${
+                    p === page
+                      ? 'bg-indigo-600 text-white'
+                      : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+                  }`}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ReleaseBrowsePage;

--- a/src/components/requests/RequestsPage.tsx
+++ b/src/components/requests/RequestsPage.tsx
@@ -1,11 +1,8 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { selectCurrentUser } from '../../store/slices/authSlice';
-import {
-  useListRequestsQuery,
-  useDeleteRequestMutation
-} from '../../store/services/requestApi';
+import { useSearchRequestsQuery } from '../../store/services/searchApi';
+import { useDeleteRequestMutation } from '../../store/services/requestApi';
 import type { RequestStatus } from '../../types';
 import Spinner from '../layout/Spinner';
 
@@ -14,16 +11,49 @@ const STATUS_LABELS: Record<RequestStatus, string> = {
   filled: 'Filled'
 };
 
+const RELEASE_TYPES = [
+  'Music',
+  'Applications',
+  'EBooks',
+  'ELearningVideos',
+  'Audiobooks',
+  'Comedy',
+  'Comics'
+];
+
+const inputCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500';
+const labelCls = 'block text-xs font-medium text-gray-400 mb-1';
+
 const RequestsPage = () => {
   const user = useSelector(selectCurrentUser);
-  const [page, setPage] = useState(1);
-  const [statusFilter, setStatusFilter] = useState<RequestStatus | undefined>(
-    undefined
-  );
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const { data, isLoading, error } = useListRequestsQuery({
-    page,
-    status: statusFilter
+  const q = searchParams.get('q') ?? undefined;
+  const artist = searchParams.get('artist') ?? undefined;
+  const type = searchParams.get('type') ?? undefined;
+  const year = searchParams.get('year')
+    ? Number(searchParams.get('year'))
+    : undefined;
+  const status = (searchParams.get('status') ?? undefined) as
+    | RequestStatus
+    | undefined;
+  const orderBy = (searchParams.get('orderBy') ?? 'createdAt') as
+    | 'createdAt'
+    | 'voteCount'
+    | 'random';
+  const order = (searchParams.get('order') ?? 'desc') as 'asc' | 'desc';
+  const page = Number(searchParams.get('page') ?? 1);
+
+  const { data, isLoading, error } = useSearchRequestsQuery({
+    q,
+    artist,
+    type,
+    year,
+    status,
+    orderBy,
+    order,
+    page
   });
   const [deleteRequest] = useDeleteRequestMutation();
 
@@ -41,9 +71,42 @@ const RequestsPage = () => {
     }
   };
 
-  if (isLoading) return <Spinner />;
-  if (error)
-    return <div className="p-4 text-red-400">Failed to load requests.</div>;
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const next = new URLSearchParams();
+    const set = (k: string) => {
+      const v = fd.get(k);
+      if (v && String(v).trim()) next.set(k, String(v).trim());
+    };
+    set('q');
+    set('artist');
+    set('year');
+    const tv = fd.get('type');
+    if (tv && String(tv)) next.set('type', String(tv));
+    const sv = fd.get('status');
+    if (sv && String(sv)) next.set('status', String(sv));
+    const ob = fd.get('orderBy');
+    if (ob && ob !== 'createdAt') next.set('orderBy', String(ob));
+    const od = fd.get('order');
+    if (od && od !== 'desc') next.set('order', String(od));
+    next.set('page', '1');
+    setSearchParams(next);
+  };
+
+  const setStatus = (s: RequestStatus | undefined) => {
+    const next = new URLSearchParams(searchParams);
+    if (s) next.set('status', s);
+    else next.delete('status');
+    next.set('page', '1');
+    setSearchParams(next);
+  };
+
+  const setPage = (p: number) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('page', String(p));
+    setSearchParams(next);
+  };
 
   const requests = data?.data ?? [];
   const meta = data?.meta;
@@ -60,17 +123,104 @@ const RequestsPage = () => {
         </Link>
       </div>
 
+      {/* Search form */}
+      <form
+        onSubmit={handleSubmit}
+        className="bg-gray-800 border border-gray-700 rounded-lg p-4 mb-4 space-y-3"
+      >
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          <div>
+            <label htmlFor="req-q" className={labelCls}>
+              Search terms
+            </label>
+            <input
+              id="req-q"
+              name="q"
+              defaultValue={q}
+              className={inputCls + ' w-full'}
+              placeholder="Title, description…"
+            />
+          </div>
+          <div>
+            <label htmlFor="req-artist" className={labelCls}>
+              Artist
+            </label>
+            <input
+              id="req-artist"
+              name="artist"
+              defaultValue={artist}
+              className={inputCls + ' w-full'}
+            />
+          </div>
+          <div>
+            <label htmlFor="req-type" className={labelCls}>
+              Type
+            </label>
+            <select
+              id="req-type"
+              name="type"
+              defaultValue={type ?? ''}
+              className={inputCls + ' w-full'}
+            >
+              <option value="">Any</option>
+              {RELEASE_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="req-year" className={labelCls}>
+              Year
+            </label>
+            <input
+              id="req-year"
+              name="year"
+              type="number"
+              defaultValue={year}
+              className={inputCls + ' w-full'}
+              placeholder="e.g. 2020"
+            />
+          </div>
+        </div>
+        <div className="flex gap-3 items-center flex-wrap">
+          <div className="flex gap-1">
+            <select name="orderBy" defaultValue={orderBy} className={inputCls}>
+              <option value="createdAt">Time Added</option>
+              <option value="voteCount">Votes</option>
+              <option value="random">Random</option>
+            </select>
+            <select name="order" defaultValue={order} className={inputCls}>
+              <option value="desc">Desc</option>
+              <option value="asc">Asc</option>
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="px-4 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded transition-colors"
+          >
+            Search
+          </button>
+          <button
+            type="button"
+            onClick={() => setSearchParams(new URLSearchParams())}
+            className="px-4 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors"
+          >
+            Reset
+          </button>
+        </div>
+      </form>
+
+      {/* Status filter */}
       <div className="flex gap-2 mb-4 text-sm">
         {([undefined, 'open', 'filled'] as (RequestStatus | undefined)[]).map(
           (s) => (
             <button
               key={s ?? 'all'}
-              onClick={() => {
-                setStatusFilter(s);
-                setPage(1);
-              }}
+              onClick={() => setStatus(s)}
               className={`px-3 py-1 rounded border ${
-                statusFilter === s
+                status === s
                   ? 'border-blue-500 bg-blue-900/30 text-blue-300'
                   : 'border-gray-700 text-gray-400 hover:border-gray-500'
               }`}
@@ -81,9 +231,16 @@ const RequestsPage = () => {
         )}
       </div>
 
-      {requests.length === 0 ? (
+      {isLoading && <Spinner />}
+      {error && (
+        <div className="p-4 text-red-400">Failed to load requests.</div>
+      )}
+
+      {!isLoading && requests.length === 0 && (
         <p className="text-gray-500 text-sm">No requests found.</p>
-      ) : (
+      )}
+
+      {requests.length > 0 && (
         <table className="w-full text-sm">
           <thead>
             <tr className="text-left text-gray-400 border-b border-gray-800">
@@ -111,10 +268,11 @@ const RequestsPage = () => {
                 </td>
                 <td className="py-2 pr-4 text-gray-400">{r.type}</td>
                 <td className="py-2 pr-4 text-gray-400">
-                  {r.community?.name ?? '—'}
+                  {(r as { community?: { name: string } }).community?.name ??
+                    '—'}
                 </td>
                 <td className="py-2 pr-4 text-right font-mono text-yellow-400">
-                  {formatBytes(r.totalBounty)}
+                  {r._count.bounties > 0 ? `${r._count.bounties} bounty` : '—'}
                 </td>
                 <td className="py-2 text-center">
                   <span
@@ -124,11 +282,11 @@ const RequestsPage = () => {
                         : 'bg-gray-800 text-gray-300'
                     }`}
                   >
-                    {STATUS_LABELS[r.status]}
+                    {STATUS_LABELS[r.status as RequestStatus] ?? r.status}
                   </span>
                 </td>
                 <td className="py-2 text-right">
-                  {user?.id === r.userId && r.status === 'open' && (
+                  {user?.id === r.user.id && r.status === 'open' && (
                     <button
                       onClick={() => handleDelete(r.id)}
                       className="text-xs text-red-500 hover:text-red-400"
@@ -144,36 +302,24 @@ const RequestsPage = () => {
       )}
 
       {meta && meta.totalPages > 1 && (
-        <div className="flex gap-2 mt-4 text-sm items-center">
-          <button
-            disabled={page <= 1}
-            onClick={() => setPage((p) => p - 1)}
-            className="px-3 py-1 border border-gray-700 rounded disabled:opacity-40 hover:border-gray-500"
-          >
-            Prev
-          </button>
-          <span className="text-gray-400">
-            Page {page} of {meta.totalPages}
-          </span>
-          <button
-            disabled={page >= meta.totalPages}
-            onClick={() => setPage((p) => p + 1)}
-            className="px-3 py-1 border border-gray-700 rounded disabled:opacity-40 hover:border-gray-500"
-          >
-            Next
-          </button>
+        <div className="flex gap-1 mt-4 flex-wrap">
+          {Array.from({ length: meta.totalPages }, (_, i) => i + 1).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPage(p)}
+              className={`px-2.5 py-1 text-xs rounded ${
+                p === page
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+              }`}
+            >
+              {p}
+            </button>
+          ))}
         </div>
       )}
     </div>
   );
 };
-
-function formatBytes(bytesStr: string): string {
-  const bytes = Number(bytesStr);
-  if (bytes >= 1073741824) return `${(bytes / 1073741824).toFixed(2)} GiB`;
-  if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(2)} MiB`;
-  if (bytes >= 1024) return `${(bytes / 1024).toFixed(2)} KiB`;
-  return `${bytes} B`;
-}
 
 export default RequestsPage;

--- a/src/components/search/RandomLinks.tsx
+++ b/src/components/search/RandomLinks.tsx
@@ -1,0 +1,55 @@
+import { useNavigate } from 'react-router-dom';
+import {
+  useLazyGetRandomReleaseQuery,
+  useLazyGetRandomArtistQuery
+} from '../../store/services/searchApi';
+
+export const RandomReleaseLink = () => {
+  const navigate = useNavigate();
+  const [trigger, { isFetching }] = useLazyGetRandomReleaseQuery();
+
+  const handleClick = async () => {
+    try {
+      const r = await trigger().unwrap();
+      if (r.communityId) {
+        navigate(`/private/communities/${r.communityId}/releases/${r.id}`);
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isFetching}
+      className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors disabled:opacity-50"
+    >
+      [Random Release]
+    </button>
+  );
+};
+
+export const RandomArtistLink = () => {
+  const navigate = useNavigate();
+  const [trigger, { isFetching }] = useLazyGetRandomArtistQuery();
+
+  const handleClick = async () => {
+    try {
+      const a = await trigger().unwrap();
+      navigate(`/private/artists/${a.id}`);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isFetching}
+      className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors disabled:opacity-50"
+    >
+      [Random Artist]
+    </button>
+  );
+};

--- a/src/components/users/UserBrowsePage.tsx
+++ b/src/components/users/UserBrowsePage.tsx
@@ -26,8 +26,8 @@ const UserBrowsePage = () => {
     searchParams.get('disabled') === 'true'
       ? true
       : searchParams.get('disabled') === 'false'
-      ? false
-      : undefined;
+        ? false
+        : undefined;
   const page = Number(searchParams.get('page') ?? 1);
 
   const { data, isLoading, error } = useSearchUsersQuery({
@@ -125,8 +125,8 @@ const UserBrowsePage = () => {
                     disabled === true
                       ? 'true'
                       : disabled === false
-                      ? 'false'
-                      : ''
+                        ? 'false'
+                        : ''
                   }
                   className="bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 >

--- a/src/components/users/UserBrowsePage.tsx
+++ b/src/components/users/UserBrowsePage.tsx
@@ -1,0 +1,258 @@
+import { useSearchParams, Link } from 'react-router-dom';
+import { useSearchUsersQuery } from '../../store/services/searchApi';
+import { useGetMeQuery } from '../../store/services/authApi';
+import { hasAnyPermission } from '../../utils/permissions';
+import Spinner from '../layout/Spinner';
+
+const inputCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 w-full';
+const labelCls = 'block text-xs font-medium text-gray-400 mb-1';
+const UserBrowsePage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { data: user } = useGetMeQuery();
+  const isPrivileged = hasAnyPermission(user, [
+    'users_search',
+    'staff',
+    'admin'
+  ]);
+
+  const q = searchParams.get('q') ?? undefined;
+  const orderBy = (searchParams.get('orderBy') ?? 'username') as
+    | 'username'
+    | 'createdAt'
+    | 'lastLogin';
+  const order = (searchParams.get('order') ?? 'asc') as 'asc' | 'desc';
+  const disabled =
+    searchParams.get('disabled') === 'true'
+      ? true
+      : searchParams.get('disabled') === 'false'
+      ? false
+      : undefined;
+  const page = Number(searchParams.get('page') ?? 1);
+
+  const { data, isLoading, error } = useSearchUsersQuery({
+    q,
+    orderBy,
+    order,
+    disabled: isPrivileged ? disabled : undefined,
+    page
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const next = new URLSearchParams();
+    const qv = fd.get('q');
+    if (qv && String(qv).trim()) next.set('q', String(qv).trim());
+    const ob = fd.get('orderBy');
+    if (ob && ob !== 'username') next.set('orderBy', String(ob));
+    const od = fd.get('order');
+    if (od && od !== 'asc') next.set('order', String(od));
+    if (isPrivileged) {
+      const dv = fd.get('disabled');
+      if (dv === 'true' || dv === 'false') next.set('disabled', dv);
+    }
+    next.set('page', '1');
+    setSearchParams(next);
+  };
+
+  const setPage = (p: number) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('page', String(p));
+    setSearchParams(next);
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
+      <h1 className="text-2xl font-bold text-white">Users</h1>
+
+      <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-wrap items-end gap-3"
+        >
+          <div className="flex-1 min-w-48">
+            <label htmlFor="user-q" className={labelCls}>
+              Username{isPrivileged ? ' or email' : ''}
+            </label>
+            <input
+              id="user-q"
+              name="q"
+              defaultValue={q}
+              className={inputCls}
+              placeholder="Search users…"
+            />
+          </div>
+          {isPrivileged && (
+            <>
+              <div>
+                <label htmlFor="user-orderBy" className={labelCls}>
+                  Order by
+                </label>
+                <select
+                  id="user-orderBy"
+                  name="orderBy"
+                  defaultValue={orderBy}
+                  className="bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                >
+                  <option value="username">Username</option>
+                  <option value="createdAt">Joined</option>
+                  <option value="lastLogin">Last login</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="user-order" className={labelCls}>
+                  Direction
+                </label>
+                <select
+                  id="user-order"
+                  name="order"
+                  defaultValue={order}
+                  className="bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                >
+                  <option value="asc">Asc</option>
+                  <option value="desc">Desc</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="user-disabled" className={labelCls}>
+                  Status
+                </label>
+                <select
+                  id="user-disabled"
+                  name="disabled"
+                  defaultValue={
+                    disabled === true
+                      ? 'true'
+                      : disabled === false
+                      ? 'false'
+                      : ''
+                  }
+                  className="bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                >
+                  <option value="">All</option>
+                  <option value="false">Active</option>
+                  <option value="true">Disabled</option>
+                </select>
+              </div>
+            </>
+          )}
+          <button
+            type="submit"
+            className="px-4 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded transition-colors"
+          >
+            Search
+          </button>
+          <button
+            type="button"
+            onClick={() => setSearchParams(new URLSearchParams())}
+            className="px-4 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded transition-colors"
+          >
+            Reset
+          </button>
+        </form>
+      </div>
+
+      {isLoading && <Spinner />}
+      {error && <p className="text-red-400 text-sm">Failed to load results.</p>}
+      {data && (
+        <>
+          <p className="text-xs text-gray-500">
+            {data.meta.total} user{data.meta.total !== 1 ? 's' : ''}
+          </p>
+          {data.data.length === 0 ? (
+            <p className="text-gray-400 text-sm">No users found.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-gray-500 border-b border-gray-800">
+                    <th className="pb-2 font-medium">Username</th>
+                    <th className="pb-2 font-medium">Rank</th>
+                    <th className="pb-2 font-medium">Joined</th>
+                    {isPrivileged && (
+                      <>
+                        <th className="pb-2 font-medium">Last login</th>
+                        <th className="pb-2 font-medium">Ratio</th>
+                        <th className="pb-2 font-medium">Status</th>
+                      </>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.data.map((u) => (
+                    <tr
+                      key={u.id}
+                      className="border-b border-gray-800/50 hover:bg-gray-900/30"
+                    >
+                      <td className="py-2 pr-4">
+                        <Link
+                          to={`/private/users/${u.id}`}
+                          className="text-indigo-400 hover:text-indigo-300 font-medium"
+                        >
+                          {u.username}
+                        </Link>
+                      </td>
+                      <td className="py-2 pr-4">
+                        <span
+                          style={{ color: u.userRank.color ?? undefined }}
+                          className="text-sm"
+                        >
+                          {u.userRank.name}
+                        </span>
+                      </td>
+                      <td className="py-2 pr-4 text-gray-400 text-xs">
+                        {new Date(u.createdAt).toLocaleDateString()}
+                      </td>
+                      {isPrivileged && (
+                        <>
+                          <td className="py-2 pr-4 text-gray-400 text-xs">
+                            {u.lastLogin
+                              ? new Date(u.lastLogin).toLocaleDateString()
+                              : '—'}
+                          </td>
+                          <td className="py-2 pr-4 text-gray-400 text-xs">
+                            {u.ratio != null ? Number(u.ratio).toFixed(2) : '∞'}
+                          </td>
+                          <td className="py-2 text-xs">
+                            {u.disabled ? (
+                              <span className="text-red-400">Disabled</span>
+                            ) : (
+                              <span className="text-green-400">Active</span>
+                            )}
+                          </td>
+                        </>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {data.meta.totalPages > 1 && (
+            <div className="flex gap-1 flex-wrap">
+              {Array.from(
+                { length: data.meta.totalPages },
+                (_, i) => i + 1
+              ).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPage(p)}
+                  className={`px-2.5 py-1 text-xs rounded ${
+                    p === page
+                      ? 'bg-indigo-600 text-white'
+                      : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+                  }`}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default UserBrowsePage;

--- a/src/store/services/searchApi.ts
+++ b/src/store/services/searchApi.ts
@@ -1,0 +1,258 @@
+import { api } from '../api';
+
+// ── Shared types ──────────────────────────────────────────────────────────────
+
+export interface PaginatedMeta {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+interface ArtistRef {
+  id: number;
+  name: string;
+}
+interface UserRef {
+  id: number;
+  username: string;
+}
+interface TagRef {
+  id: number;
+  name: string;
+}
+
+// ── Release search ────────────────────────────────────────────────────────────
+
+export interface SearchReleasesParams {
+  q?: string;
+  tags?: string;
+  tagMode?: 'any' | 'all';
+  orderBy?: 'createdAt' | 'year' | 'consumers' | 'contributors' | 'random';
+  order?: 'asc' | 'desc';
+  communityId?: number | number[];
+  artist?: string;
+  title?: string;
+  recordLabel?: string;
+  catalogueNumber?: string;
+  year?: number;
+  yearTo?: number;
+  description?: string;
+  type?: string;
+  releaseType?: string;
+  format?: string;
+  bitrate?: string;
+  media?: string;
+  hasLog?: boolean;
+  hasCue?: boolean;
+  isScene?: boolean;
+  vanityHouse?: boolean;
+  page?: number;
+  limit?: number;
+}
+
+export interface ReleaseSearchResult {
+  id: number;
+  title: string;
+  year: number;
+  type: string;
+  releaseType: string;
+  communityId: number | null;
+  catalogueNumber: string | null;
+  recordLabel: string | null;
+  description: string;
+  createdAt: string;
+  artist: ArtistRef & { vanityHouse: boolean };
+  tags: TagRef[];
+  _count: { consumers: number; contributors: number };
+}
+
+// ── Artist search ─────────────────────────────────────────────────────────────
+
+export interface SearchArtistsParams {
+  q?: string;
+  tags?: string;
+  tagMode?: 'any' | 'all';
+  vanityHouse?: boolean;
+  orderBy?: 'name' | 'random';
+  order?: 'asc' | 'desc';
+  page?: number;
+  limit?: number;
+}
+
+export interface ArtistSearchResult {
+  id: number;
+  name: string;
+  vanityHouse: boolean;
+  tags: Array<{ tag: TagRef }>;
+  _count: { releases: number };
+}
+
+// ── Request search ────────────────────────────────────────────────────────────
+
+export interface SearchRequestsParams {
+  q?: string;
+  artist?: string;
+  type?: string;
+  year?: number;
+  status?: string;
+  communityId?: number;
+  orderBy?: 'createdAt' | 'voteCount' | 'random';
+  order?: 'asc' | 'desc';
+  page?: number;
+  limit?: number;
+}
+
+export interface RequestSearchResult {
+  id: number;
+  title: string;
+  description: string;
+  type: string;
+  year: number | null;
+  status: string;
+  voteCount: number;
+  communityId: number;
+  createdAt: string;
+  user: UserRef;
+  artists: Array<{ artist: ArtistRef }>;
+  _count: { bounties: number };
+}
+
+// ── Log search ────────────────────────────────────────────────────────────────
+
+export interface SearchLogParams {
+  q?: string;
+  type?: 'topic' | 'post' | 'all';
+  authorId?: number;
+  orderBy?: 'createdAt';
+  order?: 'asc' | 'desc';
+  page?: number;
+  limit?: number;
+}
+
+export interface TopicSearchResult {
+  id: number;
+  title: string;
+  createdAt: string;
+  isLocked: boolean;
+  isSticky: boolean;
+  numPosts: number;
+  forumId: number;
+  author: UserRef;
+}
+
+export interface PostSearchResult {
+  id: number;
+  body: string;
+  createdAt: string;
+  forumTopicId: number;
+  author: UserRef;
+}
+
+export type LogSearchResponse =
+  | { data: TopicSearchResult[]; meta: PaginatedMeta }
+  | { data: PostSearchResult[]; meta: PaginatedMeta }
+  | {
+      topics: { data: TopicSearchResult[]; meta: PaginatedMeta };
+      posts: { data: PostSearchResult[]; meta: PaginatedMeta };
+    };
+
+// ── User search ───────────────────────────────────────────────────────────────
+
+export interface SearchUsersParams {
+  q?: string;
+  orderBy?: 'username' | 'createdAt' | 'lastLogin';
+  order?: 'asc' | 'desc';
+  disabled?: boolean;
+  page?: number;
+  limit?: number;
+}
+
+export interface UserSearchResult {
+  id: number;
+  username: string;
+  createdAt: string;
+  userRank: { name: string; color: string | null };
+  // staff-only fields (may be absent for regular users)
+  email?: string;
+  lastLogin?: string | null;
+  disabled?: boolean;
+  ratio?: number | null;
+  uploaded?: string;
+  downloaded?: string;
+}
+
+// ── Random ────────────────────────────────────────────────────────────────────
+
+export interface RandomRelease {
+  id: number;
+  communityId: number | null;
+  title: string;
+  year: number;
+  artist: ArtistRef;
+}
+
+export interface RandomArtist {
+  id: number;
+  name: string;
+}
+
+// ── API endpoints ─────────────────────────────────────────────────────────────
+
+export const searchApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    searchReleases: build.query<
+      { data: ReleaseSearchResult[]; meta: PaginatedMeta },
+      SearchReleasesParams
+    >({
+      query: (params) => ({ url: '/search/releases', params }),
+      providesTags: [{ type: 'Release', id: 'SEARCH' }]
+    }),
+
+    searchArtists: build.query<
+      { data: ArtistSearchResult[]; meta: PaginatedMeta },
+      SearchArtistsParams
+    >({
+      query: (params) => ({ url: '/search/artists', params }),
+      providesTags: [{ type: 'Artist', id: 'SEARCH' }]
+    }),
+
+    searchRequests: build.query<
+      { data: RequestSearchResult[]; meta: PaginatedMeta },
+      SearchRequestsParams
+    >({
+      query: (params) => ({ url: '/search/requests', params }),
+      providesTags: [{ type: 'Request', id: 'SEARCH' }]
+    }),
+
+    searchLog: build.query<LogSearchResponse, SearchLogParams>({
+      query: (params) => ({ url: '/search/log', params })
+    }),
+
+    searchUsers: build.query<
+      { data: UserSearchResult[]; meta: PaginatedMeta },
+      SearchUsersParams
+    >({
+      query: (params) => ({ url: '/search/users', params }),
+      providesTags: [{ type: 'User', id: 'SEARCH' }]
+    }),
+
+    getRandomRelease: build.query<RandomRelease, void>({
+      query: () => '/random/release'
+    }),
+
+    getRandomArtist: build.query<RandomArtist, void>({
+      query: () => '/random/artist'
+    })
+  })
+});
+
+export const {
+  useSearchReleasesQuery,
+  useSearchArtistsQuery,
+  useSearchRequestsQuery,
+  useSearchLogQuery,
+  useSearchUsersQuery,
+  useLazyGetRandomReleaseQuery,
+  useLazyGetRandomArtistQuery
+} = searchApi;

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -15,6 +15,8 @@ export const VALID_PERMISSIONS = [
   'users_disable',
   'wiki_edit',
   'wiki_manage',
+  'advanced_search',
+  'users_search',
   'staff',
   'admin'
 ] as const;


### PR DESCRIPTION
## Summary

- **QuickSearch strip**: six uncontrolled text inputs below the primary nav (Releases, Artists, Requests, Forums, Log, Users) — pressing Enter navigates to that entity's browse page with `?q=` pre-populated
- **Browse pages**: `ReleaseBrowsePage`, `ArtistBrowsePage`, `LogBrowsePage`, `UserBrowsePage` — basic search always visible, advanced fields behind toggle gated by `advanced_search` permission
- **Random links**: Random Release and Random Artist on the Releases browse page
- **Requests**: `RequestsPage` rewritten with full text + filter search via `useSearchParams`
- **Contribution form**: `bitrate`, `media`, `hasLog`, `hasCue`, `isScene` fields shown for audio file types
- **RTK Query**: new `searchApi` service with 7 endpoints (`searchReleases`, `searchArtists`, `searchRequests`, `searchLog`, `searchUsers`, `getRandomRelease`, `getRandomArtist`)
- **Permissions**: `advanced_search`, `users_search` added; Search group in `UserRankFormPage`

## Test plan

- [ ] QuickSearch bar visible below nav on all private pages
- [ ] Each input navigates to the correct browse page with `?q=` on Enter; input clears after navigation
- [ ] Releases browse: basic search, tag any/all, community filter, order by (including random)
- [ ] Releases browse: Advanced toggle hidden without `advanced_search` permission; visible with it
- [ ] Random Release / Random Artist navigate to a valid entity page
- [ ] Artists browse: name search, tag filter, vanity house toggle
- [ ] Log browse: topic-only, post-only, and all-mode results; pagination works
- [ ] Users browse: non-privileged sees username/rank/joined only; staff see full fields
- [ ] Requests page: text search, artist, type, year, status, orderBy all sync to URL
- [ ] AddContributionForm: rip fields appear for audio file types; hidden for others
- [ ] Admin UserRankFormPage shows Search group with `advanced_search` and `users_search` checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)