### PR TITLE
Artist subscriptions, comment subscriptions, and notification improvements

### DIFF
--- a/src/__tests__/communities/ArtistPage.test.tsx
+++ b/src/__tests__/communities/ArtistPage.test.tsx
@@ -27,6 +27,13 @@ jest.mock('../../store/services/subscriptionApi', () => ({
   ]
 }));
 
+jest.mock('../../components/layout/CommentsSection', () => ({
+  __esModule: true,
+  default: ({ page, pageId }: { page: string; pageId: number }) => (
+    <div data-testid="artist-comments">{`${page}:${pageId}`}</div>
+  )
+}));
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => ({ id: '42' })
@@ -117,6 +124,9 @@ describe('ArtistPage', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Jazz Vault')).toBeInTheDocument();
     expect(screen.getByText('1959')).toBeInTheDocument();
+    expect(screen.getByTestId('artist-comments')).toHaveTextContent(
+      'artist:42'
+    );
   });
 
   it('shows vanity house badge when applicable', () => {

--- a/src/__tests__/communities/ArtistPage.test.tsx
+++ b/src/__tests__/communities/ArtistPage.test.tsx
@@ -6,6 +6,8 @@ import ArtistPage from '../../components/communities/ArtistPage';
 
 const mockUseGetArtistByIdQuery = jest.fn();
 const mockUseToggleArtistBookmarkMutation = jest.fn();
+const mockSubscribeArtist = jest.fn();
+const mockUnsubscribeArtist = jest.fn();
 const mockDispatch = jest.fn();
 
 jest.mock('../../store/services/artistApi', () => ({
@@ -15,6 +17,14 @@ jest.mock('../../store/services/artistApi', () => ({
 
 jest.mock('../../store/services/bookmarkApi', () => ({
   useToggleArtistBookmarkMutation: () => mockUseToggleArtistBookmarkMutation()
+}));
+
+jest.mock('../../store/services/subscriptionApi', () => ({
+  useSubscribeArtistMutation: () => [mockSubscribeArtist, { isLoading: false }],
+  useUnsubscribeArtistMutation: () => [
+    mockUnsubscribeArtist,
+    { isLoading: false }
+  ]
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -37,6 +47,7 @@ const makeArtist = (overrides = {}) => ({
   name: 'Miles Davis',
   description: 'Jazz legend',
   vanityHouse: false,
+  isSubscribed: false,
   tags: [{ tag: { id: 1, name: 'jazz' } }],
   similarTo: [{ similarArtist: { id: 10, name: 'John Coltrane' } }],
   aliases: [],
@@ -60,6 +71,12 @@ describe('ArtistPage', () => {
       jest.fn().mockResolvedValue({ bookmarked: true }),
       { isLoading: false }
     ]);
+    mockSubscribeArtist.mockReturnValue({
+      unwrap: () => Promise.resolve({ subscribed: true })
+    });
+    mockUnsubscribeArtist.mockReturnValue({
+      unwrap: () => Promise.resolve({ subscribed: false })
+    });
   });
 
   it('shows spinner while loading', () => {
@@ -335,5 +352,84 @@ describe('ArtistPage', () => {
     expect(screen.getByText('First')).toBeInTheDocument();
     expect(screen.getByText('Second')).toBeInTheDocument();
     expect(screen.getByText('1959')).toBeInTheDocument();
+  });
+
+  it('shows Subscribe button when not subscribed', () => {
+    mockUseGetArtistByIdQuery.mockReturnValue({
+      data: makeArtist({ isSubscribed: false }),
+      isLoading: false,
+      error: undefined
+    });
+    renderWithProviders(<ArtistPage />);
+    expect(
+      screen.getByRole('button', { name: 'Subscribe' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows Subscribed button when subscribed', () => {
+    mockUseGetArtistByIdQuery.mockReturnValue({
+      data: makeArtist({ isSubscribed: true }),
+      isLoading: false,
+      error: undefined
+    });
+    renderWithProviders(<ArtistPage />);
+    expect(
+      screen.getByRole('button', { name: 'Subscribed' })
+    ).toBeInTheDocument();
+  });
+
+  it('calls subscribeArtist and dispatches success alert when subscribing', async () => {
+    mockUseGetArtistByIdQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: undefined
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<ArtistPage />);
+    await user.click(screen.getByRole('button', { name: 'Subscribe' }));
+    expect(mockSubscribeArtist).toHaveBeenCalledWith(42);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ msg: 'Subscribed to artist.' })
+      })
+    );
+  });
+
+  it('calls unsubscribeArtist and dispatches success alert when unsubscribing', async () => {
+    mockUseGetArtistByIdQuery.mockReturnValue({
+      data: makeArtist({ isSubscribed: true }),
+      isLoading: false,
+      error: undefined
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<ArtistPage />);
+    await user.click(screen.getByRole('button', { name: 'Subscribed' }));
+    expect(mockUnsubscribeArtist).toHaveBeenCalledWith(42);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ msg: 'Unsubscribed from artist.' })
+      })
+    );
+  });
+
+  it('dispatches danger alert when subscribe fails', async () => {
+    mockSubscribeArtist.mockReturnValue({
+      unwrap: () => Promise.reject(new Error('error'))
+    });
+    mockUseGetArtistByIdQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: undefined
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<ArtistPage />);
+    await user.click(screen.getByRole('button', { name: 'Subscribe' }));
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          msg: 'Failed to update subscription.'
+        })
+      })
+    );
   });
 });

