### PR TITLE
Add recovery queue page and staff trigger on user profile

### DIFF
--- a/src/__tests__/profile/UserProfile.test.tsx
+++ b/src/__tests__/profile/UserProfile.test.tsx
@@ -118,7 +118,8 @@ jest.mock('../../store/services/userApi', () => ({
   useRevokeDonorMutation: () => [mockRevokeDonor, { isLoading: false }],
   useRemoveUserWarningMutation: () => [mockRemoveUserWarning],
   useGetSnatchListByUserIdQuery: () => ({ data: mockSnatchListByUser }),
-  useGetSnatchListQuery: () => ({ data: mockSnatchList, isLoading: false })
+  useGetSnatchListQuery: () => ({ data: mockSnatchList, isLoading: false }),
+  useTriggerUserRecoveryMutation: () => [jest.fn(), { isLoading: false }]
 }));
 
 const mockProfile = {

--- a/src/components/admin/Toolbox.tsx
+++ b/src/components/admin/Toolbox.tsx
@@ -117,6 +117,11 @@ const sections: SectionProps[] = [
         label: 'Reports queue',
         to: '/private/staff/reports',
         permissions: ['staff', 'admin']
+      },
+      {
+        label: 'Recovery queue',
+        to: '/private/staff/tools/recovery-queue',
+        permissions: ['users_edit', 'admin']
       }
     ]
   },

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -57,6 +57,7 @@ import TicketQueuePage from '../../../staffInbox/TicketQueuePage';
 import SiteHistoryPage from '../../../staff/SiteHistoryPage';
 import MassPmPage from '../../../staff/MassPmPage';
 import DonorRanksPage from '../../../staff/DonorRanksPage';
+import RecoveryQueuePage from '../../../staff/RecoveryQueuePage';
 import SnatchList from '../snatch/SnatchList';
 import BookmarksPage from '../bookmarks/BookmarksPage';
 import WikiListPage from '../../../wiki/WikiListPage';
