### PR TITLE
Add release tag UI and lazy forum edit history loading

### DIFF
--- a/src/__tests__/communities/ReleasePage.test.tsx
+++ b/src/__tests__/communities/ReleasePage.test.tsx
@@ -10,11 +10,19 @@ const mockVoteOn = jest.fn();
 const mockRemoveVote = jest.fn();
 const mockToggleBookmark = jest.fn();
 const mockAddTag = jest.fn();
+const mockVoteTag = jest.fn();
 const mockRemoveTag = jest.fn();
 const mockSubscribeComments = jest.fn();
 const mockGetCommentSubscription = jest.fn();
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
+const mockCurrentUser = {
+  id: 1,
+  username: 'testuser',
+  avatar: null,
+  canDownload: true,
+  userRank: { level: 100, name: 'User', color: '#fff', permissions: {} }
+};
 
 jest.mock('../../store/services/communityApi', () => ({
   useGetReleaseByIdQuery: (...args: unknown[]) =>
@@ -24,6 +32,7 @@ jest.mock('../../store/services/communityApi', () => ({
   useVoteOnReleaseMutation: () => [mockVoteOn, { isLoading: false }],
   useRemoveVoteOnReleaseMutation: () => [mockRemoveVote, { isLoading: false }],
   useAddTagToReleaseMutation: () => [mockAddTag, { isLoading: false }],
+  useVoteOnReleaseTagMutation: () => [mockVoteTag, { isLoading: false }],
   useRemoveTagFromReleaseMutation: () => [mockRemoveTag, { isLoading: false }]
 }));
 
@@ -37,18 +46,15 @@ jest.mock('../../store/services/bookmarkApi', () => ({
 jest.mock('../../store/services/subscriptionApi', () => ({
   useGetCommentSubscriptionQuery: (...args: unknown[]) =>
     mockGetCommentSubscription(...args),
-  useSubscribeCommentsMutation: () => [mockSubscribeComments, { isLoading: false }]
+  useSubscribeCommentsMutation: () => [
+    mockSubscribeComments,
+    { isLoading: false }
+  ]
 }));
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
-  useSelector: () => ({
-    id: 1,
-    username: 'testuser',
-    avatar: null,
-    canDownload: true,
-    userRank: { level: 100, name: 'User', color: '#fff' }
-  }),
+  useSelector: () => mockCurrentUser,
   useDispatch: () => mockDispatch
 }));
 
@@ -114,7 +120,8 @@ const makeRelease = (overrides: Record<string, unknown> = {}) => ({
   ],
   myVote: null,
   voteAggregate: null,
-  tags: [],
+  releaseTags: [],
+  historyEntries: [],
   ...overrides
 });
 
@@ -133,7 +140,9 @@ describe('ReleasePage', () => {
       unwrap: () => Promise.resolve({ bookmarked: true })
     });
     mockAddTag.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockVoteTag.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     mockRemoveTag.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockCurrentUser.userRank.permissions = {};
   });
 
   it('shows spinner while loading', () => {
@@ -270,9 +279,29 @@ describe('ReleasePage', () => {
   it('shows existing tags', () => {
     mockGetReleaseByIdQuery.mockReturnValue({
       data: makeRelease({
-        tags: [
-          { id: 1, name: 'jazz' },
-          { id: 2, name: 'modal' }
+        releaseTags: [
+          {
+            id: 1,
+            tagId: 1,
+            name: 'jazz',
+            occurrences: 4,
+            score: 6,
+            positiveVotes: 7,
+            negativeVotes: 1,
+            createdAt: '2024-01-01T00:00:00Z',
+            myVotes: { up: false, down: false }
+          },
+          {
+            id: 2,
+            tagId: 2,
+            name: 'modal',
+            occurrences: 3,
+            score: 2,
+            positiveVotes: 2,
+            negativeVotes: 0,
+            createdAt: '2024-01-01T00:00:00Z',
+            myVotes: { up: false, down: false }
+          }
         ]
       }),
       isLoading: false,
@@ -286,7 +315,7 @@ describe('ReleasePage', () => {
   it('calls addTag and clears input after adding a tag', async () => {
     const user = userEvent.setup();
     mockGetReleaseByIdQuery.mockReturnValue({
-      data: makeRelease({ tags: [] }),
+      data: makeRelease({ releaseTags: [] }),
       isLoading: false,
       error: undefined
     });
@@ -303,7 +332,7 @@ describe('ReleasePage', () => {
   it('calls addTag on Enter key in tag input', async () => {
     const user = userEvent.setup();
     mockGetReleaseByIdQuery.mockReturnValue({
-      data: makeRelease({ tags: [] }),
+      data: makeRelease({ releaseTags: [] }),
       isLoading: false,
       error: undefined
     });
@@ -312,10 +341,25 @@ describe('ReleasePage', () => {
     expect(mockAddTag).toHaveBeenCalled();
   });
 
-  it('calls removeTag when × button on a tag is clicked', async () => {
+  it('calls removeTag when a manager clicks remove on a tag', async () => {
     const user = userEvent.setup();
+    mockCurrentUser.userRank.permissions = { communities_manage: true };
     mockGetReleaseByIdQuery.mockReturnValue({
-      data: makeRelease({ tags: [{ id: 7, name: 'jazz' }] }),
+      data: makeRelease({
+        releaseTags: [
+          {
+            id: 7,
+            tagId: 7,
+            name: 'jazz',
+            occurrences: 4,
+            score: 3,
+            positiveVotes: 3,
+            negativeVotes: 0,
+            createdAt: '2024-01-01T00:00:00Z',
+            myVotes: { up: false, down: false }
+          }
+        ]
+      }),
       isLoading: false,
       error: undefined
     });
@@ -326,6 +370,88 @@ describe('ReleasePage', () => {
       releaseId: 5,
       tagId: 7
     });
+  });
+
+  it('calls voteOnReleaseTag with the selected direction', async () => {
+    const user = userEvent.setup();
+    mockGetReleaseByIdQuery.mockReturnValue({
+      data: makeRelease({
+        releaseTags: [
+          {
+            id: 7,
+            tagId: 7,
+            name: 'jazz',
+            occurrences: 4,
+            score: 3,
+            positiveVotes: 3,
+            negativeVotes: 0,
+            createdAt: '2024-01-01T00:00:00Z',
+            myVotes: { up: false, down: false }
+          }
+        ]
+      }),
+      isLoading: false,
+      error: undefined
+    });
+    renderWithProviders(<ReleasePage />);
+    await user.click(screen.getByRole('button', { name: /vote tag jazz up/i }));
+    expect(mockVoteTag).toHaveBeenCalledWith({
+      communityId: 1,
+      releaseId: 5,
+      tagId: 7,
+      direction: 'up'
+    });
+  });
+
+  it('does not show remove tag control to non-managers', () => {
+    mockGetReleaseByIdQuery.mockReturnValue({
+      data: makeRelease({
+        releaseTags: [
+          {
+            id: 7,
+            tagId: 7,
+            name: 'jazz',
+            occurrences: 4,
+            score: 3,
+            positiveVotes: 3,
+            negativeVotes: 0,
+            createdAt: '2024-01-01T00:00:00Z',
+            myVotes: { up: false, down: false }
+          }
+        ]
+      }),
+      isLoading: false,
+      error: undefined
+    });
+    renderWithProviders(<ReleasePage />);
+    expect(screen.queryByTitle('Remove tag')).not.toBeInTheDocument();
+  });
+
+  it('renders release history entries and snapshot details', async () => {
+    const user = userEvent.setup();
+    mockGetReleaseByIdQuery.mockReturnValue({
+      data: makeRelease({
+        historyEntries: [
+          {
+            id: 4,
+            action: 'edit',
+            summary: 'Updated title, tags',
+            changedFields: ['title', 'tags'],
+            before: { title: 'Old Title' },
+            after: { title: 'Kind of Blue' },
+            createdAt: '2024-01-02T00:00:00Z',
+            actor: { id: 9, username: 'editor' }
+          }
+        ]
+      }),
+      isLoading: false,
+      error: undefined
+    });
+    renderWithProviders(<ReleasePage />);
+    expect(screen.getByText(/updated title, tags/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'editor' })).toBeInTheDocument();
+    await user.click(screen.getByText(/view snapshot/i));
+    expect(screen.getByText(/old title/i)).toBeInTheDocument();
   });
 
   it('opens report modal on [Report] click and closes on close', async () => {
@@ -452,7 +578,7 @@ describe('ReleasePage', () => {
       unwrap: () => Promise.reject({ data: { msg: 'Tag already exists' } })
     });
     mockGetReleaseByIdQuery.mockReturnValue({
-      data: makeRelease({ tags: [] }),
+      data: makeRelease({ releaseTags: [] }),
       isLoading: false,
       error: undefined
     });
@@ -477,7 +603,7 @@ describe('ReleasePage', () => {
       unwrap: () => Promise.reject({})
     });
     mockGetReleaseByIdQuery.mockReturnValue({
-      data: makeRelease({ tags: [] }),
+      data: makeRelease({ releaseTags: [] }),
       isLoading: false,
       error: undefined
     });
@@ -498,11 +624,26 @@ describe('ReleasePage', () => {
 
   it('dispatches danger alert on removeTag failure', async () => {
     const user = userEvent.setup();
+    mockCurrentUser.userRank.permissions = { communities_manage: true };
     mockRemoveTag.mockReturnValue({
       unwrap: () => Promise.reject(new Error('fail'))
     });
     mockGetReleaseByIdQuery.mockReturnValue({
-      data: makeRelease({ tags: [{ id: 7, name: 'jazz' }] }),
+      data: makeRelease({
+        releaseTags: [
+          {
+            id: 7,
+            tagId: 7,
+            name: 'jazz',
+            occurrences: 4,
+            score: 3,
+            positiveVotes: 3,
+            negativeVotes: 0,
+            createdAt: '2024-01-01T00:00:00Z',
+            myVotes: { up: false, down: false }
+          }
+        ]
+      }),
       isLoading: false,
       error: undefined
     });

--- a/src/__tests__/forum/ForumTopicPost.test.tsx
+++ b/src/__tests__/forum/ForumTopicPost.test.tsx
@@ -28,10 +28,18 @@ jest.mock('react-router-dom', () => ({
 
 const mockUpdatePost = jest.fn();
 const mockDeletePost = jest.fn();
+const mockLoadEditHistory = jest.fn();
 
 let mockIsSaving = false;
+let mockEditHistoryData: { data: Array<Record<string, unknown>> } | undefined =
+  undefined;
+let mockEditHistoryLoading = false;
 
 jest.mock('../../store/services/forumApi', () => ({
+  useLazyGetPostEditHistoryQuery: () => [
+    mockLoadEditHistory,
+    { data: mockEditHistoryData, isFetching: mockEditHistoryLoading }
+  ],
   useUpdatePostMutation: () => [mockUpdatePost, { isLoading: mockIsSaving }],
   useDeletePostMutation: () => [mockDeletePost]
 }));
@@ -42,22 +50,23 @@ const mockPost = {
   authorId: 10,
   author: { id: 10, username: 'alice', avatar: null },
   body: 'Hello forum world',
-  edits: [],
   createdAt: '2024-03-01T00:00:00Z',
   updatedAt: '2024-03-01T00:00:00Z'
 };
 
 const mockEditedPost = {
   ...mockPost,
-  edits: [
-    {
-      id: 1,
-      forumPostId: 7,
-      editorId: 10,
-      previousBody: 'Original body',
-      editedAt: '2024-03-02T00:00:00Z',
-      editor: { id: 10, username: 'alice' }
-    },
+  lastEdit: {
+    id: 2,
+    forumPostId: 7,
+    editorId: 12,
+    editedAt: '2024-03-03T00:00:00Z',
+    editor: { id: 12, username: 'charlie' }
+  }
+};
+
+const mockEditHistory = {
+  data: [
     {
       id: 2,
       forumPostId: 7,
@@ -65,6 +74,14 @@ const mockEditedPost = {
       previousBody: 'Second draft',
       editedAt: '2024-03-03T00:00:00Z',
       editor: { id: 12, username: 'charlie' }
+    },
+    {
+      id: 1,
+      forumPostId: 7,
+      editorId: 10,
+      previousBody: 'Original body',
+      editedAt: '2024-03-02T00:00:00Z',
+      editor: { id: 10, username: 'alice' }
     }
   ]
 };
@@ -73,8 +90,11 @@ describe('ForumTopicPost', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsSaving = false;
+    mockEditHistoryData = undefined;
+    mockEditHistoryLoading = false;
     mockUpdatePost.mockResolvedValue({});
     mockDeletePost.mockResolvedValue({});
+    mockLoadEditHistory.mockResolvedValue({});
     window.confirm = jest.fn(() => true);
   });
 
@@ -338,6 +358,7 @@ describe('ForumTopicPost', () => {
 
   it('shows moderator edit history with previous revisions newest first', async () => {
     const user = userEvent.setup();
+    mockEditHistoryData = mockEditHistory;
     renderWithProviders(
       <ForumTopicPost
         post={mockEditedPost}
@@ -363,6 +384,7 @@ describe('ForumTopicPost', () => {
 
   it('hides moderator edit history after toggling closed', async () => {
     const user = userEvent.setup();
+    mockEditHistoryData = mockEditHistory;
     renderWithProviders(
       <ForumTopicPost
         post={mockEditedPost}
@@ -381,5 +403,46 @@ describe('ForumTopicPost', () => {
 
     expect(screen.queryByText('Second draft')).not.toBeInTheDocument();
     expect(screen.queryByText('Original body')).not.toBeInTheDocument();
+  });
+
+  it('loads moderator edit history on first open when not already cached', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ForumTopicPost
+        post={mockEditedPost}
+        forumId={1}
+        topicId={5}
+        canModerate={true}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: /view edit history/i })
+    );
+
+    expect(mockLoadEditHistory).toHaveBeenCalledWith({
+      forumId: 1,
+      topicId: 5,
+      postId: 7
+    });
+  });
+
+  it('shows loading state while moderator edit history is fetching', async () => {
+    const user = userEvent.setup();
+    mockEditHistoryLoading = true;
+    renderWithProviders(
+      <ForumTopicPost
+        post={mockEditedPost}
+        forumId={1}
+        topicId={5}
+        canModerate={true}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: /view edit history/i })
+    );
+
+    expect(screen.getByText(/loading edit history/i)).toBeInTheDocument();
   });
 });

--- a/src/__tests__/store/discussionApis.test.ts
+++ b/src/__tests__/store/discussionApis.test.ts
@@ -116,6 +116,22 @@ describe('discussion-oriented service APIs', () => {
       {
         run: (store: ReturnType<typeof createTestStore>) =>
           store.dispatch(
+            forumApi.endpoints.getPostEditHistory.initiate({
+              forumId: 4,
+              topicId: 8,
+              postId: 12
+            })
+          ),
+        response: { status: 200, body: { data: [] } },
+        expected: {
+          url: '/api/forums/4/topics/8/posts/12/edits',
+          method: 'GET',
+          body: ''
+        }
+      },
+      {
+        run: (store: ReturnType<typeof createTestStore>) =>
+          store.dispatch(
             forumApi.endpoints.createPost.initiate({
               forumId: 4,
               topicId: 8,

--- a/src/__tests__/store/resourceApis.test.ts
+++ b/src/__tests__/store/resourceApis.test.ts
@@ -172,6 +172,23 @@ describe('resource-oriented service APIs', () => {
       {
         run: (store: ReturnType<typeof createTestStore>) =>
           store.dispatch(
+            communityApi.endpoints.voteOnReleaseTag.initiate({
+              communityId: 9,
+              releaseId: 3,
+              tagId: 6,
+              direction: 'up'
+            })
+          ),
+        response: { status: 200, body: { id: 6, name: 'modal-jazz' } },
+        expected: {
+          url: '/api/communities/9/releases/3/tags/6/vote',
+          method: 'POST',
+          body: JSON.stringify({ direction: 'up' })
+        }
+      },
+      {
+        run: (store: ReturnType<typeof createTestStore>) =>
+          store.dispatch(
             communityApi.endpoints.removeTagFromRelease.initiate({
               communityId: 9,
               releaseId: 3,

--- a/src/components/communities/ReleasePage.tsx
+++ b/src/components/communities/ReleasePage.tsx
@@ -9,9 +9,15 @@ import {
   useVoteOnReleaseMutation,
   useRemoveVoteOnReleaseMutation,
   useAddTagToReleaseMutation,
+  useVoteOnReleaseTagMutation,
   useRemoveTagFromReleaseMutation
 } from '../../store/services/communityApi';
-import type { MyVote, VoteAggregate } from '../../store/services/communityApi';
+import type {
+  MyVote,
+  ReleaseHistoryEntry,
+  ReleaseTag,
+  VoteAggregate
+} from '../../store/services/communityApi';
 import { useToggleReleaseBookmarkMutation } from '../../store/services/bookmarkApi';
 import {
   useGetCommentSubscriptionQuery,
@@ -19,6 +25,7 @@ import {
 } from '../../store/services/subscriptionApi';
 import { addAlert } from '../../store/slices/alertSlice';
 import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
 import DownloadButton from './DownloadButton';
 import LinkStatusBadge from './LinkStatusBadge';
 import ReportContributionModal from './ReportContributionModal';
@@ -28,7 +35,14 @@ import type { LinkHealthStatus } from '../../types';
 type ReleaseWithVote = {
   myVote?: MyVote;
   voteAggregate?: VoteAggregate | null;
-  tags?: Array<{ id: number; name: string }>;
+  releaseTags?: ReleaseTag[];
+  historyEntries?: ReleaseHistoryEntry[];
+};
+
+const formatHistoryValue = (value: unknown) => {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value, null, 2);
 };
 
 const ReleasePage = () => {
@@ -56,7 +70,9 @@ const ReleasePage = () => {
   const [removeVote, { isLoading: unvoting }] =
     useRemoveVoteOnReleaseMutation();
   const [addTag, { isLoading: addingTag }] = useAddTagToReleaseMutation();
-  const [removeTag] = useRemoveTagFromReleaseMutation();
+  const [voteTag, { isLoading: votingTag }] = useVoteOnReleaseTagMutation();
+  const [removeTag, { isLoading: removingTag }] =
+    useRemoveTagFromReleaseMutation();
   const { data: commentSubData } = useGetCommentSubscriptionQuery(
     { page: 'release', pageId: rId },
     { skip: !user }
@@ -139,14 +155,33 @@ const ReleasePage = () => {
     }
   };
 
+  const handleVoteTag = async (tagId: number, direction: 'up' | 'down') => {
+    try {
+      await voteTag({
+        communityId: cId,
+        releaseId: rId,
+        tagId,
+        direction
+      }).unwrap();
+    } catch {
+      dispatch(addAlert('Failed to record tag vote.', 'danger'));
+    }
+  };
+
   if (isLoading) return <Spinner />;
   if (error || !release)
     return <div className="p-4 text-red-400">Release not found.</div>;
 
   const r = release as typeof release & ReleaseWithVote;
-  const tags = r.tags ?? [];
+  const tags = r.releaseTags ?? [];
   const myVote = r.myVote ?? null;
   const agg = r.voteAggregate ?? null;
+  const historyEntries = r.historyEntries ?? [];
+  const canManageTags = Boolean(
+    user?.userRank?.permissions?.communities_manage ||
+      user?.userRank?.permissions?.staff ||
+      user?.userRank?.permissions?.admin
+  );
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-6">
@@ -323,6 +358,70 @@ const ReleasePage = () => {
             </div>
           )}
 
+          <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+            <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 text-xs font-semibold uppercase tracking-wider text-gray-400">
+              History
+            </div>
+            {historyEntries.length > 0 ? (
+              <div className="divide-y divide-gray-800">
+                {historyEntries.map((entry) => {
+                  const hasSnapshot = entry.before || entry.after;
+                  return (
+                    <div key={entry.id} className="px-4 py-3 text-sm">
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-gray-300">
+                        <span>{entry.summary}</span>
+                        <span className="text-gray-600">by</span>
+                        <Link
+                          to={`/private/user/${entry.actor.username}`}
+                          className="text-indigo-400 hover:text-indigo-300"
+                        >
+                          {entry.actor.username}
+                        </Link>
+                        <span className="text-gray-600">
+                          <Time date={entry.createdAt} />
+                        </span>
+                      </div>
+                      {entry.changedFields.length > 0 && (
+                        <p className="mt-1 text-xs text-gray-500">
+                          Fields: {entry.changedFields.join(', ')}
+                        </p>
+                      )}
+                      {hasSnapshot && (
+                        <details className="mt-2">
+                          <summary className="cursor-pointer text-xs text-indigo-300 hover:text-indigo-200">
+                            View snapshot
+                          </summary>
+                          <div className="mt-2 grid gap-3 md:grid-cols-2">
+                            <div className="rounded border border-gray-800 bg-gray-950/60 p-3">
+                              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                                Before
+                              </p>
+                              <pre className="whitespace-pre-wrap break-words text-xs text-gray-300">
+                                {formatHistoryValue(entry.before)}
+                              </pre>
+                            </div>
+                            <div className="rounded border border-gray-800 bg-gray-950/60 p-3">
+                              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                                After
+                              </p>
+                              <pre className="whitespace-pre-wrap break-words text-xs text-gray-300">
+                                {formatHistoryValue(entry.after)}
+                              </pre>
+                            </div>
+                          </div>
+                        </details>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="px-4 py-4 text-sm text-gray-500">
+                No release history yet.
+              </div>
+            )}
+          </div>
+
           <CommentsSection
             page="release"
             pageId={rId}
@@ -416,22 +515,65 @@ const ReleasePage = () => {
             </div>
             <div className="px-3 py-2 space-y-2">
               {tags.length > 0 ? (
-                <div className="flex flex-wrap gap-1.5">
+                <div className="space-y-2">
                   {tags.map((t) => (
-                    <span
+                    <div
                       key={t.id}
-                      className="group flex items-center gap-1 text-xs px-2 py-0.5 bg-gray-800 text-indigo-300 rounded border border-gray-700"
+                      className="flex items-center justify-between gap-2 rounded border border-gray-700 bg-gray-800 px-2 py-1.5 text-xs"
                     >
-                      {t.name}
-                      <button
-                        type="button"
-                        title="Remove tag"
-                        onClick={() => handleRemoveTag(t.id)}
-                        className="text-gray-600 hover:text-red-400 transition-colors leading-none"
+                      <Link
+                        to={`/private/releases?tags=${encodeURIComponent(
+                          t.name
+                        )}`}
+                        className="min-w-0 truncate text-indigo-300 hover:text-indigo-200"
                       >
-                        ×
-                      </button>
-                    </span>
+                        {t.name}
+                      </Link>
+                      <div className="flex items-center gap-1 text-[11px]">
+                        <button
+                          type="button"
+                          title="Vote tag up"
+                          aria-label={`Vote tag ${t.name} up`}
+                          disabled={votingTag || t.myVotes.up}
+                          onClick={() => handleVoteTag(t.tagId, 'up')}
+                          className={`rounded border px-1.5 py-0.5 transition-colors disabled:opacity-50 ${
+                            t.myVotes.up
+                              ? 'border-green-600 bg-green-700/60 text-white'
+                              : 'border-gray-600 text-green-400 hover:bg-green-900/40'
+                          }`}
+                        >
+                          ▲
+                        </button>
+                        <span className="min-w-8 text-center text-gray-300">
+                          {t.score}
+                        </span>
+                        <button
+                          type="button"
+                          title="Vote tag down"
+                          aria-label={`Vote tag ${t.name} down`}
+                          disabled={votingTag || t.myVotes.down}
+                          onClick={() => handleVoteTag(t.tagId, 'down')}
+                          className={`rounded border px-1.5 py-0.5 transition-colors disabled:opacity-50 ${
+                            t.myVotes.down
+                              ? 'border-red-700 bg-red-800/60 text-white'
+                              : 'border-gray-600 text-red-400 hover:bg-red-900/40'
+                          }`}
+                        >
+                          ▼
+                        </button>
+                        {canManageTags && (
+                          <button
+                            type="button"
+                            title="Remove tag"
+                            onClick={() => handleRemoveTag(t.tagId)}
+                            disabled={removingTag}
+                            className="ml-1 text-gray-500 transition-colors hover:text-red-400 disabled:opacity-50"
+                          >
+                            ×
+                          </button>
+                        )}
+                      </div>
+                    </div>
                   ))}
                 </div>
               ) : (

--- a/src/components/forum/ForumTopicPost.tsx
+++ b/src/components/forum/ForumTopicPost.tsx
@@ -3,11 +3,12 @@ import { Link } from 'react-router-dom';
 import DOMPurify from 'dompurify';
 import Time from '../layout/Time';
 import {
+  useLazyGetPostEditHistoryQuery,
   useUpdatePostMutation,
   useDeletePostMutation
 } from '../../store/services/forumApi';
 import { parseBBCode, quotePost } from '../../utils/bbcode';
-import type { ForumPost } from '../../types';
+import type { ForumPost, ForumPostEdit } from '../../types';
 
 interface Props {
   post: ForumPost;
@@ -26,11 +27,15 @@ const ForumTopicPost = ({
   canModerate = false,
   onQuote
 }: Props) => {
-  const { id, author, body, createdAt, edits } = post;
+  const { id, author, body, createdAt, lastEdit } = post;
   const [editing, setEditing] = useState(false);
   const [showEditHistory, setShowEditHistory] = useState(false);
   const [editBody, setEditBody] = useState(body);
 
+  const [
+    loadEditHistory,
+    { data: editHistory, isFetching: loadingEditHistory }
+  ] = useLazyGetPostEditHistoryQuery();
   const [updatePost, { isLoading: saving }] = useUpdatePostMutation();
   const [deletePost] = useDeletePostMutation();
 
@@ -59,8 +64,19 @@ const ForumTopicPost = ({
     ADD_ATTR: ['style', 'class', 'rel', 'target']
   });
 
-  const latestEdit = edits.length > 0 ? edits[edits.length - 1] : null;
-  const renderedEdits = [...edits].reverse();
+  const renderedEdits: ForumPostEdit[] = editHistory?.data ?? [];
+
+  const toggleEditHistory = async () => {
+    if (showEditHistory) {
+      setShowEditHistory(false);
+      return;
+    }
+
+    setShowEditHistory(true);
+    if (!editHistory) {
+      await loadEditHistory({ forumId, topicId, postId: id });
+    }
+  };
 
   return (
     <div
@@ -162,28 +178,28 @@ const ForumTopicPost = ({
         </div>
       )}
 
-      {latestEdit && !editing && (
+      {lastEdit && !editing && (
         <div className="px-4 pb-4">
           <div className="text-xs text-gray-500">
             Last edited by{' '}
-            {latestEdit.editor ? (
+            {lastEdit.editor ? (
               <Link
-                to={`/private/user/${latestEdit.editor.username}`}
+                to={`/private/user/${lastEdit.editor.username}`}
                 className="text-gray-400 hover:text-gray-200"
               >
-                {latestEdit.editor.username}
+                {lastEdit.editor.username}
               </Link>
             ) : (
               'Unknown'
             )}{' '}
-            <Time date={latestEdit.editedAt} />
+            <Time date={lastEdit.editedAt} />
           </div>
 
           {canModerate && (
             <div className="mt-2">
               <button
                 type="button"
-                onClick={() => setShowEditHistory((value) => !value)}
+                onClick={toggleEditHistory}
                 className="text-xs text-gray-400 hover:text-gray-200"
               >
                 {showEditHistory ? 'Hide edit history' : 'View edit history'}
@@ -191,34 +207,45 @@ const ForumTopicPost = ({
 
               {showEditHistory && (
                 <div className="mt-3 space-y-3 rounded border border-gray-800 bg-gray-950/60 p-3">
-                  {renderedEdits.map((edit, index) => (
-                    <div
-                      key={edit.id}
-                      className={
-                        index === edits.length - 1
-                          ? ''
-                          : 'border-b border-gray-800 pb-3'
-                      }
-                    >
-                      <div className="mb-2 text-xs text-gray-500">
-                        Edited by{' '}
-                        {edit.editor ? (
-                          <Link
-                            to={`/private/user/${edit.editor.username}`}
-                            className="text-gray-400 hover:text-gray-200"
-                          >
-                            {edit.editor.username}
-                          </Link>
-                        ) : (
-                          'Unknown'
-                        )}{' '}
-                        <Time date={edit.editedAt} />
-                      </div>
-                      <pre className="whitespace-pre-wrap break-words rounded bg-gray-900/80 p-3 text-sm text-gray-300">
-                        {edit.previousBody}
-                      </pre>
+                  {loadingEditHistory && (
+                    <div className="text-xs text-gray-500">
+                      Loading edit history…
                     </div>
-                  ))}
+                  )}
+                  {!loadingEditHistory && renderedEdits.length === 0 && (
+                    <div className="text-xs text-gray-500">
+                      No edit history available.
+                    </div>
+                  )}
+                  {!loadingEditHistory &&
+                    renderedEdits.map((edit, index) => (
+                      <div
+                        key={edit.id}
+                        className={
+                          index === renderedEdits.length - 1
+                            ? ''
+                            : 'border-b border-gray-800 pb-3'
+                        }
+                      >
+                        <div className="mb-2 text-xs text-gray-500">
+                          Edited by{' '}
+                          {edit.editor ? (
+                            <Link
+                              to={`/private/user/${edit.editor.username}`}
+                              className="text-gray-400 hover:text-gray-200"
+                            >
+                              {edit.editor.username}
+                            </Link>
+                          ) : (
+                            'Unknown'
+                          )}{' '}
+                          <Time date={edit.editedAt} />
+                        </div>
+                        <pre className="whitespace-pre-wrap break-words rounded bg-gray-900/80 p-3 text-sm text-gray-300">
+                          {edit.previousBody}
+                        </pre>
+                      </div>
+                    ))}
                 </div>
               )}
             </div>

--- a/src/store/services/communityApi.ts
+++ b/src/store/services/communityApi.ts
@@ -17,8 +17,32 @@ export interface VoteResponse {
 
 export interface ReleaseTag {
   id: number;
+  tagId: number;
   name: string;
   occurrences: number;
+  score: number;
+  positiveVotes: number;
+  negativeVotes: number;
+  createdAt: string | null;
+  addedBy?: { id: number; username: string } | null;
+  myVotes: {
+    up: boolean;
+    down: boolean;
+  };
+}
+
+export interface ReleaseHistoryEntry {
+  id: number;
+  action: 'edit' | 'tag_added' | 'tag_removed';
+  summary: string;
+  changedFields: string[];
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  createdAt: string;
+  actor: {
+    id: number;
+    username: string;
+  };
 }
 
 interface ReleaseArgs {
@@ -32,8 +56,12 @@ type CommunityResponse =
   paths['/communities/{id}']['get']['responses'][200]['content']['application/json'];
 type CommunityReleasesResponse =
   paths['/communities/{id}/releases']['get']['responses'][200]['content']['application/json'];
-type ReleaseResponse =
+type GeneratedReleaseResponse =
   paths['/communities/{communityId}/releases/{releaseId}']['get']['responses'][200]['content']['application/json'];
+export type ReleaseResponse = GeneratedReleaseResponse & {
+  releaseTags?: ReleaseTag[];
+  historyEntries?: ReleaseHistoryEntry[];
+};
 type ContributionsResponse =
   paths['/contributions']['get']['responses'][200]['content']['application/json'];
 type CreateContributionArgs = NonNullable<
@@ -258,6 +286,20 @@ export const communityApi = api.injectEndpoints({
         ]
       }
     ),
+    voteOnReleaseTag: build.mutation<
+      ReleaseTag,
+      ReleaseArgs & { tagId: number; direction: 'up' | 'down' }
+    >({
+      query: ({ communityId, releaseId, tagId, direction }) => ({
+        url: `/communities/${communityId}/releases/${releaseId}/tags/${tagId}/vote`,
+        method: 'POST',
+        body: { direction }
+      }),
+      invalidatesTags: (_, __, { releaseId }) => [
+        { type: 'Release', id: releaseId },
+        'Top10'
+      ]
+    }),
     removeTagFromRelease: build.mutation<void, ReleaseArgs & { tagId: number }>(
       {
         query: ({ communityId, releaseId, tagId }) => ({
@@ -293,5 +335,6 @@ export const {
   useVoteOnReleaseMutation,
   useRemoveVoteOnReleaseMutation,
   useAddTagToReleaseMutation,
+  useVoteOnReleaseTagMutation,
   useRemoveTagFromReleaseMutation
 } = communityApi;

--- a/src/store/services/forumApi.ts
+++ b/src/store/services/forumApi.ts
@@ -70,6 +70,8 @@ type UpdatePostArgs = PostArgs &
   >['content']['application/json'];
 type UpdatePostResponse =
   paths['/forums/{forumId}/topics/{topicId}/posts/{id}']['put']['responses'][200]['content']['application/json'];
+type PostEditHistoryResponse =
+  paths['/forums/{forumId}/topics/{topicId}/posts/{id}/edits']['get']['responses'][200]['content']['application/json'];
 
 type PollResponse =
   paths['/forums/polls/{topicId}']['get']['responses'][200]['content']['application/json'];
@@ -198,6 +200,10 @@ export const forumApi = api.injectEndpoints({
         `/forums/${forumId}/topics/${topicId}/posts`,
       providesTags: (_, __, { topicId }) => [{ type: 'ForumPost', id: topicId }]
     }),
+    getPostEditHistory: build.query<PostEditHistoryResponse, PostArgs>({
+      query: ({ forumId, topicId, postId }) =>
+        `/forums/${forumId}/topics/${topicId}/posts/${postId}/edits`
+    }),
     createPost: build.mutation<CreatePostResponse, CreatePostArgs>({
       query: ({ forumId, topicId, ...data }) => ({
         url: `/forums/${forumId}/topics/${topicId}/posts`,
@@ -285,6 +291,7 @@ export const {
   useUpdateTopicMutation,
   useDeleteTopicMutation,
   useGetPostsByTopicQuery,
+  useLazyGetPostEditHistoryQuery,
   useCreatePostMutation,
   useUpdatePostMutation,
   useDeletePostMutation,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1388,7 +1388,6 @@ export interface paths {
     get: {
       parameters: {
         query: {
-          /** @enum {string} */
           page:
             | 'forums'
             | 'artist'
@@ -2179,6 +2178,65 @@ export interface paths {
         };
       };
     };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/forums/{forumId}/topics/{topicId}/posts/{id}/edits': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          forumId: string;
+          topicId: string;
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Moderator edit history */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['ForumPostEdit'][];
+            };
+          };
+        };
+        /** @description Insufficient permission */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -3421,6 +3479,100 @@ export interface paths {
           };
           content: {
             'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/artists/{id}/subscribe': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Subscription status */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              subscribed: boolean;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Subscribed */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              subscribed: boolean;
+            };
+          };
+        };
+        /** @description Artist not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Unsubscribed */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              subscribed: boolean;
+            };
           };
         };
       };
@@ -6546,7 +6698,14 @@ export interface components {
     };
     Notification: {
       id: number;
-      type: string;
+      /** @enum {string} */
+      type:
+        | 'forum_quote'
+        | 'forum_sub'
+        | 'request_filled'
+        | 'collage_updated'
+        | 'comment_sub'
+        | 'artist_release';
       actorId?: number | null;
       actor?: {
         id: number;
@@ -6561,6 +6720,8 @@ export interface components {
       source?: {
         title: string;
         forumId?: number;
+        releaseId?: number;
+        communityId?: number;
       } | null;
     };
     Subscription: {
@@ -6633,12 +6794,22 @@ export interface components {
         username: string;
       };
     };
+    ForumPostLastEdit: {
+      id: number;
+      forumPostId: number;
+      editorId: number;
+      editedAt: string;
+      editor?: {
+        id: number;
+        username: string;
+      };
+    };
     ForumPost: {
       id: number;
       forumTopicId: number;
       authorId: number;
       body: string;
-      edits: components['schemas']['ForumPostEdit'][];
+      lastEdit?: components['schemas']['ForumPostLastEdit'];
       author?: {
         id: number;
         username: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,7 @@ export type ForumCategory = components['schemas']['ForumCategory'];
 export type Forum = components['schemas']['Forum'];
 export type ForumTopic = components['schemas']['ForumTopic'];
 export type ForumPost = components['schemas']['ForumPost'];
+export type ForumPostEdit = components['schemas']['ForumPostEdit'];
 export type ForumPollVote = components['schemas']['ForumPollVote'];
 export type ForumPoll = components['schemas']['ForumPoll'];
 


### PR DESCRIPTION
## Summary
- add release tag voting and release history UI on the community release page
- wire the community API client and generated types to the new backend release contracts
- load forum post edit history on demand for moderators instead of receiving revision bodies in the thread payload

## Commits
- `939a3a1` Add tag voting UI and release history section
- `9f01560` Load forum edit history on demand for moderators

## Testing
- `npm run api:generate`
- `npm test -- --runInBand src/__tests__/forum/ForumTopicPost.test.tsx src/__tests__/store/discussionApis.test.ts`
- `npm run typecheck`
- `npm run lint`
