### PR TITLE
Forum edit history UI

### DIFF
--- a/src/__tests__/forum/ForumTopicPost.test.tsx
+++ b/src/__tests__/forum/ForumTopicPost.test.tsx
@@ -347,7 +347,9 @@ describe('ForumTopicPost', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: /view edit history/i }));
+    await user.click(
+      screen.getByRole('button', { name: /view edit history/i })
+    );
 
     expect(screen.getAllByText('2024-03-03T00:00:00Z')).toHaveLength(2);
     expect(screen.getAllByText('2024-03-02T00:00:00Z')).toHaveLength(1);
@@ -370,8 +372,12 @@ describe('ForumTopicPost', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: /view edit history/i }));
-    await user.click(screen.getByRole('button', { name: /hide edit history/i }));
+    await user.click(
+      screen.getByRole('button', { name: /view edit history/i })
+    );
+    await user.click(
+      screen.getByRole('button', { name: /hide edit history/i })
+    );
 
     expect(screen.queryByText('Second draft')).not.toBeInTheDocument();
     expect(screen.queryByText('Original body')).not.toBeInTheDocument();

--- a/src/__tests__/forum/ForumTopicPost.test.tsx
+++ b/src/__tests__/forum/ForumTopicPost.test.tsx
@@ -47,6 +47,28 @@ const mockPost = {
   updatedAt: '2024-03-01T00:00:00Z'
 };
 
+const mockEditedPost = {
+  ...mockPost,
+  edits: [
+    {
+      id: 1,
+      forumPostId: 7,
+      editorId: 10,
+      previousBody: 'Original body',
+      editedAt: '2024-03-02T00:00:00Z',
+      editor: { id: 10, username: 'alice' }
+    },
+    {
+      id: 2,
+      forumPostId: 7,
+      editorId: 12,
+      previousBody: 'Second draft',
+      editedAt: '2024-03-03T00:00:00Z',
+      editor: { id: 12, username: 'charlie' }
+    }
+  ]
+};
+
 describe('ForumTopicPost', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -95,6 +117,19 @@ describe('ForumTopicPost', () => {
     expect(
       screen.queryByRole('button', { name: /edit/i })
     ).not.toBeInTheDocument();
+  });
+
+  it('shows Edit button for moderator even without ownership', () => {
+    renderWithProviders(
+      <ForumTopicPost
+        post={mockPost}
+        forumId={1}
+        topicId={5}
+        currentUserId={99}
+        canModerate={true}
+      />
+    );
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
   });
 
   it('shows Delete button for post owner', () => {
@@ -152,6 +187,21 @@ describe('ForumTopicPost', () => {
     await user.click(screen.getByRole('button', { name: /edit/i }));
     expect(screen.getByRole('textbox')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+
+  it('lets moderators open the edit form for another user post', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ForumTopicPost
+        post={mockPost}
+        forumId={1}
+        topicId={5}
+        currentUserId={99}
+        canModerate={true}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 
   it('calls updatePost on save with edited body', async () => {
@@ -263,5 +313,67 @@ describe('ForumTopicPost', () => {
     );
     await user.click(screen.getByRole('button', { name: /delete/i }));
     expect(mockDeletePost).not.toHaveBeenCalled();
+  });
+
+  it('renders the latest edit attribution for edited posts', () => {
+    renderWithProviders(
+      <ForumTopicPost post={mockEditedPost} forumId={1} topicId={5} />
+    );
+
+    expect(screen.getByText(/last edited by/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'charlie' })).toBeInTheDocument();
+    expect(screen.getByText('2024-03-03T00:00:00Z')).toBeInTheDocument();
+  });
+
+  it('does not show edit history control to non-moderators', () => {
+    renderWithProviders(
+      <ForumTopicPost post={mockEditedPost} forumId={1} topicId={5} />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /view edit history/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Original body')).not.toBeInTheDocument();
+  });
+
+  it('shows moderator edit history with previous revisions newest first', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ForumTopicPost
+        post={mockEditedPost}
+        forumId={1}
+        topicId={5}
+        canModerate={true}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /view edit history/i }));
+
+    expect(screen.getAllByText('2024-03-03T00:00:00Z')).toHaveLength(2);
+    expect(screen.getAllByText('2024-03-02T00:00:00Z')).toHaveLength(1);
+    expect(screen.getByText('Second draft')).toBeInTheDocument();
+    expect(screen.getByText('Original body')).toBeInTheDocument();
+
+    const historyBodies = screen.getAllByText(/Second draft|Original body/);
+    expect(historyBodies[0]).toHaveTextContent('Second draft');
+    expect(historyBodies[1]).toHaveTextContent('Original body');
+  });
+
+  it('hides moderator edit history after toggling closed', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ForumTopicPost
+        post={mockEditedPost}
+        forumId={1}
+        topicId={5}
+        canModerate={true}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /view edit history/i }));
+    await user.click(screen.getByRole('button', { name: /hide edit history/i }));
+
+    expect(screen.queryByText('Second draft')).not.toBeInTheDocument();
+    expect(screen.queryByText('Original body')).not.toBeInTheDocument();
   });
 });

