### PR TITLE
Surface launch checklist in staff bar

### DIFF
--- a/src/__tests__/admin/ModBar.test.tsx
+++ b/src/__tests__/admin/ModBar.test.tsx
@@ -5,6 +5,7 @@ import ModBar from '../../components/admin/ModBar';
 
 const mockUseAppSelector = jest.fn();
 const mockUseGetReportCountsQuery = jest.fn();
+const mockUseGetInstallStatusQuery = jest.fn();
 
 jest.mock('../../store/hooks', () => ({
   useAppSelector: (...args: unknown[]) => mockUseAppSelector(...args)
@@ -12,6 +13,10 @@ jest.mock('../../store/hooks', () => ({
 
 jest.mock('../../store/services/reportsApi', () => ({
   useGetReportCountsQuery: () => mockUseGetReportCountsQuery()
+}));
+
+jest.mock('../../store/services/installApi', () => ({
+  useGetInstallStatusQuery: () => mockUseGetInstallStatusQuery()
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -44,6 +49,9 @@ describe('ModBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseGetReportCountsQuery.mockReturnValue({ data: { open: 0 } });
+    mockUseGetInstallStatusQuery.mockReturnValue({
+      data: { setupChecklist: [] }
+    });
   });
 
   it('renders nothing for non-staff users', () => {
@@ -79,5 +87,42 @@ describe('ModBar', () => {
     renderWithProviders(<ModBar />);
     expect(screen.queryByText('0')).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: /reports/i })).toBeInTheDocument();
+  });
+
+  it('shows unresolved launch checklist items when setup is incomplete', () => {
+    mockUseAppSelector.mockReturnValue(staffUser);
+    mockUseGetInstallStatusQuery.mockReturnValue({
+      data: {
+        setupChecklist: [
+          'registrationStatus is still "open".',
+          'STELLAR_SITE_URL is not set.'
+        ]
+      }
+    });
+
+    renderWithProviders(<ModBar />);
+
+    expect(
+      screen.getByText(/configuration steps to complete before launch/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/registrationStatus is still "open"/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/STELLAR_SITE_URL is not set/i)
+    ).toBeInTheDocument();
+  });
+
+  it('hides the launch checklist when there are no unresolved items', () => {
+    mockUseAppSelector.mockReturnValue(staffUser);
+    mockUseGetInstallStatusQuery.mockReturnValue({
+      data: { setupChecklist: [] }
+    });
+
+    renderWithProviders(<ModBar />);
+
+    expect(
+      screen.queryByText(/configuration steps to complete before launch/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/pages/Install.test.tsx
+++ b/src/__tests__/pages/Install.test.tsx
@@ -9,16 +9,25 @@ const mockNavigate = jest.fn();
 const mockDispatch = jest.fn();
 let mockIsInstalling = false;
 
+let mockConfigWarnings: string[] = [];
+
 jest.mock('../../store/services/installApi', () => ({
   installApi: {
     util: {
       updateQueryData: jest.fn((...args: unknown[]) => {
         const fn = args[2];
-        if (typeof fn === 'function') fn({});
+        if (typeof fn === 'function') fn({ installed: false, registrationStatus: 'open', configWarnings: [] });
         return { type: 'mock' };
       })
     }
   },
+  useGetInstallStatusQuery: () => ({
+    data: {
+      installed: false,
+      registrationStatus: 'open',
+      configWarnings: mockConfigWarnings
+    }
+  }),
   useInstallMutation: () => [mockInstall, { isLoading: mockIsInstalling }]
 }));
 
@@ -40,48 +49,54 @@ const fillForm = async (
     confirm = 'secret123'
   } = {}
 ) => {
-  await user.type(
-    document.querySelector('input[autocomplete="username"]') as HTMLElement,
-    username
-  );
-  await user.type(
-    document.querySelector('input[autocomplete="email"]') as HTMLElement,
-    email
-  );
-  const passwordInputs = document.querySelectorAll(
-    'input[autocomplete="new-password"]'
-  );
-  await user.type(passwordInputs[0] as HTMLElement, password);
-  await user.type(passwordInputs[1] as HTMLElement, confirm);
+  await user.type(screen.getByLabelText(/username/i), username);
+  await user.type(screen.getByLabelText(/^email$/i), email);
+  await user.type(screen.getByLabelText(/^password$/i), password);
+  await user.type(screen.getByLabelText(/confirm password/i), confirm);
 };
 
 describe('Install', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsInstalling = false;
+    mockConfigWarnings = [];
   });
 
-  it('renders username, email, password, confirm fields and Install button', () => {
+  it('renders labeled fields and Install button', () => {
     renderWithProviders(<Install />);
-    expect(
-      document.querySelector('input[autocomplete="username"]')
-    ).toBeInTheDocument();
-    expect(
-      document.querySelector('input[autocomplete="email"]')
-    ).toBeInTheDocument();
-    const passwordInputs = document.querySelectorAll(
-      'input[autocomplete="new-password"]'
-    );
-    expect(passwordInputs.length).toBe(2);
-    expect(
-      screen.getByRole('button', { name: /^install$/i })
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^email$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^install$/i })).toBeInTheDocument();
   });
 
   it('shows explanatory text about what will be created', () => {
     renderWithProviders(<Install />);
     expect(screen.getByText(/first-time setup/i)).toBeInTheDocument();
     expect(screen.getAllByText(/sysop/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/5 gib/i)).toBeInTheDocument();
+    expect(screen.getByText(/pre-launch configuration checklist/i)).toBeInTheDocument();
+  });
+
+  it('shows configWarnings from install status when present', () => {
+    mockConfigWarnings = [
+      'STELLAR_SITE_URL is not set or uses the development default.',
+      'SMTP is not configured.'
+    ];
+    renderWithProviders(<Install />);
+    expect(
+      screen.getByText(/STELLAR_SITE_URL is not set or uses the development default./i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/SMTP is not configured./i)).toBeInTheDocument();
+  });
+
+  it('does not render the warnings panel when configWarnings is empty', () => {
+    mockConfigWarnings = [];
+    renderWithProviders(<Install />);
+    expect(
+      screen.queryByText(/environment configuration notes/i)
+    ).not.toBeInTheDocument();
   });
 
   it('calls install mutation with correct values on submit', async () => {
@@ -150,7 +165,7 @@ describe('Install', () => {
   it('shows "Installing…" when isLoading is true', () => {
     mockIsInstalling = true;
     renderWithProviders(<Install />);
-    expect(screen.getByDisplayValue(/installing…/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /installing…/i })).toBeInTheDocument();
   });
 
   it('dispatches fallback danger alert when install fails with no API message', async () => {

--- a/src/__tests__/pages/Install.test.tsx
+++ b/src/__tests__/pages/Install.test.tsx
@@ -16,7 +16,13 @@ jest.mock('../../store/services/installApi', () => ({
     util: {
       updateQueryData: jest.fn((...args: unknown[]) => {
         const fn = args[2];
-        if (typeof fn === 'function') fn({ installed: false, registrationStatus: 'open', configWarnings: [] });
+        if (typeof fn === 'function')
+          fn({
+            installed: false,
+            registrationStatus: 'open',
+            configWarnings: [],
+            setupChecklist: []
+          });
         return { type: 'mock' };
       })
     }
@@ -25,7 +31,8 @@ jest.mock('../../store/services/installApi', () => ({
     data: {
       installed: false,
       registrationStatus: 'open',
-      configWarnings: mockConfigWarnings
+      configWarnings: mockConfigWarnings,
+      setupChecklist: []
     }
   }),
   useInstallMutation: () => [mockInstall, { isLoading: mockIsInstalling }]
@@ -68,7 +75,9 @@ describe('Install', () => {
     expect(screen.getByLabelText(/^email$/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^install$/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^install$/i })
+    ).toBeInTheDocument();
   });
 
   it('shows explanatory text about what will be created', () => {
@@ -76,7 +85,9 @@ describe('Install', () => {
     expect(screen.getByText(/first-time setup/i)).toBeInTheDocument();
     expect(screen.getAllByText(/sysop/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/5 gib/i)).toBeInTheDocument();
-    expect(screen.getByText(/pre-launch configuration checklist/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/launch configuration reminders will remain visible/i)
+    ).toBeInTheDocument();
   });
 
   it('shows configWarnings from install status when present', () => {
@@ -86,7 +97,9 @@ describe('Install', () => {
     ];
     renderWithProviders(<Install />);
     expect(
-      screen.getByText(/STELLAR_SITE_URL is not set or uses the development default./i)
+      screen.getByText(
+        /STELLAR_SITE_URL is not set or uses the development default./i
+      )
     ).toBeInTheDocument();
     expect(screen.getByText(/SMTP is not configured./i)).toBeInTheDocument();
   });
@@ -165,7 +178,9 @@ describe('Install', () => {
   it('shows "Installing…" when isLoading is true', () => {
     mockIsInstalling = true;
     renderWithProviders(<Install />);
-    expect(screen.getByRole('button', { name: /installing…/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /installing…/i })
+    ).toBeInTheDocument();
   });
 
   it('dispatches fallback danger alert when install fails with no API message', async () => {

--- a/src/components/admin/ModBar.tsx
+++ b/src/components/admin/ModBar.tsx
@@ -3,38 +3,59 @@ import { useAppSelector } from '../../store/hooks';
 import { selectCurrentUser } from '../../store/slices/authSlice';
 import { isStaffUser } from '../../utils/permissions';
 import { useGetReportCountsQuery } from '../../store/services/reportsApi';
+import { useGetInstallStatusQuery } from '../../store/services/installApi';
 
 const ModBar = () => {
   const user = useAppSelector(selectCurrentUser);
   const { data: reportCounts } = useGetReportCountsQuery();
+  const { data: installStatus } = useGetInstallStatusQuery();
 
   if (!isStaffUser(user)) return null;
 
   const openReports = reportCounts?.open ?? 0;
+  const setupChecklist = installStatus?.setupChecklist ?? [];
 
   return (
     <div className="bg-amber-950/40 border-b border-amber-900/40">
-      <div className="max-w-7xl mx-auto px-4 py-1 flex items-center gap-3 text-xs text-amber-400">
-        <span className="font-semibold uppercase tracking-wide">Staff</span>
-        <span className="text-amber-800">|</span>
-        <Link
-          to="/private/staff/tools"
-          className="hover:text-amber-200 transition-colors"
-        >
-          Toolbox
-        </Link>
-        <span className="text-amber-800">|</span>
-        <Link
-          to="/private/staff/reports"
-          className="hover:text-amber-200 transition-colors flex items-center gap-1"
-        >
-          Reports
-          {openReports > 0 && (
-            <span className="bg-red-700 text-red-100 rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none">
-              {openReports}
+      <div className="max-w-7xl mx-auto px-4 py-1.5">
+        <div className="flex items-center gap-3 text-xs text-amber-400">
+          <span className="font-semibold uppercase tracking-wide">Staff</span>
+          <span className="text-amber-800">|</span>
+          <Link
+            to="/private/staff/tools"
+            className="hover:text-amber-200 transition-colors"
+          >
+            Toolbox
+          </Link>
+          <span className="text-amber-800">|</span>
+          <Link
+            to="/private/staff/reports"
+            className="hover:text-amber-200 transition-colors flex items-center gap-1"
+          >
+            Reports
+            {openReports > 0 && (
+              <span className="bg-red-700 text-red-100 rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none">
+                {openReports}
+              </span>
+            )}
+          </Link>
+        </div>
+
+        {setupChecklist.length > 0 && (
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-amber-200">
+            <span className="font-medium">
+              Configuration steps to complete before launch:
             </span>
-          )}
-        </Link>
+            {setupChecklist.map((item) => (
+              <span
+                key={item}
+                className="rounded border border-amber-800/70 bg-amber-900/30 px-2 py-0.5"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/pages/public/Install.tsx
+++ b/src/components/pages/public/Install.tsx
@@ -212,8 +212,8 @@ const Install = () => {
           buffer.
         </p>
         <p className="pt-1 text-gray-500">
-          A pre-launch configuration checklist will be waiting in your staff
-          inbox.
+          Launch configuration reminders will remain visible in the staff bar
+          until they are addressed.
         </p>
       </div>
     </div>

--- a/src/components/pages/public/Install.tsx
+++ b/src/components/pages/public/Install.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import {
   installApi,
+  useGetInstallStatusQuery,
   useInstallMutation
 } from '../../../store/services/installApi';
 import { useAppDispatch } from '../../../store/hooks';
@@ -20,6 +21,7 @@ const Install = () => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const [install, { isLoading }] = useInstallMutation();
+  const { data: installStatus } = useGetInstallStatusQuery();
 
   const {
     register,
@@ -39,10 +41,10 @@ const Install = () => {
 
       dispatch(setCredentials(user));
       dispatch(
-        installApi.util.updateQueryData('getInstallStatus', undefined, () => ({
-          installed: true,
-          registrationStatus: 'open' as const
-        }))
+        installApi.util.updateQueryData('getInstallStatus', undefined, (draft) => {
+          draft.installed = true;
+          draft.registrationStatus = 'open';
+        })
       );
       dispatch(addAlert('Installation complete. Welcome, SysOp.', 'success'));
       navigate('/private');
@@ -53,121 +55,150 @@ const Install = () => {
     }
   };
 
-  return (
-    <div className="thin">
-      <h2>Stellar — First-Time Setup</h2>
-      <p className="lead">
-        No ranks or users exist yet. Create the initial SysOp account to get
-        started. This form is only available on a fresh installation and will be
-        locked once complete.
-      </p>
+  const warnings = installStatus?.configWarnings ?? [];
 
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <table className="layout">
-          <tbody>
-            <tr>
-              <td className="label">Username</td>
-              <td>
-                <input
-                  type="text"
-                  {...register('username', {
-                    required: 'Username is required'
-                  })}
-                  autoComplete="username"
-                />
-                {errors.username && (
-                  <span className="error">{errors.username.message}</span>
-                )}
-              </td>
-            </tr>
-            <tr>
-              <td className="label">Email</td>
-              <td>
-                <input
-                  type="email"
-                  {...register('email', {
-                    required: 'Email is required',
-                    pattern: {
-                      value: /\S+@\S+\.\S+/,
-                      message: 'Invalid email address'
-                    }
-                  })}
-                  autoComplete="email"
-                />
-                {errors.email && (
-                  <span className="error">{errors.email.message}</span>
-                )}
-              </td>
-            </tr>
-            <tr>
-              <td className="label">Password</td>
-              <td>
-                <input
-                  type="password"
-                  {...register('password', {
-                    required: 'Password is required',
-                    minLength: {
-                      value: 8,
-                      message: 'Password must be at least 8 characters'
-                    }
-                  })}
-                  autoComplete="new-password"
-                />
-                {errors.password && (
-                  <span className="error">{errors.password.message}</span>
-                )}
-              </td>
-            </tr>
-            <tr>
-              <td className="label">Confirm Password</td>
-              <td>
-                <input
-                  type="password"
-                  {...register('confirmPassword', {
-                    required: 'Please confirm your password',
-                    validate: (v) => v === password || 'Passwords do not match'
-                  })}
-                  autoComplete="new-password"
-                />
-                {errors.confirmPassword && (
-                  <span className="error">
-                    {errors.confirmPassword.message}
-                  </span>
-                )}
-              </td>
-            </tr>
-            <tr>
-              <td />
-              <td>
-                <input
-                  type="submit"
-                  value={isLoading ? 'Installing…' : 'Install'}
-                  disabled={isLoading}
-                  className="button"
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
+  return (
+    <div className="w-full max-w-md">
+      <div className="text-center mb-8">
+        <h1 className="text-3xl font-black tracking-widest uppercase bg-gradient-to-r from-indigo-400 via-purple-400 to-indigo-300 bg-clip-text text-transparent mb-2">
+          Stellar
+        </h1>
+        <p className="text-gray-400 text-sm">First-time setup</p>
+      </div>
+
+      {warnings.length > 0 && (
+        <div className="mb-6 bg-amber-900/40 border border-amber-700 rounded-lg p-4">
+          <p className="text-amber-300 text-sm font-medium mb-2">
+            Environment configuration notes
+          </p>
+          <ul className="space-y-1">
+            {warnings.map((w, i) => (
+              <li key={i} className="text-amber-200 text-xs">
+                {w}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="bg-gray-800 rounded-xl border border-gray-700 p-6 space-y-4"
+      >
+        <div>
+          <label
+            htmlFor="install-username"
+            className="block text-sm font-medium text-gray-300 mb-1"
+          >
+            Username
+          </label>
+          <input
+            id="install-username"
+            type="text"
+            {...register('username', { required: 'Username is required' })}
+            autoComplete="username"
+            placeholder="sysop"
+            className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm placeholder-gray-500"
+          />
+          {errors.username && (
+            <p className="mt-1 text-xs text-red-400">{errors.username.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="install-email"
+            className="block text-sm font-medium text-gray-300 mb-1"
+          >
+            Email
+          </label>
+          <input
+            id="install-email"
+            type="email"
+            {...register('email', {
+              required: 'Email is required',
+              pattern: {
+                value: /\S+@\S+\.\S+/,
+                message: 'Invalid email address'
+              }
+            })}
+            autoComplete="email"
+            placeholder="you@example.com"
+            className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm placeholder-gray-500"
+          />
+          {errors.email && (
+            <p className="mt-1 text-xs text-red-400">{errors.email.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="install-password"
+            className="block text-sm font-medium text-gray-300 mb-1"
+          >
+            Password
+          </label>
+          <input
+            id="install-password"
+            type="password"
+            {...register('password', {
+              required: 'Password is required',
+              minLength: {
+                value: 8,
+                message: 'Password must be at least 8 characters'
+              }
+            })}
+            autoComplete="new-password"
+            placeholder="8+ characters"
+            className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm placeholder-gray-500"
+          />
+          {errors.password && (
+            <p className="mt-1 text-xs text-red-400">{errors.password.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="install-confirm"
+            className="block text-sm font-medium text-gray-300 mb-1"
+          >
+            Confirm Password
+          </label>
+          <input
+            id="install-confirm"
+            type="password"
+            {...register('confirmPassword', {
+              required: 'Please confirm your password',
+              validate: (v) => v === password || 'Passwords do not match'
+            })}
+            autoComplete="new-password"
+            placeholder="••••••••"
+            className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm placeholder-gray-500"
+          />
+          {errors.confirmPassword && (
+            <p className="mt-1 text-xs text-red-400">
+              {errors.confirmPassword.message}
+            </p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white font-medium py-2.5 px-4 rounded-lg transition-colors text-sm"
+        >
+          {isLoading ? 'Installing…' : 'Install'}
+        </button>
       </form>
 
-      <div className="thin">
-        <h3>What this will create</h3>
-        <ul>
-          <li>
-            <strong>User</strong> (level 100) — default registration rank
-          </li>
-          <li>
-            <strong>Power User</strong> (level 200) — promoted members
-          </li>
-          <li>
-            <strong>Staff</strong> (level 500) — moderators and staff
-          </li>
-          <li>
-            <strong>SysOp</strong> (level 1000) — full administrative access
-          </li>
-        </ul>
-        <p>Your account will be assigned the SysOp rank.</p>
+      <div className="mt-6 bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-xs text-gray-400 space-y-1">
+        <p className="font-medium text-gray-300 mb-2">What this creates</p>
+        <p>User ranks: User (100) · Power User (200) · Staff (500) · SysOp (1000)</p>
+        <p>Default forum structure (Site, Community, Music, Help, Staff, Trash)</p>
+        <p>Your account will be assigned the SysOp rank with a 5 GiB startup buffer.</p>
+        <p className="pt-1 text-gray-500">
+          A pre-launch configuration checklist will be waiting in your staff inbox.
+        </p>
       </div>
     </div>
   );

--- a/src/components/pages/public/Install.tsx
+++ b/src/components/pages/public/Install.tsx
@@ -41,10 +41,14 @@ const Install = () => {
 
       dispatch(setCredentials(user));
       dispatch(
-        installApi.util.updateQueryData('getInstallStatus', undefined, (draft) => {
-          draft.installed = true;
-          draft.registrationStatus = 'open';
-        })
+        installApi.util.updateQueryData(
+          'getInstallStatus',
+          undefined,
+          (draft) => {
+            draft.installed = true;
+            draft.registrationStatus = 'open';
+          }
+        )
       );
       dispatch(addAlert('Installation complete. Welcome, SysOp.', 'success'));
       navigate('/private');
@@ -101,7 +105,9 @@ const Install = () => {
             className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm placeholder-gray-500"
           />
           {errors.username && (
-            <p className="mt-1 text-xs text-red-400">{errors.username.message}</p>
+            <p className="mt-1 text-xs text-red-400">
+              {errors.username.message}
+            </p>
           )}
         </div>
 
@@ -153,7 +159,9 @@ const Install = () => {
             className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm placeholder-gray-500"
           />
           {errors.password && (
-            <p className="mt-1 text-xs text-red-400">{errors.password.message}</p>
+            <p className="mt-1 text-xs text-red-400">
+              {errors.password.message}
+            </p>
           )}
         </div>
 
@@ -193,11 +201,19 @@ const Install = () => {
 
       <div className="mt-6 bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-xs text-gray-400 space-y-1">
         <p className="font-medium text-gray-300 mb-2">What this creates</p>
-        <p>User ranks: User (100) · Power User (200) · Staff (500) · SysOp (1000)</p>
-        <p>Default forum structure (Site, Community, Music, Help, Staff, Trash)</p>
-        <p>Your account will be assigned the SysOp rank with a 5 GiB startup buffer.</p>
+        <p>
+          User ranks: User (100) · Power User (200) · Staff (500) · SysOp (1000)
+        </p>
+        <p>
+          Default forum structure (Site, Community, Music, Help, Staff, Trash)
+        </p>
+        <p>
+          Your account will be assigned the SysOp rank with a 5 GiB startup
+          buffer.
+        </p>
         <p className="pt-1 text-gray-500">
-          A pre-launch configuration checklist will be waiting in your staff inbox.
+          A pre-launch configuration checklist will be waiting in your staff
+          inbox.
         </p>
       </div>
     </div>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -200,6 +200,7 @@ export interface paths {
               installed: boolean;
               /** @enum {string} */
               registrationStatus: 'open' | 'invite' | 'closed';
+              configWarnings: string[];
             };
           };
         };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -201,6 +201,7 @@ export interface paths {
               /** @enum {string} */
               registrationStatus: 'open' | 'invite' | 'closed';
               configWarnings: string[];
+              setupChecklist: string[];
             };
           };
         };


### PR DESCRIPTION
Summary
- surface unresolved launch configuration items in the staff ModBar instead of promising a staff inbox ticket
- update the install page copy to match the real admin guidance path
- regenerate frontend OpenAPI types and add coverage for the launch checklist banner

Verification
- npm test -- --runTestsByPath src/__tests__/admin/ModBar.test.tsx src/__tests__/pages/Install.test.tsx
- npm run typecheck

Note
- npm run lint still reports a pre-existing unrelated failure in src/__tests__/releases/ReleaseBrowsePage.test.tsx
