### PR TITLE
Fix profile staff PM links to point at ticket view

### DIFF
--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -368,7 +368,7 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
                             <td className="py-1 pr-3">
                               {conversation.viewerCanOpen ? (
                                 <Link
-                                  to={`/private/messages/${conversation.id}`}
+                                  to={`/private/messages/tickets/${conversation.id}`}
                                   className="text-indigo-400 hover:text-indigo-300"
                                 >
                                   {conversation.subject}


### PR DESCRIPTION
## Summary

- Updates the staff PM conversation links on the user profile page to navigate to `/private/messages/tickets/:id` (the staff inbox ticket view) instead of `/private/messages/:id` (the regular PM view)
- Companion to stellar-api#20

## Test plan

- [ ] Staff viewing a user profile — clicking a staff PM conversation opens the ticket view correctly
- [ ] Regular PM links elsewhere unaffected