--- a/src/__tests__/communities/ReleasePage.test.tsx
+++ b/src/__tests__/communities/ReleasePage.test.tsx
@@ -11,6 +11,8 @@ const mockRemoveVote = jest.fn();
 const mockToggleBookmark = jest.fn();
 const mockAddTag = jest.fn();
 const mockRemoveTag = jest.fn();
+const mockSubscribeComments = jest.fn();
+const mockGetCommentSubscription = jest.fn();
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
 
@@ -30,6 +32,12 @@ jest.mock('../../store/services/bookmarkApi', () => ({
     mockToggleBookmark,
     { isLoading: false }
   ]
+}));
+
+jest.mock('../../store/services/subscriptionApi', () => ({
+  useGetCommentSubscriptionQuery: (...args: unknown[]) =>
+    mockGetCommentSubscription(...args),
+  useSubscribeCommentsMutation: () => [mockSubscribeComments, { isLoading: false }]
 }));
 
 jest.mock('react-redux', () => ({
@@ -115,6 +123,9 @@ describe('ReleasePage', () => {
     jest.clearAllMocks();
     mockGetCommunityByIdQuery.mockReturnValue({
       data: { id: 1, name: 'Jazz Community' }
+    });
+    mockGetCommentSubscription.mockReturnValue({
+      data: { subscribed: false }
     });
     mockVoteOn.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     mockRemoveVote.mockReturnValue({ unwrap: () => Promise.resolve({}) });

--- a/src/__tests__/layout/CommentsSection.test.tsx
+++ b/src/__tests__/layout/CommentsSection.test.tsx
@@ -44,7 +44,10 @@ jest.mock('../../store/services/commentApi', () => ({
 }));
 
 jest.mock('../../store/services/subscriptionApi', () => ({
-  useSubscribeCommentsMutation: () => [mockSubscribeComments]
+  useSubscribeCommentsMutation: () => [
+    mockSubscribeComments,
+    { isLoading: false }
+  ]
 }));
 
 let mockCurrentUser: { id: number; username: string } | null = {
@@ -81,7 +84,9 @@ describe('CommentsSection', () => {
     mockIsLoading = false;
     mockCurrentUser = { id: 99, username: 'bob' };
     mockCreateComment.mockReturnValue({ unwrap: () => Promise.resolve({}) });
-    mockSubscribeComments.mockReturnValue({});
+    mockSubscribeComments.mockReturnValue({
+      unwrap: () => Promise.resolve({})
+    });
   });
 
   it('shows loading state', () => {
@@ -240,11 +245,11 @@ describe('CommentsSection', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not show subscribe checkbox on release page', () => {
+  it('shows subscribe checkbox on release page', () => {
     renderWithProviders(<CommentsSection page="release" pageId={5} />);
     expect(
-      screen.queryByRole('checkbox', { name: /subscribe to comments/i })
-    ).not.toBeInTheDocument();
+      screen.getByRole('checkbox', { name: /subscribe to comments/i })
+    ).toBeInTheDocument();
   });
 
   it('calls subscribeComments when checkbox is checked on submit', async () => {
@@ -287,6 +292,28 @@ describe('CommentsSection', () => {
     await user.click(screen.getByRole('button', { name: /post comment/i }));
     await waitFor(() => {
       expect(checkbox).not.toBeChecked();
+    });
+  });
+
+  it('keeps form state when comment creation fails', async () => {
+    mockCreateComment.mockReturnValue({
+      unwrap: () => Promise.reject(new Error('nope'))
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<CommentsSection page="artist" pageId={3} />);
+    const checkbox = screen.getByRole('checkbox', {
+      name: /subscribe to comments/i
+    });
+    const textarea = screen.getByPlaceholderText(/add a comment/i);
+
+    await user.click(checkbox);
+    await user.type(textarea, 'Great');
+    await user.click(screen.getByRole('button', { name: /post comment/i }));
+
+    await waitFor(() => {
+      expect(mockSubscribeComments).not.toHaveBeenCalled();
+      expect((textarea as HTMLTextAreaElement).value).toBe('Great');
+      expect(checkbox).toBeChecked();
     });
   });
 });

--- a/src/__tests__/layout/CommentsSection.test.tsx
+++ b/src/__tests__/layout/CommentsSection.test.tsx
@@ -12,6 +12,7 @@ jest.mock('../../components/layout/Time', () => ({
 
 const mockCreateComment = jest.fn();
 const mockDeleteComment = jest.fn();
+const mockSubscribeComments = jest.fn();
 
 let mockCommentsData: unknown[] | undefined = [];
 let mockIsLoading = false;
@@ -40,6 +41,10 @@ jest.mock('../../store/services/commentApi', () => ({
   }),
   useCreateCommentMutation: () => [mockCreateComment, { isLoading: false }],
   useDeleteCommentMutation: () => [mockDeleteComment]
+}));
+
+jest.mock('../../store/services/subscriptionApi', () => ({
+  useSubscribeCommentsMutation: () => [mockSubscribeComments]
 }));
 
 let mockCurrentUser: { id: number; username: string } | null = {
@@ -76,6 +81,7 @@ describe('CommentsSection', () => {
     mockIsLoading = false;
     mockCurrentUser = { id: 99, username: 'bob' };
     mockCreateComment.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockSubscribeComments.mockReturnValue({});
   });
 
   it('shows loading state', () => {
@@ -225,5 +231,62 @@ describe('CommentsSection', () => {
     expect(
       screen.queryByPlaceholderText(/add a comment/i)
     ).not.toBeInTheDocument();
+  });
+
+  it('shows subscribe checkbox on subscribable pages (artist)', () => {
+    renderWithProviders(<CommentsSection page="artist" pageId={3} />);
+    expect(
+      screen.getByRole('checkbox', { name: /subscribe to comments/i })
+    ).toBeInTheDocument();
+  });
+
+  it('does not show subscribe checkbox on release page', () => {
+    renderWithProviders(<CommentsSection page="release" pageId={5} />);
+    expect(
+      screen.queryByRole('checkbox', { name: /subscribe to comments/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls subscribeComments when checkbox is checked on submit', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CommentsSection page="artist" pageId={3} />);
+    await user.click(
+      screen.getByRole('checkbox', { name: /subscribe to comments/i })
+    );
+    await user.type(screen.getByPlaceholderText(/add a comment/i), 'Great');
+    await user.click(screen.getByRole('button', { name: /post comment/i }));
+    await waitFor(() => {
+      expect(mockSubscribeComments).toHaveBeenCalledWith({
+        page: 'artist',
+        pageId: 3,
+        action: 'subscribe'
+      });
+    });
+  });
+
+  it('does not call subscribeComments when checkbox is unchecked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CommentsSection page="artist" pageId={3} />);
+    await user.type(screen.getByPlaceholderText(/add a comment/i), 'Great');
+    await user.click(screen.getByRole('button', { name: /post comment/i }));
+    await waitFor(() => {
+      expect(mockCreateComment).toHaveBeenCalled();
+    });
+    expect(mockSubscribeComments).not.toHaveBeenCalled();
+  });
+
+  it('resets subscribe checkbox to unchecked after submit', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CommentsSection page="communities" pageId={7} />);
+    const checkbox = screen.getByRole('checkbox', {
+      name: /subscribe to comments/i
+    });
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+    await user.type(screen.getByPlaceholderText(/add a comment/i), 'Hello');
+    await user.click(screen.getByRole('button', { name: /post comment/i }));
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+    });
   });
 });

--- a/src/__tests__/layout/NotificationCorner.test.tsx
+++ b/src/__tests__/layout/NotificationCorner.test.tsx
@@ -331,6 +331,35 @@ describe('NotificationCorner', () => {
     expect(mockMarkRead).not.toHaveBeenCalled();
   });
 
+  it('renders artist_release notification with correct text and link to release page', async () => {
+    mockNotificationsData = [
+      {
+        id: 8,
+        userId: 1,
+        type: 'artist_release',
+        actorId: 20,
+        createdAt: '2024-01-08',
+        readAt: null,
+        pageId: 101,
+        page: 'contributions',
+        postId: null,
+        source: { title: 'Kind of Blue', releaseId: 55, communityId: 3 },
+        actor: { id: 20, username: 'grace', avatar: null }
+      }
+    ];
+    mockUnreadCount = 1;
+
+    const user = userEvent.setup();
+    renderWithProviders(<NotificationCorner />);
+    await user.click(screen.getByRole('button', { name: /notifications/i }));
+
+    const link = screen.getByRole('link', {
+      name: /grace added a new contribution for Kind of Blue/i
+    });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/private/communities/3/releases/55');
+  });
+
   it('closes panel when close (✕) button is clicked', async () => {
     const user = userEvent.setup();
     renderWithProviders(<NotificationCorner />);

--- a/src/components/communities/ArtistPage.tsx
+++ b/src/components/communities/ArtistPage.tsx
@@ -2,6 +2,10 @@ import { Link, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { useGetArtistByIdQuery } from '../../store/services/artistApi';
 import { useToggleArtistBookmarkMutation } from '../../store/services/bookmarkApi';
+import {
+  useSubscribeArtistMutation,
+  useUnsubscribeArtistMutation
+} from '../../store/services/subscriptionApi';
 import { selectCurrentUser } from '../../store/slices/authSlice';
 import { addAlert } from '../../store/slices/alertSlice';
 import { useAppDispatch } from '../../store/hooks';
@@ -16,6 +20,10 @@ const ArtistPage = () => {
   const { data: artist, isLoading, error } = useGetArtistByIdQuery(artistId);
   const [toggleBookmark, { isLoading: bookmarking }] =
     useToggleArtistBookmarkMutation();
+  const [subscribeArtist, { isLoading: subscribing }] =
+    useSubscribeArtistMutation();
+  const [unsubscribeArtist, { isLoading: unsubscribing }] =
+    useUnsubscribeArtistMutation();
 
   const handleBookmark = async () => {
     try {
@@ -31,10 +39,25 @@ const ArtistPage = () => {
     }
   };
 
+  const handleSubscribe = async () => {
+    try {
+      if (isSubscribed) {
+        await unsubscribeArtist(artistId).unwrap();
+        dispatch(addAlert('Unsubscribed from artist.', 'success'));
+      } else {
+        await subscribeArtist(artistId).unwrap();
+        dispatch(addAlert('Subscribed to artist.', 'success'));
+      }
+    } catch {
+      dispatch(addAlert('Failed to update subscription.', 'danger'));
+    }
+  };
+
   if (isLoading) return <Spinner />;
   if (error || !artist)
     return <div className="p-4 text-red-400">Artist not found.</div>;
 
+  const isSubscribed = artist.isSubscribed ?? false;
   const tags = artist.tags ?? [];
   const similar = artist.similarTo ?? [];
   const aliases = artist.aliases ?? [];
@@ -66,14 +89,27 @@ const ArtistPage = () => {
             </span>
           )}
           {user && (
-            <button
-              onClick={handleBookmark}
-              disabled={bookmarking}
-              title="Bookmark artist"
-              className="ml-auto text-gray-500 hover:text-yellow-300 text-sm transition-colors disabled:opacity-50"
-            >
-              🔖
-            </button>
+            <div className="ml-auto flex items-center gap-2">
+              <button
+                onClick={handleSubscribe}
+                disabled={subscribing || unsubscribing}
+                className={`text-xs px-2 py-0.5 rounded border transition-colors disabled:opacity-50 ${
+                  isSubscribed
+                    ? 'border-indigo-600 text-indigo-400 hover:border-red-500 hover:text-red-400'
+                    : 'border-gray-600 text-gray-400 hover:border-indigo-500 hover:text-indigo-400'
+                }`}
+              >
+                {isSubscribed ? 'Subscribed' : 'Subscribe'}
+              </button>
+              <button
+                onClick={handleBookmark}
+                disabled={bookmarking}
+                title="Bookmark artist"
+                className="text-gray-500 hover:text-yellow-300 text-sm transition-colors disabled:opacity-50"
+              >
+                🔖
+              </button>
+            </div>
           )}
         </div>
         {artist.description && (

--- a/src/components/communities/ArtistPage.tsx
+++ b/src/components/communities/ArtistPage.tsx
@@ -10,6 +10,7 @@ import { selectCurrentUser } from '../../store/slices/authSlice';
 import { addAlert } from '../../store/slices/alertSlice';
 import { useAppDispatch } from '../../store/hooks';
 import Spinner from '../layout/Spinner';
+import CommentsSection from '../layout/CommentsSection';
 
 const ArtistPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -255,6 +256,7 @@ const ArtistPage = () => {
           </table>
         )}
       </div>
+      <CommentsSection page="artist" pageId={artistId} />
     </div>
   );
 };

--- a/src/components/communities/ReleasePage.tsx
+++ b/src/components/communities/ReleasePage.tsx
@@ -13,6 +13,10 @@ import {
 } from '../../store/services/communityApi';
 import type { MyVote, VoteAggregate } from '../../store/services/communityApi';
 import { useToggleReleaseBookmarkMutation } from '../../store/services/bookmarkApi';
+import {
+  useGetCommentSubscriptionQuery,
+  useSubscribeCommentsMutation
+} from '../../store/services/subscriptionApi';
 import { addAlert } from '../../store/slices/alertSlice';
 import Spinner from '../layout/Spinner';
 import DownloadButton from './DownloadButton';
@@ -53,6 +57,33 @@ const ReleasePage = () => {
     useRemoveVoteOnReleaseMutation();
   const [addTag, { isLoading: addingTag }] = useAddTagToReleaseMutation();
   const [removeTag] = useRemoveTagFromReleaseMutation();
+  const { data: commentSubData } = useGetCommentSubscriptionQuery(
+    { page: 'release', pageId: rId },
+    { skip: !user }
+  );
+  const isSubscribedToComments = commentSubData?.subscribed ?? false;
+  const [subscribeComments, { isLoading: subscribingComments }] =
+    useSubscribeCommentsMutation();
+
+  const handleCommentSubscribe = async () => {
+    try {
+      await subscribeComments({
+        page: 'release',
+        pageId: rId,
+        action: isSubscribedToComments ? 'unsubscribe' : 'subscribe'
+      }).unwrap();
+      dispatch(
+        addAlert(
+          isSubscribedToComments
+            ? 'Unsubscribed from comments.'
+            : 'Subscribed to comments.',
+          'success'
+        )
+      );
+    } catch {
+      dispatch(addAlert('Failed to update comment subscription.', 'danger'));
+    }
+  };
 
   const handleBookmark = async () => {
     try {
@@ -171,6 +202,16 @@ const ReleasePage = () => {
             [🔖 Bookmark]
           </button>
         )}
+        {user && (
+          <button
+            type="button"
+            onClick={handleCommentSubscribe}
+            disabled={subscribingComments}
+            className="hover:text-indigo-300 transition-colors disabled:opacity-50"
+          >
+            {isSubscribedToComments ? '[Unsubscribe]' : '[Subscribe]'}
+          </button>
+        )}
         <Link
           to={`/private/reports/new?targetType=Release&targetId=${rId}`}
           className="hover:text-indigo-300 transition-colors"
@@ -282,7 +323,11 @@ const ReleasePage = () => {
             </div>
           )}
 
-          <CommentsSection page="release" pageId={rId} />
+          <CommentsSection
+            page="release"
+            pageId={rId}
+            alreadySubscribed={isSubscribedToComments}
+          />
         </div>
 
         {/* Sidebar */}

--- a/src/components/layout/CommentsSection.tsx
+++ b/src/components/layout/CommentsSection.tsx
@@ -12,8 +12,8 @@ import { useSubscribeCommentsMutation } from '../../store/services/subscriptionA
 import { selectCurrentUser } from '../../store/slices/authSlice';
 import Time from './Time';
 
-// Pages where comment subscriptions are supported (SubscriptionPage enum excludes 'release')
 const SUBSCRIBABLE_PAGES: CommentPage[] = [
+  'release',
   'artist',
   'collages',
   'communities',
@@ -24,9 +24,14 @@ const SUBSCRIBABLE_PAGES: CommentPage[] = [
 interface Props {
   page: CommentPage;
   pageId: number;
+  alreadySubscribed?: boolean;
 }
 
-const CommentsSection = ({ page, pageId }: Props) => {
+const CommentsSection = ({
+  page,
+  pageId,
+  alreadySubscribed = false
+}: Props) => {
   const currentUser = useSelector(selectCurrentUser);
   const { data: comments, isLoading } = useGetCommentsQuery({ page, pageId });
   const [createComment, { isLoading: posting }] = useCreateCommentMutation();
@@ -34,39 +39,37 @@ const CommentsSection = ({ page, pageId }: Props) => {
 
   const [body, setBody] = useState('');
   const [subscribe, setSubscribe] = useState(false);
-  const [subscribeComments] = useSubscribeCommentsMutation();
-  const canSubscribe = SUBSCRIBABLE_PAGES.includes(page);
+  const [subscribeComments, { isLoading: subscribing }] =
+    useSubscribeCommentsMutation();
+  const canSubscribe = SUBSCRIBABLE_PAGES.includes(page) && !alreadySubscribed;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!body.trim()) return;
-    if (page === 'communities') {
-      await createComment({ page, body, communityId: pageId });
-    } else if (page === 'artist') {
-      await createComment({ page, body, artistId: pageId });
-    } else if (page === 'release') {
-      await createComment({ page, body, releaseId: pageId });
-    } else if (page === 'collages') {
-      await createComment({ page, body, collageId: pageId });
-    } else if (page === 'contributions') {
-      await createComment({ page, body, contributionId: pageId });
-    } else {
-      await createComment({ page, body, requestId: pageId });
+    try {
+      if (page === 'communities') {
+        await createComment({ page, body, communityId: pageId }).unwrap();
+      } else if (page === 'artist') {
+        await createComment({ page, body, artistId: pageId }).unwrap();
+      } else if (page === 'release') {
+        await createComment({ page, body, releaseId: pageId }).unwrap();
+      } else if (page === 'collages') {
+        await createComment({ page, body, collageId: pageId }).unwrap();
+      } else if (page === 'contributions') {
+        await createComment({ page, body, contributionId: pageId }).unwrap();
+      } else {
+        await createComment({ page, body, requestId: pageId }).unwrap();
+      }
+
+      if (subscribe && canSubscribe) {
+        await subscribeComments({ page, pageId, action: 'subscribe' }).unwrap();
+      }
+
+      setBody('');
+      setSubscribe(false);
+    } catch {
+      return;
     }
-    if (subscribe && canSubscribe) {
-      subscribeComments({
-        page: page as
-          | 'artist'
-          | 'collages'
-          | 'communities'
-          | 'contributions'
-          | 'requests',
-        pageId,
-        action: 'subscribe'
-      });
-    }
-    setBody('');
-    setSubscribe(false);
   };
 
   return (
@@ -159,7 +162,11 @@ const CommentsSection = ({ page, pageId }: Props) => {
             </label>
           )}
           {canSubscribe && <br />}
-          <input type="submit" value="Post comment" disabled={posting} />
+          <input
+            type="submit"
+            value="Post comment"
+            disabled={posting || subscribing}
+          />
         </form>
       )}
     </div>

--- a/src/components/layout/CommentsSection.tsx
+++ b/src/components/layout/CommentsSection.tsx
@@ -8,8 +8,18 @@ import {
   useCreateCommentMutation,
   useDeleteCommentMutation
 } from '../../store/services/commentApi';
+import { useSubscribeCommentsMutation } from '../../store/services/subscriptionApi';
 import { selectCurrentUser } from '../../store/slices/authSlice';
 import Time from './Time';
+
+// Pages where comment subscriptions are supported (SubscriptionPage enum excludes 'release')
+const SUBSCRIBABLE_PAGES: CommentPage[] = [
+  'artist',
+  'collages',
+  'communities',
+  'contributions',
+  'requests'
+];
 
 interface Props {
   page: CommentPage;
@@ -23,6 +33,9 @@ const CommentsSection = ({ page, pageId }: Props) => {
   const [deleteComment] = useDeleteCommentMutation();
 
   const [body, setBody] = useState('');
+  const [subscribe, setSubscribe] = useState(false);
+  const [subscribeComments] = useSubscribeCommentsMutation();
+  const canSubscribe = SUBSCRIBABLE_PAGES.includes(page);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -40,7 +53,20 @@ const CommentsSection = ({ page, pageId }: Props) => {
     } else {
       await createComment({ page, body, requestId: pageId });
     }
+    if (subscribe && canSubscribe) {
+      subscribeComments({
+        page: page as
+          | 'artist'
+          | 'collages'
+          | 'communities'
+          | 'contributions'
+          | 'requests',
+        pageId,
+        action: 'subscribe'
+      });
+    }
     setBody('');
+    setSubscribe(false);
   };
 
   return (
@@ -114,6 +140,25 @@ const CommentsSection = ({ page, pageId }: Props) => {
             required
           />
           <br />
+          {canSubscribe && (
+            <label
+              className="small"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                marginBottom: 4
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={subscribe}
+                onChange={(e) => setSubscribe(e.target.checked)}
+              />
+              Subscribe to comments
+            </label>
+          )}
+          {canSubscribe && <br />}
           <input type="submit" value="Post comment" disabled={posting} />
         </form>
       )}

--- a/src/components/layout/NotificationCorner.tsx
+++ b/src/components/layout/NotificationCorner.tsx
@@ -44,6 +44,7 @@ function sourcePath(n: Notification): string | null {
     case 'artist':
       return `/private/artists/${n.pageId}`;
     case 'contributions':
+    case 'release':
       if (!n.source?.releaseId || !n.source?.communityId) return null;
       return `/private/communities/${n.source.communityId}/releases/${n.source.releaseId}`;
     case 'collages':

--- a/src/components/layout/NotificationCorner.tsx
+++ b/src/components/layout/NotificationCorner.tsx
@@ -29,6 +29,8 @@ function renderNotificationText(
       return `${actor} added to ${title}`;
     case 'comment_sub':
       return `${actor} commented on ${title}`;
+    case 'artist_release':
+      return `${actor} added a new contribution for ${title}`;
     default:
       return `New notification in ${title}`;
   }
@@ -41,6 +43,9 @@ function sourcePath(n: Notification): string | null {
       return `/private/forums/${n.source.forumId}/topics/${n.pageId}#post${n.postId}`;
     case 'artist':
       return `/private/artists/${n.pageId}`;
+    case 'contributions':
+      if (!n.source?.releaseId || !n.source?.communityId) return null;
+      return `/private/communities/${n.source.communityId}/releases/${n.source.releaseId}`;
     case 'collages':
       return `/private/collages/${n.pageId}`;
     case 'requests':

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -52,7 +52,8 @@ export const api = createApi({
     'SiteHistory',
     'Draft',
     'WikiPage',
-    'Top10'
+    'Top10',
+    'ArtistSubscription'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/authApi.ts
+++ b/src/store/services/authApi.ts
@@ -61,6 +61,7 @@ export const authApi = api.injectEndpoints({
       async onQueryStarted(_, { dispatch, queryFulfilled }) {
         try {
           const { data } = await queryFulfilled;
+          dispatch(api.util.resetApiState());
           dispatch(setCredentials(data.user));
         } catch {
           // login component handles the error display

--- a/src/store/services/notificationApi.ts
+++ b/src/store/services/notificationApi.ts
@@ -5,7 +5,8 @@ export type NotificationType =
   | 'forum_sub'
   | 'request_filled'
   | 'collage_updated'
-  | 'comment_sub';
+  | 'comment_sub'
+  | 'artist_release';
 
 export interface NotificationActor {
   id: number;
@@ -16,6 +17,8 @@ export interface NotificationActor {
 export interface NotificationSource {
   title: string;
   forumId?: number;
+  releaseId?: number;
+  communityId?: number;
 }
 
 export interface Notification {

--- a/src/store/services/subscriptionApi.ts
+++ b/src/store/services/subscriptionApi.ts
@@ -31,6 +31,32 @@ export const subscriptionApi = api.injectEndpoints({
         body: data
       }),
       invalidatesTags: ['Subscription']
+    }),
+    getArtistSubscription: build.query<{ subscribed: boolean }, number>({
+      query: (artistId) => `/artists/${artistId}/subscribe`,
+      providesTags: (_result, _err, artistId) => [
+        { type: 'ArtistSubscription', id: artistId }
+      ]
+    }),
+    subscribeArtist: build.mutation<{ subscribed: boolean }, number>({
+      query: (artistId) => ({
+        url: `/artists/${artistId}/subscribe`,
+        method: 'POST'
+      }),
+      invalidatesTags: (_result, _err, artistId) => [
+        { type: 'ArtistSubscription', id: artistId },
+        { type: 'Artist', id: artistId }
+      ]
+    }),
+    unsubscribeArtist: build.mutation<{ subscribed: boolean }, number>({
+      query: (artistId) => ({
+        url: `/artists/${artistId}/subscribe`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: (_result, _err, artistId) => [
+        { type: 'ArtistSubscription', id: artistId },
+        { type: 'Artist', id: artistId }
+      ]
     })
   })
 });
@@ -38,5 +64,8 @@ export const subscriptionApi = api.injectEndpoints({
 export const {
   useGetSubscriptionsQuery,
   useSubscribeMutation,
-  useSubscribeCommentsMutation
+  useSubscribeCommentsMutation,
+  useGetArtistSubscriptionQuery,
+  useSubscribeArtistMutation,
+  useUnsubscribeArtistMutation
 } = subscriptionApi;

--- a/src/store/services/subscriptionApi.ts
+++ b/src/store/services/subscriptionApi.ts
@@ -9,6 +9,10 @@ type SubscribeArgs = NonNullable<
 type SubscribeCommentsArgs = NonNullable<
   paths['/subscriptions/subscribe-comments']['post']['requestBody']
 >['content']['application/json'];
+type CommentStatusArgs =
+  paths['/subscriptions/comment-status']['get']['parameters']['query'];
+type CommentStatusResponse =
+  paths['/subscriptions/comment-status']['get']['responses'][200]['content']['application/json'];
 
 export const subscriptionApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -30,7 +34,20 @@ export const subscriptionApi = api.injectEndpoints({
         method: 'POST',
         body: data
       }),
-      invalidatesTags: ['Subscription']
+      invalidatesTags: (_result, _err, { page, pageId }) => [
+        'Subscription',
+        { type: 'Subscription', id: `comment-${page}-${pageId}` }
+      ]
+    }),
+    getCommentSubscription: build.query<
+      CommentStatusResponse,
+      CommentStatusArgs
+    >({
+      query: ({ page, pageId }) =>
+        `/subscriptions/comment-status?page=${page}&pageId=${pageId}`,
+      providesTags: (_result, _err, { page, pageId }) => [
+        { type: 'Subscription', id: `comment-${page}-${pageId}` }
+      ]
     }),
     getArtistSubscription: build.query<{ subscribed: boolean }, number>({
       query: (artistId) => `/artists/${artistId}/subscribe`,
@@ -65,6 +82,7 @@ export const {
   useGetSubscriptionsQuery,
   useSubscribeMutation,
   useSubscribeCommentsMutation,
+  useGetCommentSubscriptionQuery,
   useGetArtistSubscriptionQuery,
   useSubscribeArtistMutation,
   useUnsubscribeArtistMutation

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -6767,6 +6767,7 @@ export interface components {
           name: string;
         } | null;
       }[];
+      isSubscribed?: boolean;
     };
     ArtistHistory: {
       id: number;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1348,7 +1348,13 @@ export interface paths {
         content: {
           'application/json': {
             /** @enum {string} */
-            page: 'forums' | 'artist' | 'collages' | 'requests' | 'communities';
+            page:
+              | 'forums'
+              | 'artist'
+              | 'collages'
+              | 'requests'
+              | 'communities'
+              | 'contributions';
             pageId: number;
             /** @enum {string} */
             action: 'subscribe' | 'unsubscribe';

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1354,7 +1354,8 @@ export interface paths {
               | 'collages'
               | 'requests'
               | 'communities'
-              | 'contributions';
+              | 'contributions'
+              | 'release';
             pageId: number;
             /** @enum {string} */
             action: 'subscribe' | 'unsubscribe';
@@ -1371,6 +1372,54 @@ export interface paths {
         };
       };
     };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/subscriptions/comment-status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query: {
+          /** @enum {string} */
+          page:
+            | 'forums'
+            | 'artist'
+            | 'collages'
+            | 'requests'
+            | 'communities'
+            | 'contributions'
+            | 'release';
+          pageId: number;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Comment subscription status */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              subscribed: boolean;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;


### PR DESCRIPTION
## Summary

- **Artist follow**: Subscribe/Unsubscribe button on artist pages; `ArtistSubscription` model; new-contribution notifications emitted to followers (`artist_release` type)
- **Comment subscriptions**: Subscribe checkbox in `CommentsSection` on all pages (artist, collages, communities, contributions, requests, release); `release` added to `SubscriptionPage` enum
- **Release page subscribe button**: Dedicated Subscribe/Unsubscribe action in the release page action row (next to Bookmark); hides the in-form checkbox when already subscribed
- **Notification rendering**: `artist_release` and `comment_sub` for release/contribution pages rendered correctly in `NotificationCorner` with links to the release
- **Auth cache hardening**: `resetApiState()` on login to flush any stale cross-user cache
- **Security fix**: `GET /api/contributions` now scoped to the authenticated user's own contributions
- **New API endpoint**: `GET /subscriptions/comment-status` for reading current comment subscription state

## Test plan

- [ ] Subscribe to an artist → create a contribution for a release linked to that artist → bell shows artist_release notification → clicking it navigates to the release page
- [ ] Unsubscribe from artist → create another contribution → no notification received
- [ ] On a release page: click Subscribe → button changes to Unsubscribe, in-form checkbox disappears → click Unsubscribe → button reverts, checkbox reappears
- [ ] Post a comment while subscribe checkbox is checked → subsequent comment by another user triggers a `comment_sub` notification
- [ ] Verify `GET /api/contributions` only returns the logged-in user's contributions
- [ ] `npx tsc --noEmit` clean in both repos
- [ ] `npm run test --no-coverage` passes in both repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)