@@ -231,6 +232,14 @@ const PrivateContent = () => (
       element={
         <StaffGate permissions={['admin']}>
           <DonorRanksPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/tools/recovery-queue"
+      element={
+        <StaffGate permissions={['users_edit']}>
+          <RecoveryQueuePage />
         </StaffGate>
       }
     />

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -24,7 +24,8 @@ import {
   useRevokeDonorMutation,
   useRemoveUserWarningMutation,
   useGetSnatchListByUserIdQuery,
-  useGetSnatchListQuery
+  useGetSnatchListQuery,
+  useTriggerUserRecoveryMutation
 } from '../../store/services/userApi';
 import { addAlert } from '../../store/slices/alertSlice';
 import { getApiErrorMessage } from '../../utils/apiError';
@@ -190,6 +191,8 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
   const [grantDonor, { isLoading: isGrantingDonor }] = useGrantDonorMutation();
   const [revokeDonor, { isLoading: isRevokingDonor }] =
     useRevokeDonorMutation();
+  const [triggerRecovery, { isLoading: isSendingRecovery }] =
+    useTriggerUserRecoveryMutation();
 
   const handleDisableToggle = async () => {
     try {
@@ -287,6 +290,21 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
     }
   };
 
+  const handleTriggerRecovery = async () => {
+    if (!confirm('Send a password recovery email to this user?')) return;
+    try {
+      await triggerRecovery(profileId).unwrap();
+      dispatch(addAlert('Recovery email sent.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(
+          getApiErrorMessage(err) ?? 'Failed to send recovery email.',
+          'danger'
+        )
+      );
+    }
+  };
+
   const sectionClass = 'border border-gray-700 rounded-lg overflow-hidden';
   const headClass =
     'bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-wider text-gray-400 border-b border-gray-700';
@@ -323,6 +341,13 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
               }`}
             >
               {isDisabled ? 'Enable Account' : 'Disable Account'}
+            </button>
+            <button
+              onClick={handleTriggerRecovery}
+              disabled={isSendingRecovery}
+              className="px-3 py-1.5 bg-indigo-700 hover:bg-indigo-600 disabled:opacity-50 text-white text-xs rounded transition-colors"
+            >
+              {isSendingRecovery ? 'Sending…' : 'Send Recovery Email'}
             </button>
           </div>
 

--- a/src/components/staff/RecoveryQueuePage.tsx
+++ b/src/components/staff/RecoveryQueuePage.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import {
+  useGetRecoveryRequestsQuery,
+  useRevokeRecoveryRequestMutation
+} from '../../store/services/userApi';
+import { addAlert } from '../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../utils/apiError';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+type StatusFilter = 'pending' | 'used' | 'expired';
+
+const STATUS_TABS: { value: StatusFilter; label: string }[] = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'used', label: 'Used' },
+  { value: 'expired', label: 'Expired' }
+];
+
+const STATUS_BADGE: Record<StatusFilter, string> = {
+  pending: 'bg-yellow-800 text-yellow-200',
+  used: 'bg-green-800 text-green-200',
+  expired: 'bg-gray-700 text-gray-400'
+};
+
+const RecoveryQueuePage = () => {
+  const dispatch = useDispatch();
+  const [status, setStatus] = useState<StatusFilter>('pending');
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading, isFetching } = useGetRecoveryRequestsQuery({
+    page,
+    status
+  });
+
+  const [revoke, { isLoading: isRevoking }] =
+    useRevokeRecoveryRequestMutation();
+
+  const handleTabChange = (next: StatusFilter) => {
+    setStatus(next);
+    setPage(1);
+  };
+
+  const handleRevoke = async (id: number, username: string) => {
+    if (!confirm(`Revoke recovery token for ${username}?`)) return;
+    try {
+      await revoke(id).unwrap();
+      dispatch(addAlert('Recovery token revoked.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to revoke token.', 'danger')
+      );
+    }
+  };
+
+  const totalPages = data?.meta.totalPages ?? 1;
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+      <h1 className="text-xl font-semibold text-white">Recovery Queue</h1>
+
+      <div className="flex gap-2">
+        {STATUS_TABS.map((t) => (
+          <button
+            key={t.value}
+            onClick={() => handleTabChange(t.value)}
+            className={`px-3 py-1.5 text-sm rounded transition-colors ${
+              status === t.value
+                ? 'bg-indigo-600 text-white'
+                : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {isLoading ? (
+        <Spinner />
+      ) : !data?.data.length ? (
+        <p className="text-sm text-gray-500">No {status} recovery requests.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-700">
+          <table className="w-full text-sm text-gray-300">
+            <thead className="bg-gray-800 text-xs text-gray-400 uppercase tracking-wider">
+              <tr>
+                <th className="px-4 py-2 text-left">User</th>
+                <th className="px-4 py-2 text-left">Email</th>
+                <th className="px-4 py-2 text-left">Status</th>
+                <th className="px-4 py-2 text-left">Created</th>
+                <th className="px-4 py-2 text-left">Expires</th>
+                <th className="px-4 py-2 text-left">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800">
+              {data.data.map((row) => (
+                <tr key={row.id} className="hover:bg-gray-900">
+                  <td className="px-4 py-2">
+                    <Link
+                      to={`/private/user/${row.userId}`}
+                      className="text-indigo-400 hover:text-indigo-300"
+                    >
+                      {row.username}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-gray-400">{row.email}</td>
+                  <td className="px-4 py-2">
+                    <span
+                      className={`rounded px-2 py-0.5 text-xs font-medium ${
+                        STATUS_BADGE[row.status]
+                      }`}
+                    >
+                      {row.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-gray-500">
+                    <Time date={row.createdAt} />
+                  </td>
+                  <td className="px-4 py-2 text-gray-500">
+                    <Time date={row.expiresAt} />
+                  </td>
+                  <td className="px-4 py-2">
+                    {row.status === 'pending' && (
+                      <button
+                        onClick={() => handleRevoke(row.id, row.username)}
+                        disabled={isRevoking || isFetching}
+                        className="text-xs text-red-500 hover:text-red-400 disabled:opacity-50"
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex gap-2 items-center text-sm text-gray-400">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+            className="px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-40"
+          >
+            ‹ Prev
+          </button>
+          <span>
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page >= totalPages}
+            className="px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-40"
+          >
+            Next ›
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RecoveryQueuePage;

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -53,7 +53,8 @@ export const api = createApi({
     'Draft',
     'WikiPage',
     'Top10',
-    'ArtistSubscription'
+    'ArtistSubscription',
+    'RecoveryRequest'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/userApi.ts
+++ b/src/store/services/userApi.ts
@@ -242,6 +242,32 @@ export const userApi = api.injectEndpoints({
     >({
       query: (id) => `/users/${id}/snatch-list`,
       providesTags: (_, __, id) => [{ type: 'User', id }]
+    }),
+
+    // Staff recovery queue
+    getRecoveryRequests: build.query<
+      paths['/users/recovery-requests']['get']['responses'][200]['content']['application/json'],
+      { page?: number; status?: 'pending' | 'used' | 'expired' }
+    >({
+      query: ({ page = 1, status = 'pending' }) =>
+        `/users/recovery-requests?page=${page}&status=${status}`,
+      providesTags: ['RecoveryRequest']
+    }),
+    revokeRecoveryRequest: build.mutation<
+      paths['/users/recovery-requests/{reqId}']['delete']['responses'][200]['content']['application/json'],
+      number
+    >({
+      query: (id) => ({
+        url: `/users/recovery-requests/${id}`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: ['RecoveryRequest']
+    }),
+    triggerUserRecovery: build.mutation<
+      paths['/users/{id}/recovery']['post']['responses'][200]['content']['application/json'],
+      number
+    >({
+      query: (userId) => ({ url: `/users/${userId}/recovery`, method: 'POST' })
     })
   })
 });
@@ -272,5 +298,8 @@ export const {
   useGrantDonorMutation,
   useRevokeDonorMutation,
   useRemoveUserWarningMutation,
-  useGetSnatchListByUserIdQuery
+  useGetSnatchListByUserIdQuery,
+  useGetRecoveryRequestsQuery,
+  useRevokeRecoveryRequestMutation,
+  useTriggerUserRecoveryMutation
 } = userApi;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -468,6 +468,185 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/users/recovery-requests': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          status?: 'pending' | 'used' | 'expired';
+          page?: number;
+          limit?: number;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated list of account recovery requests */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['RecoveryRequestItem'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/users/recovery-requests/{reqId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          reqId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Recovery request revoked */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Token already used */
+        409: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/users/{id}/recovery': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Recovery email sent */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description User not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Email delivery not configured */
+        502: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/profile/me': {
     parameters: {
       query?: never;
@@ -6641,6 +6820,20 @@ export interface components {
       username: string;
       /** Format: email */
       email: string;
+    };
+    RecoveryRequestItem: {
+      id: number;
+      userId: number;
+      username: string;
+      email: string;
+      /** @enum {string} */
+      status: 'pending' | 'used' | 'expired';
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      expiresAt: string;
+      /** Format: date-time */
+      usedAt: string | null;
     };
     HomepageFeaturedRelease: {
       id: number;


### PR DESCRIPTION
## Summary

- **RecoveryQueuePage**: staff view at `/private/staff/tools/recovery-queue` — paginated table of pending/used/expired recovery tokens with filter tabs and per-row revoke button (pending only)
- **Toolbox**: "Recovery queue" link added to the Support section
- **UserProfile**: "Send Recovery Email" button added to `StaffActionsPanel`; calls `POST /api/users/:id/recovery`
- **userApi**: three new RTK Query endpoints (`getRecoveryRequests`, `revokeRecoveryRequest`, `triggerUserRecovery`) typed against generated OpenAPI types; `RecoveryRequest` tag added
- **api.ts**: regenerated from updated `openapi.json` — includes `RecoveryRequestItem` component and all three new path types

Pairs with stellar-api#29.

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run lint` — clean
- [ ] `npm test -- --watchAll=false` — 1111 passed
- [ ] As staff: navigate to Toolbox → Support → Recovery queue; confirm page loads and filter tabs work
- [ ] As staff: revoke a pending token from the queue; confirm it disappears
- [ ] On a user profile as staff: click "Send Recovery Email"; confirm success alert and that the target user receives the email

🤖 Generated with [Claude Code](https://claude.com/claude-code)