### PR TITLE
Top 10 leaderboards, release voting, tag management, and contribute/consume rename

### DIFF
--- a/src/components/communities/ReleasePage.tsx
+++ b/src/components/communities/ReleasePage.tsx
@@ -5,8 +5,13 @@ import { selectCurrentUser } from '../../store/slices/authSlice';
 import CommentsSection from '../layout/CommentsSection';
 import {
   useGetReleaseByIdQuery,
-  useGetCommunityByIdQuery
+  useGetCommunityByIdQuery,
+  useVoteOnReleaseMutation,
+  useRemoveVoteOnReleaseMutation,
+  useAddTagToReleaseMutation,
+  useRemoveTagFromReleaseMutation
 } from '../../store/services/communityApi';
+import type { MyVote, VoteAggregate } from '../../store/services/communityApi';
 import { useToggleReleaseBookmarkMutation } from '../../store/services/bookmarkApi';
 import { addAlert } from '../../store/slices/alertSlice';
 import Spinner from '../layout/Spinner';
@@ -15,6 +20,12 @@ import LinkStatusBadge from './LinkStatusBadge';
 import ReportContributionModal from './ReportContributionModal';
 import { formatBytes } from '../../utils';
 import type { LinkHealthStatus } from '../../types';
+
+type ReleaseWithVote = {
+  myVote?: MyVote;
+  voteAggregate?: VoteAggregate | null;
+  tags?: Array<{ id: number; name: string }>;
+};
 
 const ReleasePage = () => {
   const { communityId, releaseId } = useParams<{
@@ -27,6 +38,7 @@ const ReleasePage = () => {
   const dispatch = useDispatch();
   const user = useSelector(selectCurrentUser);
   const [reportingId, setReportingId] = useState<number | null>(null);
+  const [pendingTag, setPendingTag] = useState('');
 
   const {
     data: release,
@@ -36,6 +48,11 @@ const ReleasePage = () => {
   const { data: community } = useGetCommunityByIdQuery(cId);
   const [toggleBookmark, { isLoading: bookmarking }] =
     useToggleReleaseBookmarkMutation();
+  const [voteOn, { isLoading: voting }] = useVoteOnReleaseMutation();
+  const [removeVote, { isLoading: unvoting }] =
+    useRemoveVoteOnReleaseMutation();
+  const [addTag, { isLoading: addingTag }] = useAddTagToReleaseMutation();
+  const [removeTag] = useRemoveTagFromReleaseMutation();
 
   const handleBookmark = async () => {
     try {
@@ -51,11 +68,54 @@ const ReleasePage = () => {
     }
   };
 
+  const handleVote = async (positive: boolean) => {
+    const r = release as ReleaseWithVote | undefined;
+    const alreadyThis =
+      (positive && r?.myVote === 'up') || (!positive && r?.myVote === 'down');
+    try {
+      if (alreadyThis) {
+        await removeVote({ communityId: cId, releaseId: rId }).unwrap();
+      } else {
+        await voteOn({
+          communityId: cId,
+          releaseId: rId,
+          positive
+        }).unwrap();
+      }
+    } catch {
+      dispatch(addAlert('Failed to record vote.', 'danger'));
+    }
+  };
+
+  const handleAddTag = async () => {
+    const name = pendingTag.trim().toLowerCase();
+    if (!name) return;
+    try {
+      await addTag({ communityId: cId, releaseId: rId, name }).unwrap();
+      setPendingTag('');
+    } catch (e: unknown) {
+      const msg =
+        (e as { data?: { msg?: string } })?.data?.msg ?? 'Failed to add tag.';
+      dispatch(addAlert(msg, 'danger'));
+    }
+  };
+
+  const handleRemoveTag = async (tagId: number) => {
+    try {
+      await removeTag({ communityId: cId, releaseId: rId, tagId }).unwrap();
+    } catch {
+      dispatch(addAlert('Failed to remove tag.', 'danger'));
+    }
+  };
+
   if (isLoading) return <Spinner />;
   if (error || !release)
     return <div className="p-4 text-red-400">Release not found.</div>;
 
-  const tags = release.tags ?? [];
+  const r = release as typeof release & ReleaseWithVote;
+  const tags = r.tags ?? [];
+  const myVote = r.myVote ?? null;
+  const agg = r.voteAggregate ?? null;
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-6">
@@ -241,6 +301,47 @@ const ReleasePage = () => {
             </div>
           )}
 
+          {/* Votes */}
+          <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+            <div className="bg-gray-800 border-b border-gray-700 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
+              Rating
+            </div>
+            <div className="px-3 py-3 flex flex-col gap-2">
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={voting || unvoting}
+                  onClick={() => handleVote(true)}
+                  className={`flex-1 py-1.5 text-sm rounded border transition-colors disabled:opacity-50 ${
+                    myVote === 'up'
+                      ? 'bg-green-700 border-green-600 text-white'
+                      : 'bg-gray-800 border-gray-700 text-green-400 hover:bg-green-900/40'
+                  }`}
+                >
+                  ▲{agg ? ` ${agg.ups}` : ''}
+                </button>
+                <button
+                  type="button"
+                  disabled={voting || unvoting}
+                  onClick={() => handleVote(false)}
+                  className={`flex-1 py-1.5 text-sm rounded border transition-colors disabled:opacity-50 ${
+                    myVote === 'down'
+                      ? 'bg-red-800 border-red-700 text-white'
+                      : 'bg-gray-800 border-gray-700 text-red-400 hover:bg-red-900/40'
+                  }`}
+                >
+                  ▼{agg ? ` ${agg.total - agg.ups}` : ''}
+                </button>
+              </div>
+              {agg && agg.total > 0 && (
+                <p className="text-xs text-gray-500 text-center">
+                  {Math.round((agg.ups / agg.total) * 100)}% positive ·{' '}
+                  {agg.total} vote{agg.total !== 1 ? 's' : ''}
+                </p>
+              )}
+            </div>
+          </div>
+
           {/* Artist */}
           {release.artist && (
             <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
@@ -259,23 +360,55 @@ const ReleasePage = () => {
           )}
 
           {/* Tags */}
-          {tags.length > 0 && (
-            <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
-              <div className="bg-gray-800 border-b border-gray-700 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
-                Tags
-              </div>
-              <div className="px-3 py-2 flex flex-wrap gap-1.5">
-                {tags.map((t) => (
-                  <span
-                    key={t.name}
-                    className="text-xs px-2 py-0.5 bg-gray-800 text-indigo-300 rounded border border-gray-700"
-                  >
-                    {t.name}
-                  </span>
-                ))}
+          <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+            <div className="bg-gray-800 border-b border-gray-700 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
+              Tags
+            </div>
+            <div className="px-3 py-2 space-y-2">
+              {tags.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {tags.map((t) => (
+                    <span
+                      key={t.id}
+                      className="group flex items-center gap-1 text-xs px-2 py-0.5 bg-gray-800 text-indigo-300 rounded border border-gray-700"
+                    >
+                      {t.name}
+                      <button
+                        type="button"
+                        title="Remove tag"
+                        onClick={() => handleRemoveTag(t.id)}
+                        className="text-gray-600 hover:text-red-400 transition-colors leading-none"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-gray-600">No tags yet.</p>
+              )}
+              <div className="flex gap-1">
+                <input
+                  type="text"
+                  value={pendingTag}
+                  onChange={(e) => setPendingTag(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleAddTag();
+                  }}
+                  placeholder="Add tag…"
+                  className="flex-1 min-w-0 bg-gray-800 border border-gray-700 text-gray-200 text-xs rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                />
+                <button
+                  type="button"
+                  disabled={addingTag || !pendingTag.trim()}
+                  onClick={handleAddTag}
+                  className="px-2 py-1 bg-indigo-700 hover:bg-indigo-600 text-white text-xs rounded disabled:opacity-50 transition-colors"
+                >
+                  +
+                </button>
               </div>
             </div>
-          )}
+          </div>
 
           {/* Metadata */}
           <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -67,6 +67,12 @@ import ReleaseBrowsePage from '../../../releases/ReleaseBrowsePage';
 import ArtistBrowsePage from '../../../artists/ArtistBrowsePage';
 import LogBrowsePage from '../../../log/LogBrowsePage';
 import UserBrowsePage from '../../../users/UserBrowsePage';
+import Top10Layout from '../../../top10/Top10Layout';
+import TopReleasesPage from '../../../top10/TopReleasesPage';
+import TopUsersPage from '../../../top10/TopUsersPage';
+import TopTagsPage from '../../../top10/TopTagsPage';
+import TopVotesPage from '../../../top10/TopVotesPage';
+import TopHistoryPage from '../../../top10/TopHistoryPage';
 import DraftsPage from '../../../messages/DraftsPage';
 import { useGetMeQuery } from '../../../../store/services/authApi';
 import {
@@ -325,6 +331,21 @@ const PrivateContent = () => (
     <Route path="artists" element={wrap(ArtistBrowsePage)} />
     <Route path="log" element={wrap(LogBrowsePage)} />
     <Route path="users" element={wrap(UserBrowsePage)} />
+
+    <Route path="top10" element={wrap(Top10Layout)}>
+      <Route path="releases" element={<TopReleasesPage />} />
+      <Route path="users" element={<TopUsersPage />} />
+      <Route path="tags" element={<TopTagsPage />} />
+      <Route path="votes" element={<TopVotesPage />} />
+      <Route
+        path="history"
+        element={
+          <StaffGate permissions={['staff', 'admin']}>
+            <TopHistoryPage />
+          </StaffGate>
+        }
+      />
+    </Route>
 
     <Route path="" element={<PrivateHomepage />} />
     <Route path="*" element={<NotFound />} />

--- a/src/components/pages/private/layout/PrivateHeader.tsx
+++ b/src/components/pages/private/layout/PrivateHeader.tsx
@@ -19,6 +19,7 @@ const navLinks = [
   { label: 'Collages', to: '/private/collages' },
   { label: 'Requests', to: '/private/requests' },
   { label: 'Forums', to: '/private/forums' },
+  { label: 'Top 10', to: '/private/top10' },
   { label: 'Wiki', to: '/private/wiki' }
 ];
 
@@ -29,10 +30,10 @@ const PrivateHeader = ({ user }: Props) => {
   const inboxUnread = inboxData?.count ?? 0;
   const ticketUnread = ticketData?.count ?? 0;
 
-  const uploaded = user.uploaded ? formatBytes(Number(user.uploaded)) : '0 B';
-  const downloaded = user.downloaded
-    ? formatBytes(Number(user.downloaded))
+  const uploaded = user.contributed
+    ? formatBytes(Number(user.contributed))
     : '0 B';
+  const downloaded = user.consumed ? formatBytes(Number(user.consumed)) : '0 B';
   const ratio = user.ratio != null ? user.ratio.toFixed(2) : '∞';
 
   return (

--- a/src/components/profile/RatioRulesPage.tsx
+++ b/src/components/profile/RatioRulesPage.tsx
@@ -70,7 +70,7 @@ const RatioRulesPage = () => {
               Downloaded
             </span>
             <p className="text-base font-medium mt-0.5 text-gray-200">
-              {formatBytes(Number(stats.downloaded))}
+              {formatBytes(Number(stats.consumed))}
             </p>
           </div>
           <div>

--- a/src/components/profile/RatioStats.tsx
+++ b/src/components/profile/RatioStats.tsx
@@ -42,7 +42,7 @@ const RatioStats = () => {
         <li className="flex justify-between px-4 py-2 text-gray-400">
           <span>Downloaded</span>
           <span className="text-gray-200">
-            {formatBytes(Number(stats.downloaded))}
+            {formatBytes(Number(stats.consumed))}
           </span>
         </li>
         <li className="flex justify-between px-4 py-2 text-gray-400">

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -798,8 +798,8 @@ const UserProfile = () => {
   const featuredShelves = profile.collageShelves.featuredPersonalCollages;
   const publicShelves = profile.collageShelves.publicCollages;
   const percentileItems = [
-    { label: 'Uploaded', value: profile.percentiles.uploaded },
-    { label: 'Downloaded', value: profile.percentiles.downloaded },
+    { label: 'Contributed', value: profile.percentiles.contributed },
+    { label: 'Consumed', value: profile.percentiles.consumed },
     { label: 'Contributions', value: profile.percentiles.contributions },
     { label: 'Forum Posts', value: profile.percentiles.forumPosts },
     { label: 'Requests Filled', value: profile.percentiles.requestsFilled }
@@ -922,12 +922,12 @@ const UserProfile = () => {
             </div>
             <ul className="px-3 py-2 space-y-1 text-xs text-gray-300">
               <li>
-                <span className="text-gray-500">Uploaded:</span>{' '}
-                {formatCount(profileStats.uploaded)}
+                <span className="text-gray-500">Contributed:</span>{' '}
+                {formatCount(profileStats.contributed)}
               </li>
               <li>
-                <span className="text-gray-500">Downloaded:</span>{' '}
-                {formatCount(profileStats.downloaded)}
+                <span className="text-gray-500">Consumed:</span>{' '}
+                {formatCount(profileStats.consumed)}
               </li>
               <li>
                 <span className="text-gray-500">Ratio:</span>{' '}

--- a/src/components/profile/invite/InviteTree.tsx
+++ b/src/components/profile/invite/InviteTree.tsx
@@ -13,8 +13,8 @@ const renderNode = (node: InviteNode): React.ReactNode => (
       <td>{node.email}</td>
       <td>{node.joinedAt ? <Time date={node.joinedAt} /> : '—'}</td>
       <td>{node.lastSeen ? <Time date={node.lastSeen} /> : '—'}</td>
-      <td>{node.uploaded}</td>
-      <td>{node.downloaded}</td>
+      <td>{node.contributed}</td>
+      <td>{node.consumed}</td>
       <td>{node.ratio}</td>
     </tr>
     {node.children?.map(renderNode)}

--- a/src/components/profile/settings/Settings.tsx
+++ b/src/components/profile/settings/Settings.tsx
@@ -53,8 +53,8 @@ const toProfileForm = (profile: MyProfileResponse): ProfileForm => ({
   notificationMethod: profile.userSettings.notificationMethod,
   showEmail: profile.userSettings.showEmail,
   showLastSeen: profile.userSettings.showLastSeen,
-  showUploadedStats: profile.userSettings.showUploadedStats,
-  showDownloadedStats: profile.userSettings.showDownloadedStats,
+  showContributedStats: profile.userSettings.showContributedStats,
+  showConsumedStats: profile.userSettings.showConsumedStats,
   showRatioStats: profile.userSettings.showRatioStats
 });
 
@@ -406,19 +406,19 @@ const Settings = () => {
               <label className="flex items-center gap-3 cursor-pointer">
                 <input
                   type="checkbox"
-                  {...register('showUploadedStats')}
+                  {...register('showContributedStats')}
                   className="accent-indigo-500"
                 />
-                <span className="text-sm text-gray-300">Uploaded stats</span>
+                <span className="text-sm text-gray-300">Contributed stats</span>
               </label>
 
               <label className="flex items-center gap-3 cursor-pointer">
                 <input
                   type="checkbox"
-                  {...register('showDownloadedStats')}
+                  {...register('showConsumedStats')}
                   className="accent-indigo-500"
                 />
-                <span className="text-sm text-gray-300">Downloaded stats</span>
+                <span className="text-sm text-gray-300">Consumed stats</span>
               </label>
 
               <label className="flex items-center gap-3 cursor-pointer">

--- a/src/components/top10/Top10Layout.tsx
+++ b/src/components/top10/Top10Layout.tsx
@@ -1,0 +1,54 @@
+import { NavLink, Outlet, Navigate, useLocation } from 'react-router-dom';
+import { useGetMeQuery } from '../../store/services/authApi';
+import { hasAnyPermission } from '../../utils/permissions';
+
+const tabCls = (active: boolean) =>
+  `px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+    active
+      ? 'border-indigo-500 text-indigo-400'
+      : 'border-transparent text-gray-400 hover:text-gray-200 hover:border-gray-600'
+  }`;
+
+const TABS = [
+  { path: 'releases', label: 'Releases' },
+  { path: 'users', label: 'Users' },
+  { path: 'tags', label: 'Tags' },
+  { path: 'votes', label: 'Votes' }
+];
+
+const Top10Layout = () => {
+  const { pathname } = useLocation();
+  const { data: user } = useGetMeQuery();
+  const isStaff = hasAnyPermission(user, ['staff', 'admin']);
+
+  if (pathname === '/private/top10' || pathname === '/private/top10/') {
+    return <Navigate to="releases" replace />;
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
+      <h1 className="text-2xl font-bold text-white">Top 10</h1>
+
+      <nav className="flex gap-1 border-b border-gray-700">
+        {TABS.map(({ path, label }) => (
+          <NavLink
+            key={path}
+            to={path}
+            className={({ isActive }) => tabCls(isActive)}
+          >
+            {label}
+          </NavLink>
+        ))}
+        {isStaff && (
+          <NavLink to="history" className={({ isActive }) => tabCls(isActive)}>
+            History
+          </NavLink>
+        )}
+      </nav>
+
+      <Outlet />
+    </div>
+  );
+};
+
+export default Top10Layout;

--- a/src/components/top10/TopHistoryPage.tsx
+++ b/src/components/top10/TopHistoryPage.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetTop10HistoryQuery } from '../../store/services/top10Api';
+import Spinner from '../layout/Spinner';
+
+const selectCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+const inputCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const TopHistoryPage = () => {
+  const [type, setType] = useState<'Daily' | 'Weekly'>('Daily');
+  const [date, setDate] = useState(today());
+
+  const { data, isLoading, error, isFetching } = useGetTop10HistoryQuery({
+    type,
+    date
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-gray-800 border border-gray-700 rounded-lg p-4 flex flex-wrap gap-4 items-end">
+        <div>
+          <label
+            htmlFor="history-type"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Snapshot Type
+          </label>
+          <select
+            id="history-type"
+            className={selectCls}
+            value={type}
+            onChange={(e) => setType(e.target.value as 'Daily' | 'Weekly')}
+          >
+            <option value="Daily">Daily</option>
+            <option value="Weekly">Weekly</option>
+          </select>
+        </div>
+        <div>
+          <label
+            htmlFor="history-date"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Date
+          </label>
+          <input
+            id="history-date"
+            type="date"
+            className={inputCls}
+            value={date}
+            max={today()}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {(isLoading || isFetching) && <Spinner />}
+
+      {error && (
+        <div className="bg-gray-800 border border-gray-700 rounded-lg p-6 text-center text-gray-400">
+          No snapshot found for {date} ({type}).
+        </div>
+      )}
+
+      {data && !isFetching && (
+        <div className="bg-gray-800 border border-gray-700 rounded-lg overflow-hidden">
+          <div className="px-4 py-3 border-b border-gray-700 flex items-center justify-between">
+            <span className="text-sm font-medium text-gray-200">
+              {data.type} snapshot
+            </span>
+            <span className="text-xs text-gray-500">
+              {new Date(data.date).toLocaleDateString()}
+            </span>
+          </div>
+          <table className="w-full text-sm text-gray-300">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-700">
+                <th className="px-4 py-2 w-8">#</th>
+                <th className="px-4 py-2">Release</th>
+                <th className="px-4 py-2">Tags</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.entries.map((entry) => (
+                <tr
+                  key={entry.rank}
+                  className="border-t border-gray-800 hover:bg-gray-800/40"
+                >
+                  <td className="px-4 py-2 text-gray-500">{entry.rank}</td>
+                  <td className="px-4 py-2">
+                    {entry.releaseId && !entry.deleted ? (
+                      <Link
+                        to={`/private/releases/${entry.releaseId}`}
+                        className="text-indigo-400 hover:text-indigo-300"
+                      >
+                        {entry.releaseTitle}
+                      </Link>
+                    ) : (
+                      <span className="text-gray-500">
+                        {entry.releaseTitle}{' '}
+                        <span className="text-xs italic">(deleted)</span>
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-gray-500 text-xs">
+                    {entry.tagString}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TopHistoryPage;

--- a/src/components/top10/TopReleasesPage.tsx
+++ b/src/components/top10/TopReleasesPage.tsx
@@ -1,0 +1,223 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetTopReleasesQuery,
+  type ReleasesParams
+} from '../../store/services/top10Api';
+import Spinner from '../layout/Spinner';
+import { formatBytes } from '../../utils';
+
+type ReleaseType = ReleasesParams['type'];
+type LimitValue = 10 | 100 | 250;
+
+const TYPE_LABELS: Record<NonNullable<ReleaseType>, string> = {
+  day: 'Past Day',
+  week: 'Past Week',
+  month: 'Past Month',
+  year: 'Past Year',
+  overall: 'All Time',
+  consumed: 'Most Consumed',
+  contributed: 'Most Contributed'
+};
+
+const FORMAT_OPTIONS = [
+  '',
+  'mp3',
+  'flac',
+  'wav',
+  'ogg',
+  'aac',
+  'm4a',
+  'mp4',
+  'mkv',
+  'pdf',
+  'epub'
+];
+
+const selectCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+const TopReleasesPage = () => {
+  const [type, setType] = useState<NonNullable<ReleaseType>>('day');
+  const [limit, setLimit] = useState<LimitValue>(10);
+  const [excludeTags, setExcludeTags] = useState('');
+  const [format, setFormat] = useState('');
+  const [pendingExclude, setPendingExclude] = useState('');
+
+  const { data, isLoading, error } = useGetTopReleasesQuery({
+    type,
+    limit,
+    excludeTags: excludeTags || undefined,
+    format: format || undefined
+  });
+
+  return (
+    <div className="space-y-4">
+      {/* Controls */}
+      <div className="bg-gray-800 border border-gray-700 rounded-lg p-4 flex flex-wrap gap-4 items-end">
+        <div>
+          <label
+            htmlFor="releases-type"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Period / Type
+          </label>
+          <select
+            id="releases-type"
+            className={selectCls}
+            value={type}
+            onChange={(e) =>
+              setType(e.target.value as NonNullable<ReleaseType>)
+            }
+          >
+            {Object.entries(TYPE_LABELS).map(([v, l]) => (
+              <option key={v} value={v}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="releases-limit"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Limit
+          </label>
+          <select
+            id="releases-limit"
+            className={selectCls}
+            value={limit}
+            onChange={(e) => setLimit(Number(e.target.value) as LimitValue)}
+          >
+            {[10, 100, 250].map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="releases-format"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Format
+          </label>
+          <select
+            id="releases-format"
+            className={selectCls}
+            value={format}
+            onChange={(e) => setFormat(e.target.value)}
+          >
+            {FORMAT_OPTIONS.map((v) => (
+              <option key={v} value={v}>
+                {v || 'Any'}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex-1 min-w-48">
+          <label
+            htmlFor="releases-exclude-tags"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Exclude Tags (comma-separated)
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="releases-exclude-tags"
+              type="text"
+              className="flex-1 bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              value={pendingExclude}
+              placeholder="e.g. pop, rock"
+              onChange={(e) => setPendingExclude(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') setExcludeTags(pendingExclude);
+              }}
+            />
+            <button
+              className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded"
+              onClick={() => setExcludeTags(pendingExclude)}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Table */}
+      {isLoading && <Spinner />}
+      {error && (
+        <p className="text-red-400 text-sm">Failed to load top releases.</p>
+      )}
+      {data && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-gray-300">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-700">
+                <th className="pb-2 pr-3 w-8">#</th>
+                <th className="pb-2 pr-3">Release</th>
+                <th className="pb-2 pr-3 text-right">Consumers</th>
+                <th className="pb-2 pr-3 text-right">Data</th>
+                <th className="pb-2 text-right">Contributions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="py-8 text-center text-gray-500">
+                    No data for this period.
+                  </td>
+                </tr>
+              )}
+              {data.items.map((item) => (
+                <tr
+                  key={item.releaseId}
+                  className="border-t border-gray-800 hover:bg-gray-800/40"
+                >
+                  <td className="py-2 pr-3 text-gray-500">{item.rank}</td>
+                  <td className="py-2 pr-3">
+                    <Link
+                      to={`/private/releases/${item.releaseId}`}
+                      className="text-indigo-400 hover:text-indigo-300 font-medium"
+                    >
+                      {item.artistName} – {item.title}
+                    </Link>
+                    <span className="text-gray-500 ml-2">[{item.year}]</span>
+                    {item.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-0.5">
+                        {item.tags.map((t) => (
+                          <span
+                            key={t.id}
+                            className="text-[10px] bg-gray-700 text-gray-400 rounded px-1.5 py-0.5"
+                          >
+                            {t.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </td>
+                  <td className="py-2 pr-3 text-right tabular-nums">
+                    {item.consumerCount.toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-right tabular-nums">
+                    {formatBytes(Number(item.totalBytesConsumed))}
+                  </td>
+                  <td className="py-2 text-right tabular-nums">
+                    {item.contributionCount}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TopReleasesPage;

--- a/src/components/top10/TopTagsPage.tsx
+++ b/src/components/top10/TopTagsPage.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetTopTagsQuery,
+  type TagsParams
+} from '../../store/services/top10Api';
+import Spinner from '../layout/Spinner';
+
+type TagType = NonNullable<TagsParams['type']>;
+type LimitValue = 10 | 100 | 250;
+
+const selectCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+const TopTagsPage = () => {
+  const [type, setType] = useState<TagType>('used');
+  const [limit, setLimit] = useState<LimitValue>(10);
+
+  const { data, isLoading, error } = useGetTopTagsQuery({ type, limit });
+
+  const showVotes = type === 'voted';
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-gray-800 border border-gray-700 rounded-lg p-4 flex flex-wrap gap-4 items-end">
+        <div>
+          <label
+            htmlFor="tags-view"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            View
+          </label>
+          <select
+            id="tags-view"
+            className={selectCls}
+            value={type}
+            onChange={(e) => setType(e.target.value as TagType)}
+          >
+            <option value="used">Most Used</option>
+            <option value="voted">Most Voted</option>
+          </select>
+        </div>
+        <div>
+          <label
+            htmlFor="tags-limit"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Limit
+          </label>
+          <select
+            id="tags-limit"
+            className={selectCls}
+            value={limit}
+            onChange={(e) => setLimit(Number(e.target.value) as LimitValue)}
+          >
+            {[10, 100, 250].map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {isLoading && <Spinner />}
+      {error && (
+        <p className="text-red-400 text-sm">Failed to load top tags.</p>
+      )}
+      {data && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-gray-300">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-700">
+                <th className="pb-2 pr-3 w-8">#</th>
+                <th className="pb-2 pr-3">Tag</th>
+                <th className="pb-2 pr-3 text-right">Uses</th>
+                {showVotes && (
+                  <>
+                    <th className="pb-2 pr-3 text-right text-green-500">
+                      Positive
+                    </th>
+                    <th className="pb-2 text-right text-red-500">Negative</th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={showVotes ? 5 : 3}
+                    className="py-8 text-center text-gray-500"
+                  >
+                    No tags found.
+                  </td>
+                </tr>
+              )}
+              {data.items.map((item) => (
+                <tr
+                  key={item.tagId}
+                  className="border-t border-gray-800 hover:bg-gray-800/40"
+                >
+                  <td className="py-2 pr-3 text-gray-500">{item.rank}</td>
+                  <td className="py-2 pr-3">
+                    <Link
+                      to={`/private/releases?tags=${encodeURIComponent(
+                        item.name
+                      )}`}
+                      className="text-indigo-400 hover:text-indigo-300"
+                    >
+                      {item.name}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-3 text-right tabular-nums">
+                    {item.uses.toLocaleString()}
+                  </td>
+                  {showVotes && (
+                    <>
+                      <td className="py-2 pr-3 text-right tabular-nums text-green-400">
+                        +{item.positiveVotes.toLocaleString()}
+                      </td>
+                      <td className="py-2 text-right tabular-nums text-red-400">
+                        −{item.negativeVotes.toLocaleString()}
+                      </td>
+                    </>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TopTagsPage;

--- a/src/components/top10/TopUsersPage.tsx
+++ b/src/components/top10/TopUsersPage.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetTopUsersQuery,
+  type UsersParams
+} from '../../store/services/top10Api';
+import Spinner from '../layout/Spinner';
+import { formatBytes } from '../../utils';
+
+type UserType = NonNullable<UsersParams['type']>;
+type LimitValue = 10 | 100 | 250;
+
+const TYPE_LABELS: Record<UserType, string> = {
+  contributed: 'Most Contributed',
+  consumed: 'Most Consumed',
+  numContributions: 'Most Contributions',
+  contributionSpeed: 'Fastest Contributors',
+  consumeSpeed: 'Fastest Consumers'
+};
+
+const ratioColor = (ratio: number) => {
+  if (ratio >= 1.0) return 'text-green-400';
+  if (ratio >= 0.5) return 'text-yellow-400';
+  return 'text-red-400';
+};
+
+const fmtSpeed = (bytesPerSec: number) => {
+  if (bytesPerSec <= 0) return '—';
+  return `${formatBytes(bytesPerSec)}/s`;
+};
+
+const selectCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+const TopUsersPage = () => {
+  const [type, setType] = useState<UserType>('contributed');
+  const [limit, setLimit] = useState<LimitValue>(10);
+
+  const { data, isLoading, error } = useGetTopUsersQuery({ type, limit });
+
+  const showSpeed = type === 'contributionSpeed' || type === 'consumeSpeed';
+  const showContributed = type !== 'consumed';
+  const showConsumed = type !== 'contributed' && type !== 'numContributions';
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-gray-800 border border-gray-700 rounded-lg p-4 flex flex-wrap gap-4 items-end">
+        <div>
+          <label
+            htmlFor="users-metric"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Metric
+          </label>
+          <select
+            id="users-metric"
+            className={selectCls}
+            value={type}
+            onChange={(e) => setType(e.target.value as UserType)}
+          >
+            {Object.entries(TYPE_LABELS).map(([v, l]) => (
+              <option key={v} value={v}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label
+            htmlFor="users-limit"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Limit
+          </label>
+          <select
+            id="users-limit"
+            className={selectCls}
+            value={limit}
+            onChange={(e) => setLimit(Number(e.target.value) as LimitValue)}
+          >
+            {[10, 100, 250].map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {isLoading && <Spinner />}
+      {error && (
+        <p className="text-red-400 text-sm">Failed to load top users.</p>
+      )}
+      {data && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-gray-300">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-700">
+                <th className="pb-2 pr-3 w-8">#</th>
+                <th className="pb-2 pr-3">User</th>
+                {showContributed && (
+                  <th className="pb-2 pr-3 text-right">Contributed</th>
+                )}
+                {showSpeed && type === 'contributionSpeed' && (
+                  <th className="pb-2 pr-3 text-right">Contrib. Speed</th>
+                )}
+                {showConsumed && (
+                  <th className="pb-2 pr-3 text-right">Consumed</th>
+                )}
+                {showSpeed && type === 'consumeSpeed' && (
+                  <th className="pb-2 pr-3 text-right">Consume Speed</th>
+                )}
+                {type === 'numContributions' && (
+                  <th className="pb-2 pr-3 text-right">Contributions</th>
+                )}
+                <th className="pb-2 pr-3 text-right">Ratio</th>
+                <th className="pb-2 text-right hidden sm:table-cell">Joined</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="py-8 text-center text-gray-500">
+                    No data available.
+                  </td>
+                </tr>
+              )}
+              {data.items.map((item) => (
+                <tr
+                  key={item.userId}
+                  className="border-t border-gray-800 hover:bg-gray-800/40"
+                >
+                  <td className="py-2 pr-3 text-gray-500">{item.rank}</td>
+                  <td className="py-2 pr-3">
+                    <Link
+                      to={`/private/user/${item.userId}`}
+                      className="text-indigo-400 hover:text-indigo-300 font-medium"
+                    >
+                      {item.username}
+                    </Link>
+                    <span className="ml-2 text-xs text-gray-500">
+                      {item.rankName}
+                    </span>
+                  </td>
+                  {showContributed && (
+                    <td className="py-2 pr-3 text-right tabular-nums">
+                      {formatBytes(Number(item.contributed))}
+                    </td>
+                  )}
+                  {showSpeed && type === 'contributionSpeed' && (
+                    <td className="py-2 pr-3 text-right tabular-nums">
+                      {fmtSpeed(item.contributionSpeed)}
+                    </td>
+                  )}
+                  {showConsumed && (
+                    <td className="py-2 pr-3 text-right tabular-nums">
+                      {formatBytes(Number(item.consumed))}
+                    </td>
+                  )}
+                  {showSpeed && type === 'consumeSpeed' && (
+                    <td className="py-2 pr-3 text-right tabular-nums">
+                      {fmtSpeed(item.consumeSpeed)}
+                    </td>
+                  )}
+                  {type === 'numContributions' && (
+                    <td className="py-2 pr-3 text-right tabular-nums">
+                      {item.numContributions.toLocaleString()}
+                    </td>
+                  )}
+                  <td
+                    className={`py-2 pr-3 text-right tabular-nums font-medium ${ratioColor(
+                      item.ratio
+                    )}`}
+                  >
+                    {item.ratio.toFixed(2)}
+                  </td>
+                  <td className="py-2 text-right text-gray-500 text-xs hidden sm:table-cell">
+                    {new Date(item.joinedAt).getFullYear()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TopUsersPage;

--- a/src/components/top10/TopVotesPage.tsx
+++ b/src/components/top10/TopVotesPage.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetTopVotesQuery,
+  type VotesParams
+} from '../../store/services/top10Api';
+import Spinner from '../layout/Spinner';
+
+type LimitValue = 25 | 100 | 250;
+
+const selectCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+const inputCls =
+  'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+const ScoreBar = ({ pct }: { pct: number }) => (
+  <div className="flex items-center gap-2">
+    <div className="w-20 h-1.5 bg-gray-700 rounded-full overflow-hidden">
+      <div
+        className="h-full bg-green-500 rounded-full"
+        style={{ width: `${Math.min(pct, 100)}%` }}
+      />
+    </div>
+    <span className="text-xs tabular-nums text-gray-400">
+      {pct.toFixed(1)}%
+    </span>
+  </div>
+);
+
+const TopVotesPage = () => {
+  const [limit, setLimit] = useState<LimitValue>(25);
+  const [tagFilter, setTagFilter] = useState('');
+  const [yearFilter, setYearFilter] = useState('');
+  const [pending, setPending] = useState({ tags: '', year: '' });
+
+  const params: VotesParams = {
+    limit,
+    tags: tagFilter || undefined,
+    year: yearFilter ? Number(yearFilter) : undefined
+  };
+
+  const { data, isLoading, error } = useGetTopVotesQuery(params);
+
+  const applyFilters = () => {
+    setTagFilter(pending.tags);
+    setYearFilter(pending.year);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-gray-800 border border-gray-700 rounded-lg p-4 flex flex-wrap gap-4 items-end">
+        <div>
+          <label
+            htmlFor="votes-limit"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Limit
+          </label>
+          <select
+            id="votes-limit"
+            className={selectCls}
+            value={limit}
+            onChange={(e) => setLimit(Number(e.target.value) as LimitValue)}
+          >
+            {[25, 100, 250].map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label
+            htmlFor="votes-tags"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Tags (comma-separated)
+          </label>
+          <input
+            id="votes-tags"
+            type="text"
+            className={inputCls}
+            value={pending.tags}
+            placeholder="e.g. jazz, blues"
+            onChange={(e) =>
+              setPending((p) => ({ ...p, tags: e.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="votes-year"
+            className="block text-xs font-medium text-gray-400 mb-1"
+          >
+            Year
+          </label>
+          <input
+            id="votes-year"
+            type="number"
+            className={`${inputCls} w-24`}
+            value={pending.year}
+            placeholder="2020"
+            onChange={(e) =>
+              setPending((p) => ({ ...p, year: e.target.value }))
+            }
+          />
+        </div>
+        <button
+          className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded"
+          onClick={applyFilters}
+        >
+          Apply
+        </button>
+      </div>
+
+      <p className="text-xs text-gray-500">
+        Ranked by Binomial Proportion Confidence Interval (90% confidence).
+        Requires ≥ 3 votes.
+      </p>
+
+      {isLoading && <Spinner />}
+      {error && (
+        <p className="text-red-400 text-sm">Failed to load top votes.</p>
+      )}
+      {data && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-gray-300">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-700">
+                <th className="pb-2 pr-3 w-8">#</th>
+                <th className="pb-2 pr-3">Release</th>
+                <th className="pb-2 pr-3 text-right">+</th>
+                <th className="pb-2 pr-3 text-right">−</th>
+                <th className="pb-2 pr-3 text-right">Total</th>
+                <th className="pb-2 pr-3 text-right">Score</th>
+                <th className="pb-2">Positive</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="py-8 text-center text-gray-500">
+                    No voted releases found.
+                  </td>
+                </tr>
+              )}
+              {data.items.map((item) => (
+                <tr
+                  key={item.releaseId}
+                  className="border-t border-gray-800 hover:bg-gray-800/40"
+                >
+                  <td className="py-2 pr-3 text-gray-500">{item.rank}</td>
+                  <td className="py-2 pr-3">
+                    <Link
+                      to={`/private/releases/${item.releaseId}`}
+                      className="text-indigo-400 hover:text-indigo-300 font-medium"
+                    >
+                      {item.artistName} – {item.title}
+                    </Link>
+                    <span className="text-gray-500 ml-2">[{item.year}]</span>
+                  </td>
+                  <td className="py-2 pr-3 text-right tabular-nums text-green-400">
+                    {item.ups.toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-right tabular-nums text-red-400">
+                    {item.downs.toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-right tabular-nums text-gray-400">
+                    {item.total.toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-3 text-right tabular-nums font-medium">
+                    {item.score.toFixed(4)}
+                  </td>
+                  <td className="py-2">
+                    <ScoreBar pct={item.positivePercent} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TopVotesPage;

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -51,7 +51,8 @@ export const api = createApi({
     'Bookmark',
     'SiteHistory',
     'Draft',
-    'WikiPage'
+    'WikiPage',
+    'Top10'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/communityApi.ts
+++ b/src/store/services/communityApi.ts
@@ -1,6 +1,26 @@
 import { api } from '../api';
 import type { paths } from '../../types/api';
 
+export interface VoteAggregate {
+  releaseId: number;
+  ups: number;
+  total: number;
+  score: number;
+}
+
+export type MyVote = 'up' | 'down' | null;
+
+export interface VoteResponse {
+  myVote: MyVote;
+  voteAggregate: VoteAggregate | null;
+}
+
+export interface ReleaseTag {
+  id: number;
+  name: string;
+  occurrences: number;
+}
+
 interface ReleaseArgs {
   communityId: number;
   releaseId: number;
@@ -196,7 +216,60 @@ export const communityApi = api.injectEndpoints({
         { type: 'Release', id: releaseId },
         'Contribution'
       ]
-    })
+    }),
+
+    // Votes
+    voteOnRelease: build.mutation<
+      VoteResponse,
+      ReleaseArgs & { positive: boolean }
+    >({
+      query: ({ communityId, releaseId, positive }) => ({
+        url: `/communities/${communityId}/releases/${releaseId}/vote`,
+        method: 'POST',
+        body: { positive }
+      }),
+      invalidatesTags: (_, __, { releaseId }) => [
+        { type: 'Release', id: releaseId },
+        'Top10'
+      ]
+    }),
+    removeVoteOnRelease: build.mutation<VoteResponse, ReleaseArgs>({
+      query: ({ communityId, releaseId }) => ({
+        url: `/communities/${communityId}/releases/${releaseId}/vote`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: (_, __, { releaseId }) => [
+        { type: 'Release', id: releaseId },
+        'Top10'
+      ]
+    }),
+
+    // Tags
+    addTagToRelease: build.mutation<ReleaseTag, ReleaseArgs & { name: string }>(
+      {
+        query: ({ communityId, releaseId, name }) => ({
+          url: `/communities/${communityId}/releases/${releaseId}/tags`,
+          method: 'POST',
+          body: { name }
+        }),
+        invalidatesTags: (_, __, { releaseId }) => [
+          { type: 'Release', id: releaseId },
+          'Top10'
+        ]
+      }
+    ),
+    removeTagFromRelease: build.mutation<void, ReleaseArgs & { tagId: number }>(
+      {
+        query: ({ communityId, releaseId, tagId }) => ({
+          url: `/communities/${communityId}/releases/${releaseId}/tags/${tagId}`,
+          method: 'DELETE'
+        }),
+        invalidatesTags: (_, __, { releaseId }) => [
+          { type: 'Release', id: releaseId },
+          'Top10'
+        ]
+      }
+    )
   })
 });
 
@@ -216,5 +289,9 @@ export const {
   useDeleteReleaseMutation,
   useGetContributionsQuery,
   useCreateContributionMutation,
-  useAddContributionToReleaseMutation
+  useAddContributionToReleaseMutation,
+  useVoteOnReleaseMutation,
+  useRemoveVoteOnReleaseMutation,
+  useAddTagToReleaseMutation,
+  useRemoveTagFromReleaseMutation
 } = communityApi;

--- a/src/store/services/searchApi.ts
+++ b/src/store/services/searchApi.ts
@@ -178,8 +178,8 @@ export interface UserSearchResult {
   lastLogin?: string | null;
   disabled?: boolean;
   ratio?: number | null;
-  uploaded?: string;
-  downloaded?: string;
+  contributed?: string;
+  consumed?: string;
 }
 
 // ── Random ────────────────────────────────────────────────────────────────────

--- a/src/store/services/top10Api.ts
+++ b/src/store/services/top10Api.ts
@@ -1,0 +1,164 @@
+import { api } from '../api';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface Top10Tag {
+  id: number;
+  name: string;
+}
+
+export interface TopReleaseItem {
+  rank: number;
+  releaseId: number;
+  title: string;
+  year: number;
+  artistId: number;
+  artistName: string;
+  type: string;
+  releaseType: string;
+  tags: Top10Tag[];
+  consumerCount: number;
+  totalBytesConsumed: string;
+  contributionCount: number;
+}
+
+export interface TopUserItem {
+  rank: number;
+  userId: number;
+  username: string;
+  avatar: string | null;
+  contributed: string;
+  consumed: string;
+  ratio: number;
+  numContributions: number;
+  contributionSpeed: number;
+  consumeSpeed: number;
+  joinedAt: string;
+  rankName: string;
+  rankLevel: number;
+}
+
+export interface TopTagItem {
+  rank: number;
+  tagId: number;
+  name: string;
+  uses: number;
+  positiveVotes: number;
+  negativeVotes: number;
+}
+
+export interface TopVoteItem {
+  rank: number;
+  releaseId: number;
+  title: string;
+  year: number;
+  artistName: string;
+  ups: number;
+  downs: number;
+  total: number;
+  score: number;
+  positivePercent: number;
+}
+
+export interface HistorySnapshotEntry {
+  rank: number;
+  releaseId: number | null;
+  releaseTitle: string;
+  tagString: string;
+  deleted: boolean;
+}
+
+export interface HistorySnapshot {
+  snapshotId: number;
+  type: 'Daily' | 'Weekly';
+  date: string;
+  entries: HistorySnapshotEntry[];
+}
+
+// ─── Query params ─────────────────────────────────────────────────────────────
+
+export interface ReleasesParams {
+  type?:
+    | 'day'
+    | 'week'
+    | 'month'
+    | 'year'
+    | 'overall'
+    | 'consumed'
+    | 'contributed';
+  limit?: 10 | 100 | 250;
+  excludeTags?: string;
+  format?: string;
+}
+
+export interface UsersParams {
+  type?:
+    | 'contributed'
+    | 'consumed'
+    | 'numContributions'
+    | 'contributionSpeed'
+    | 'consumeSpeed';
+  limit?: 10 | 100 | 250;
+}
+
+export interface TagsParams {
+  type?: 'used' | 'voted';
+  limit?: 10 | 100 | 250;
+}
+
+export interface VotesParams {
+  limit?: 25 | 100 | 250;
+  tags?: string;
+  year?: number;
+}
+
+export interface HistoryParams {
+  type?: 'Daily' | 'Weekly';
+  date?: string;
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+function buildQs(params: Record<string, unknown>): string {
+  const entries = Object.entries(params).filter(
+    ([, v]) => v !== undefined && v !== ''
+  );
+  if (entries.length === 0) return '';
+  return (
+    '?' +
+    entries.map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&')
+  );
+}
+
+export const top10Api = api.injectEndpoints({
+  endpoints: (build) => ({
+    getTopReleases: build.query<{ items: TopReleaseItem[] }, ReleasesParams>({
+      query: (p) => `/top10/releases${buildQs(p as Record<string, unknown>)}`,
+      providesTags: ['Top10']
+    }),
+    getTopUsers: build.query<{ items: TopUserItem[] }, UsersParams>({
+      query: (p) => `/top10/users${buildQs(p as Record<string, unknown>)}`,
+      providesTags: ['Top10']
+    }),
+    getTopTags: build.query<{ items: TopTagItem[] }, TagsParams>({
+      query: (p) => `/top10/tags${buildQs(p as Record<string, unknown>)}`,
+      providesTags: ['Top10']
+    }),
+    getTopVotes: build.query<{ items: TopVoteItem[] }, VotesParams>({
+      query: (p) => `/top10/votes${buildQs(p as Record<string, unknown>)}`,
+      providesTags: ['Top10']
+    }),
+    getTop10History: build.query<HistorySnapshot, HistoryParams>({
+      query: (p) => `/top10/history${buildQs(p as Record<string, unknown>)}`,
+      providesTags: ['Top10']
+    })
+  })
+});
+
+export const {
+  useGetTopReleasesQuery,
+  useGetTopUsersQuery,
+  useGetTopTagsQuery,
+  useGetTopVotesQuery,
+  useGetTop10HistoryQuery
+} = top10Api;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -367,8 +367,8 @@ export interface paths {
               | 'Combined';
             showEmail?: boolean;
             showLastSeen?: boolean;
-            showUploadedStats?: boolean;
-            showDownloadedStats?: boolean;
+            showContributedStats?: boolean;
+            showConsumedStats?: boolean;
             showRatioStats?: boolean;
           };
         };
@@ -538,8 +538,8 @@ export interface paths {
               | 'Combined';
             showEmail?: boolean;
             showLastSeen?: boolean;
-            showUploadedStats?: boolean;
-            showDownloadedStats?: boolean;
+            showContributedStats?: boolean;
+            showConsumedStats?: boolean;
             showRatioStats?: boolean;
           };
         };
@@ -5910,8 +5910,8 @@ export interface components {
       isArtist?: boolean;
       isDonor?: boolean;
       canDownload?: boolean;
-      uploaded?: string;
-      downloaded?: string;
+      contributed?: string;
+      consumed?: string;
       ratio?: number;
       userRank: {
         level: number;
@@ -5969,13 +5969,13 @@ export interface components {
         | 'Combined';
       showEmail: boolean;
       showLastSeen: boolean;
-      showUploadedStats: boolean;
-      showDownloadedStats: boolean;
+      showContributedStats: boolean;
+      showConsumedStats: boolean;
       showRatioStats: boolean;
     };
     ProfileStats: {
-      uploaded: string | null;
-      downloaded: string | null;
+      contributed: string | null;
+      consumed: string | null;
       totalEarned: string | null;
       ratio: string | null;
       buffer: string | null;
@@ -6010,8 +6010,8 @@ export interface components {
       total: number;
     };
     ProfilePercentiles: {
-      uploaded: components['schemas']['ProfilePercentile'];
-      downloaded: components['schemas']['ProfilePercentile'];
+      contributed: components['schemas']['ProfilePercentile'];
+      consumed: components['schemas']['ProfilePercentile'];
       contributions: components['schemas']['ProfilePercentile'];
       forumPosts: components['schemas']['ProfilePercentile'];
       requestsFilled: components['schemas']['ProfilePercentile'];
@@ -6084,8 +6084,8 @@ export interface components {
       email?: string;
       joinedAt: string;
       lastSeen?: string | null;
-      uploaded?: string;
-      downloaded?: string;
+      contributed?: string;
+      consumed?: string;
       ratio?: string;
       children?: components['schemas']['InviteNode'][];
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -126,7 +126,7 @@ export interface RatioBracket {
 export interface RatioStats {
   ratio: number;
   totalEarned: string;
-  downloaded: string;
+  consumed: string;
   bracket: RatioBracket;
   eligibleContributionBytes: string;
   contributionCoverage: number;


### PR DESCRIPTION
## Summary

Companion PR to stellar-api#21.

- **Rename** `AuthUser.uploaded/downloaded` → `contributed/consumed` and all derived types (`UserSettings`, `ProfileStats`, `ProfilePercentiles`, `InviteNode`, `RatioStats`). Updates profile, settings, invite tree, ratio stats, and search components.
- **Top 10 nav link** added between Forums and Wiki in the private header.
- **Top 10 leaderboard pages** — tabbed layout at `/private/top10` with pages for Releases, Users, Tags, Votes, and History. Each page has filter controls and an RTK Query service (`top10Api.ts`).
- **Release voting UI** — up/down vote buttons in the release detail sidebar with live aggregate display (% positive, total count). Clicking your current vote removes it.
- **Tag management UI** — Tags sidebar section is now interactive: add tags by name (Enter or + button), remove with ×. Mutations invalidate `Release` and `Top10` cache tags.

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] Navigate to a release page — vote up/down, confirm aggregate updates live
- [ ] Add and remove tags on a release
- [ ] Top 10 → Releases tab shows results; filters (period, limit, format, exclude tags) work
- [ ] Top 10 → Users/Tags/Votes tabs show graceful empty state on fresh DB
- [ ] Top 10 → History tab shows 404 message when no snapshots exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)