--- a/src/components/forum/ForumTopicPost.tsx
+++ b/src/components/forum/ForumTopicPost.tsx
@@ -26,16 +26,18 @@ const ForumTopicPost = ({
   canModerate = false,
   onQuote
 }: Props) => {
-  const { id, author, body, createdAt } = post;
+  const { id, author, body, createdAt, edits } = post;
   const [editing, setEditing] = useState(false);
+  const [showEditHistory, setShowEditHistory] = useState(false);
   const [editBody, setEditBody] = useState(body);
 
   const [updatePost, { isLoading: saving }] = useUpdatePostMutation();
   const [deletePost] = useDeletePostMutation();
 
   const isOwner = !!currentUserId && currentUserId === author?.id;
-  const canEdit = isOwner;
+  const canEdit = isOwner || canModerate;
   const canDelete = isOwner || canModerate;
+  const latestEdit = edits.length > 0 ? edits[edits.length - 1] : null;
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -57,6 +59,12 @@ const ForumTopicPost = ({
     ADD_TAGS: ['blockquote', 'cite', 'u', 's', 'pre', 'code', 'ul', 'li'],
     ADD_ATTR: ['style', 'class', 'rel', 'target']
   });
+
+  const renderPostBody = (content: string) =>
+    DOMPurify.sanitize(parseBBCode(content), {
+      ADD_TAGS: ['blockquote', 'cite', 'u', 's', 'pre', 'code', 'ul', 'li'],
+      ADD_ATTR: ['style', 'class', 'rel', 'target']
+    });
 
   return (
     <div
@@ -155,6 +163,73 @@ const ForumTopicPost = ({
             className="flex-1 text-sm text-gray-300 bbcode-content"
             dangerouslySetInnerHTML={{ __html: renderedBody }}
           />
+        </div>
+      )}
+
+      {latestEdit && !editing && (
+        <div className="px-4 pb-4">
+          <div className="text-xs text-gray-500">
+            Last edited by{' '}
+            {latestEdit.editor ? (
+              <Link
+                to={`/private/user/${latestEdit.editor.username}`}
+                className="text-gray-400 hover:text-gray-200"
+              >
+                {latestEdit.editor.username}
+              </Link>
+            ) : (
+              'Unknown'
+            )}{' '}
+            <Time date={latestEdit.editedAt} />
+          </div>
+
+          {canModerate && (
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => setShowEditHistory((value) => !value)}
+                className="text-xs text-gray-400 hover:text-gray-200"
+              >
+                {showEditHistory ? 'Hide edit history' : 'View edit history'}
+              </button>
+
+              {showEditHistory && (
+                <div className="mt-3 space-y-3 rounded border border-gray-800 bg-gray-950/60 p-3">
+                  {[...edits].reverse().map((edit, index) => (
+                    <div
+                      key={edit.id}
+                      className={
+                        index === edits.length - 1
+                          ? ''
+                          : 'border-b border-gray-800 pb-3'
+                      }
+                    >
+                      <div className="mb-2 text-xs text-gray-500">
+                        Edited by{' '}
+                        {edit.editor ? (
+                          <Link
+                            to={`/private/user/${edit.editor.username}`}
+                            className="text-gray-400 hover:text-gray-200"
+                          >
+                            {edit.editor.username}
+                          </Link>
+                        ) : (
+                          'Unknown'
+                        )}{' '}
+                        <Time date={edit.editedAt} />
+                      </div>
+                      <div
+                        className="text-sm text-gray-300 bbcode-content"
+                        dangerouslySetInnerHTML={{
+                          __html: renderPostBody(edit.previousBody)
+                        }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/forum/ForumTopicPost.tsx
+++ b/src/components/forum/ForumTopicPost.tsx
@@ -37,7 +37,6 @@ const ForumTopicPost = ({
   const isOwner = !!currentUserId && currentUserId === author?.id;
   const canEdit = isOwner || canModerate;
   const canDelete = isOwner || canModerate;
-  const latestEdit = edits.length > 0 ? edits[edits.length - 1] : null;
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -65,6 +64,12 @@ const ForumTopicPost = ({
       ADD_TAGS: ['blockquote', 'cite', 'u', 's', 'pre', 'code', 'ul', 'li'],
       ADD_ATTR: ['style', 'class', 'rel', 'target']
     });
+
+  const latestEdit = edits.length > 0 ? edits[edits.length - 1] : null;
+  const renderedEdits = [...edits].reverse().map((edit) => ({
+    ...edit,
+    renderedPreviousBody: renderPostBody(edit.previousBody)
+  }));
 
   return (
     <div
@@ -195,7 +200,7 @@ const ForumTopicPost = ({
 
               {showEditHistory && (
                 <div className="mt-3 space-y-3 rounded border border-gray-800 bg-gray-950/60 p-3">
-                  {[...edits].reverse().map((edit, index) => (
+                  {renderedEdits.map((edit, index) => (
                     <div
                       key={edit.id}
                       className={
@@ -221,7 +226,7 @@ const ForumTopicPost = ({
                       <div
                         className="text-sm text-gray-300 bbcode-content"
                         dangerouslySetInnerHTML={{
-                          __html: renderPostBody(edit.previousBody)
+                          __html: edit.renderedPreviousBody
                         }}
                       />
                     </div>

--- a/src/components/forum/ForumTopicPost.tsx
+++ b/src/components/forum/ForumTopicPost.tsx
@@ -59,17 +59,8 @@ const ForumTopicPost = ({
     ADD_ATTR: ['style', 'class', 'rel', 'target']
   });
 
-  const renderPostBody = (content: string) =>
-    DOMPurify.sanitize(parseBBCode(content), {
-      ADD_TAGS: ['blockquote', 'cite', 'u', 's', 'pre', 'code', 'ul', 'li'],
-      ADD_ATTR: ['style', 'class', 'rel', 'target']
-    });
-
   const latestEdit = edits.length > 0 ? edits[edits.length - 1] : null;
-  const renderedEdits = [...edits].reverse().map((edit) => ({
-    ...edit,
-    renderedPreviousBody: renderPostBody(edit.previousBody)
-  }));
+  const renderedEdits = [...edits].reverse();
 
   return (
     <div
@@ -223,12 +214,9 @@ const ForumTopicPost = ({
                         )}{' '}
                         <Time date={edit.editedAt} />
                       </div>
-                      <div
-                        className="text-sm text-gray-300 bbcode-content"
-                        dangerouslySetInnerHTML={{
-                          __html: edit.renderedPreviousBody
-                        }}
-                      />
+                      <pre className="whitespace-pre-wrap break-words rounded bg-gray-900/80 p-3 text-sm text-gray-300">
+                        {edit.previousBody}
+                      </pre>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- add inline forum post last-edited metadata
- add staff-only revision history disclosure for forum posts
- expose edit controls to moderators editing other users' posts

## Verification
- npm test -- --runInBand src/__tests__/forum/ForumTopicPost.test.tsx
- npm run typecheck
