### PR TITLE
Release edit modal, history diff view, and revert UI

### DIFF
--- a/src/__tests__/communities/ReleasePage.test.tsx
+++ b/src/__tests__/communities/ReleasePage.test.tsx
@@ -6,6 +6,7 @@ import ReleasePage from '../../components/communities/ReleasePage';
 
 const mockGetReleaseByIdQuery = jest.fn();
 const mockGetCommunityByIdQuery = jest.fn();
+const mockGetReleaseHistoryQuery = jest.fn();
 const mockVoteOn = jest.fn();
 const mockRemoveVote = jest.fn();
 const mockToggleBookmark = jest.fn();
@@ -29,6 +30,8 @@ jest.mock('../../store/services/communityApi', () => ({
     mockGetReleaseByIdQuery(...args),
   useGetCommunityByIdQuery: (...args: unknown[]) =>
     mockGetCommunityByIdQuery(...args),
+  useGetReleaseHistoryQuery: (...args: unknown[]) =>
+    mockGetReleaseHistoryQuery(...args),
   useVoteOnReleaseMutation: () => [mockVoteOn, { isLoading: false }],
   useRemoveVoteOnReleaseMutation: () => [mockRemoveVote, { isLoading: false }],
   useAddTagToReleaseMutation: () => [mockAddTag, { isLoading: false }],
@@ -134,6 +137,7 @@ describe('ReleasePage', () => {
     mockGetCommentSubscription.mockReturnValue({
       data: { subscribed: false }
     });
+    mockGetReleaseHistoryQuery.mockReturnValue({ data: undefined, isLoading: false });
     mockVoteOn.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     mockRemoveVote.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     mockToggleBookmark.mockReturnValue({
@@ -238,7 +242,7 @@ describe('ReleasePage', () => {
       error: undefined
     });
     renderWithProviders(<ReleasePage />);
-    await user.click(screen.getByRole('button', { name: /▲/ }));
+    await user.click(screen.getByRole('button', { name: 'Vote up' }));
     expect(mockVoteOn).toHaveBeenCalledWith({
       communityId: 1,
       releaseId: 5,
@@ -254,7 +258,7 @@ describe('ReleasePage', () => {
       error: undefined
     });
     renderWithProviders(<ReleasePage />);
-    await user.click(screen.getByRole('button', { name: /▲/ }));
+    await user.click(screen.getByRole('button', { name: 'Vote up' }));
     expect(mockRemoveVote).toHaveBeenCalledWith({
       communityId: 1,
       releaseId: 5
@@ -430,25 +434,31 @@ describe('ReleasePage', () => {
   it('renders release history entries and snapshot details', async () => {
     const user = userEvent.setup();
     mockGetReleaseByIdQuery.mockReturnValue({
-      data: makeRelease({
-        historyEntries: [
+      data: makeRelease(),
+      isLoading: false,
+      error: undefined
+    });
+    mockGetReleaseHistoryQuery.mockReturnValue({
+      data: {
+        data: [
           {
             id: 4,
             action: 'edit',
             summary: 'Updated title, tags',
-            changedFields: ['title', 'tags'],
+            changedFields: ['title'],
             before: { title: 'Old Title' },
             after: { title: 'Kind of Blue' },
             createdAt: '2024-01-02T00:00:00Z',
             actor: { id: 9, username: 'editor' }
           }
-        ]
-      }),
-      isLoading: false,
-      error: undefined
+        ],
+        meta: { total: 1, page: 1, limit: 25 }
+      },
+      isLoading: false
     });
     renderWithProviders(<ReleasePage />);
-    expect(screen.getByText(/updated title, tags/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /history/i }));
+    expect(await screen.findByText(/updated title, tags/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'editor' })).toBeInTheDocument();
     await user.click(screen.getByText(/view snapshot/i));
     expect(screen.getByText(/old title/i)).toBeInTheDocument();
@@ -506,7 +516,7 @@ describe('ReleasePage', () => {
       error: undefined
     });
     renderWithProviders(<ReleasePage />);
-    await user.click(screen.getByRole('button', { name: /▼/ }));
+    await user.click(screen.getByRole('button', { name: 'Vote down' }));
     expect(mockVoteOn).toHaveBeenCalledWith({
       communityId: 1,
       releaseId: 5,
@@ -522,7 +532,7 @@ describe('ReleasePage', () => {
       error: undefined
     });
     renderWithProviders(<ReleasePage />);
-    await user.click(screen.getByRole('button', { name: /▼/ }));
+    await user.click(screen.getByRole('button', { name: 'Vote down' }));
     expect(mockRemoveVote).toHaveBeenCalledWith({
       communityId: 1,
       releaseId: 5
@@ -562,7 +572,7 @@ describe('ReleasePage', () => {
       error: undefined
     });
     renderWithProviders(<ReleasePage />);
-    await user.click(screen.getByRole('button', { name: /▲/ }));
+    await user.click(screen.getByRole('button', { name: 'Vote up' }));
     await waitFor(() => {
       expect(mockDispatch).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/__tests__/communities/ReleasePage.test.tsx
+++ b/src/__tests__/communities/ReleasePage.test.tsx
@@ -13,6 +13,7 @@ const mockToggleBookmark = jest.fn();
 const mockAddTag = jest.fn();
 const mockVoteTag = jest.fn();
 const mockRemoveTag = jest.fn();
+const mockRevertHistory = jest.fn();
 const mockSubscribeComments = jest.fn();
 const mockGetCommentSubscription = jest.fn();
 const mockDispatch = jest.fn();
@@ -36,7 +37,15 @@ jest.mock('../../store/services/communityApi', () => ({
   useRemoveVoteOnReleaseMutation: () => [mockRemoveVote, { isLoading: false }],
   useAddTagToReleaseMutation: () => [mockAddTag, { isLoading: false }],
   useVoteOnReleaseTagMutation: () => [mockVoteTag, { isLoading: false }],
-  useRemoveTagFromReleaseMutation: () => [mockRemoveTag, { isLoading: false }]
+  useRemoveTagFromReleaseMutation: () => [mockRemoveTag, { isLoading: false }],
+  useRevertReleaseHistoryMutation: () => [
+    mockRevertHistory,
+    { isLoading: false }
+  ],
+  useUpdateReleaseMutation: () => [
+    jest.fn().mockResolvedValue({}),
+    { isLoading: false }
+  ]
 }));
 
 jest.mock('../../store/services/bookmarkApi', () => ({
@@ -137,7 +146,10 @@ describe('ReleasePage', () => {
     mockGetCommentSubscription.mockReturnValue({
       data: { subscribed: false }
     });
-    mockGetReleaseHistoryQuery.mockReturnValue({ data: undefined, isLoading: false });
+    mockGetReleaseHistoryQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false
+    });
     mockVoteOn.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     mockRemoveVote.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     mockToggleBookmark.mockReturnValue({
@@ -460,8 +472,8 @@ describe('ReleasePage', () => {
     await user.click(screen.getByRole('button', { name: /history/i }));
     expect(await screen.findByText(/updated title, tags/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'editor' })).toBeInTheDocument();
-    await user.click(screen.getByText(/view snapshot/i));
-    expect(screen.getByText(/old title/i)).toBeInTheDocument();
+    expect(screen.getByText('Old Title')).toBeInTheDocument();
+    expect(screen.getByText('Title')).toBeInTheDocument();
   });
 
   it('opens report modal on [Report] click and closes on close', async () => {

--- a/src/components/communities/ReleasePage.tsx
+++ b/src/components/communities/ReleasePage.tsx
@@ -6,6 +6,7 @@ import CommentsSection from '../layout/CommentsSection';
 import {
   useGetReleaseByIdQuery,
   useGetCommunityByIdQuery,
+  useGetReleaseHistoryQuery,
   useVoteOnReleaseMutation,
   useRemoveVoteOnReleaseMutation,
   useAddTagToReleaseMutation,
@@ -14,7 +15,6 @@ import {
 } from '../../store/services/communityApi';
 import type {
   MyVote,
-  ReleaseHistoryEntry,
   ReleaseTag,
   VoteAggregate
 } from '../../store/services/communityApi';
@@ -36,7 +36,6 @@ type ReleaseWithVote = {
   myVote?: MyVote;
   voteAggregate?: VoteAggregate | null;
   releaseTags?: ReleaseTag[];
-  historyEntries?: ReleaseHistoryEntry[];
 };
 
 const formatHistoryValue = (value: unknown) => {
@@ -57,6 +56,7 @@ const ReleasePage = () => {
   const user = useSelector(selectCurrentUser);
   const [reportingId, setReportingId] = useState<number | null>(null);
   const [pendingTag, setPendingTag] = useState('');
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   const {
     data: release,
@@ -64,6 +64,11 @@ const ReleasePage = () => {
     error
   } = useGetReleaseByIdQuery({ communityId: cId, releaseId: rId });
   const { data: community } = useGetCommunityByIdQuery(cId);
+  const { data: historyData, isLoading: historyLoading } =
+    useGetReleaseHistoryQuery(
+      { communityId: cId, releaseId: rId },
+      { skip: !historyOpen }
+    );
   const [toggleBookmark, { isLoading: bookmarking }] =
     useToggleReleaseBookmarkMutation();
   const [voteOn, { isLoading: voting }] = useVoteOnReleaseMutation();
@@ -176,7 +181,7 @@ const ReleasePage = () => {
   const tags = r.releaseTags ?? [];
   const myVote = r.myVote ?? null;
   const agg = r.voteAggregate ?? null;
-  const historyEntries = r.historyEntries ?? [];
+  const historyEntries = historyData?.data ?? [];
   const canManageTags = Boolean(
     user?.userRank?.permissions?.communities_manage ||
       user?.userRank?.permissions?.staff ||
@@ -359,66 +364,78 @@ const ReleasePage = () => {
           )}
 
           <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
-            <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 text-xs font-semibold uppercase tracking-wider text-gray-400">
-              History
-            </div>
-            {historyEntries.length > 0 ? (
-              <div className="divide-y divide-gray-800">
-                {historyEntries.map((entry) => {
-                  const hasSnapshot = entry.before || entry.after;
-                  return (
-                    <div key={entry.id} className="px-4 py-3 text-sm">
-                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-gray-300">
-                        <span>{entry.summary}</span>
-                        <span className="text-gray-600">by</span>
-                        <Link
-                          to={`/private/user/${entry.actor.username}`}
-                          className="text-indigo-400 hover:text-indigo-300"
-                        >
-                          {entry.actor.username}
-                        </Link>
-                        <span className="text-gray-600">
-                          <Time date={entry.createdAt} />
-                        </span>
-                      </div>
-                      {entry.changedFields.length > 0 && (
-                        <p className="mt-1 text-xs text-gray-500">
-                          Fields: {entry.changedFields.join(', ')}
-                        </p>
-                      )}
-                      {hasSnapshot && (
-                        <details className="mt-2">
-                          <summary className="cursor-pointer text-xs text-indigo-300 hover:text-indigo-200">
-                            View snapshot
-                          </summary>
-                          <div className="mt-2 grid gap-3 md:grid-cols-2">
-                            <div className="rounded border border-gray-800 bg-gray-950/60 p-3">
-                              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
-                                Before
-                              </p>
-                              <pre className="whitespace-pre-wrap break-words text-xs text-gray-300">
-                                {formatHistoryValue(entry.before)}
-                              </pre>
-                            </div>
-                            <div className="rounded border border-gray-800 bg-gray-950/60 p-3">
-                              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
-                                After
-                              </p>
-                              <pre className="whitespace-pre-wrap break-words text-xs text-gray-300">
-                                {formatHistoryValue(entry.after)}
-                              </pre>
-                            </div>
+            <button
+              onClick={() => setHistoryOpen((o) => !o)}
+              className="w-full bg-gray-800 border-b border-gray-700 px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-400 hover:text-gray-200 flex items-center justify-between"
+            >
+              <span>History</span>
+              <span>{historyOpen ? '▲' : '▼'}</span>
+            </button>
+            {historyOpen && (
+              <>
+                {historyLoading ? (
+                  <div className="px-4 py-4">
+                    <Spinner />
+                  </div>
+                ) : historyEntries.length > 0 ? (
+                  <div className="divide-y divide-gray-800">
+                    {historyEntries.map((entry) => {
+                      const hasSnapshot = entry.before || entry.after;
+                      return (
+                        <div key={entry.id} className="px-4 py-3 text-sm">
+                          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-gray-300">
+                            <span>{entry.summary}</span>
+                            <span className="text-gray-600">by</span>
+                            <Link
+                              to={`/private/user/${entry.actor.username}`}
+                              className="text-indigo-400 hover:text-indigo-300"
+                            >
+                              {entry.actor.username}
+                            </Link>
+                            <span className="text-gray-600">
+                              <Time date={entry.createdAt} />
+                            </span>
                           </div>
-                        </details>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="px-4 py-4 text-sm text-gray-500">
-                No release history yet.
-              </div>
+                          {entry.changedFields.length > 0 && (
+                            <p className="mt-1 text-xs text-gray-500">
+                              Fields: {entry.changedFields.join(', ')}
+                            </p>
+                          )}
+                          {hasSnapshot && (
+                            <details className="mt-2">
+                              <summary className="cursor-pointer text-xs text-indigo-300 hover:text-indigo-200">
+                                View snapshot
+                              </summary>
+                              <div className="mt-2 grid gap-3 md:grid-cols-2">
+                                <div className="rounded border border-gray-800 bg-gray-950/60 p-3">
+                                  <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                                    Before
+                                  </p>
+                                  <pre className="whitespace-pre-wrap break-words text-xs text-gray-300">
+                                    {formatHistoryValue(entry.before)}
+                                  </pre>
+                                </div>
+                                <div className="rounded border border-gray-800 bg-gray-950/60 p-3">
+                                  <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                                    After
+                                  </p>
+                                  <pre className="whitespace-pre-wrap break-words text-xs text-gray-300">
+                                    {formatHistoryValue(entry.after)}
+                                  </pre>
+                                </div>
+                              </div>
+                            </details>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="px-4 py-4 text-sm text-gray-500">
+                    No release history yet.
+                  </div>
+                )}
+              </>
             )}
           </div>
 
@@ -454,6 +471,7 @@ const ReleasePage = () => {
               <div className="flex gap-2">
                 <button
                   type="button"
+                  aria-label="Vote up"
                   disabled={voting || unvoting}
                   onClick={() => handleVote(true)}
                   className={`flex-1 py-1.5 text-sm rounded border transition-colors disabled:opacity-50 ${
@@ -466,6 +484,7 @@ const ReleasePage = () => {
                 </button>
                 <button
                   type="button"
+                  aria-label="Vote down"
                   disabled={voting || unvoting}
                   onClick={() => handleVote(false)}
                   className={`flex-1 py-1.5 text-sm rounded border transition-colors disabled:opacity-50 ${
@@ -534,10 +553,10 @@ const ReleasePage = () => {
                           type="button"
                           title="Vote tag up"
                           aria-label={`Vote tag ${t.name} up`}
-                          disabled={votingTag || t.myVotes.up}
+                          disabled={votingTag || t.myVotes?.up}
                           onClick={() => handleVoteTag(t.tagId, 'up')}
                           className={`rounded border px-1.5 py-0.5 transition-colors disabled:opacity-50 ${
-                            t.myVotes.up
+                            t.myVotes?.up
                               ? 'border-green-600 bg-green-700/60 text-white'
                               : 'border-gray-600 text-green-400 hover:bg-green-900/40'
                           }`}
@@ -551,10 +570,10 @@ const ReleasePage = () => {
                           type="button"
                           title="Vote tag down"
                           aria-label={`Vote tag ${t.name} down`}
-                          disabled={votingTag || t.myVotes.down}
+                          disabled={votingTag || t.myVotes?.down}
                           onClick={() => handleVoteTag(t.tagId, 'down')}
                           className={`rounded border px-1.5 py-0.5 transition-colors disabled:opacity-50 ${
-                            t.myVotes.down
+                            t.myVotes?.down
                               ? 'border-red-700 bg-red-800/60 text-white'
                               : 'border-gray-600 text-red-400 hover:bg-red-900/40'
                           }`}

--- a/src/components/communities/ReleasePage.tsx
+++ b/src/components/communities/ReleasePage.tsx
@@ -11,7 +11,9 @@ import {
   useRemoveVoteOnReleaseMutation,
   useAddTagToReleaseMutation,
   useVoteOnReleaseTagMutation,
-  useRemoveTagFromReleaseMutation
+  useRemoveTagFromReleaseMutation,
+  useRevertReleaseHistoryMutation,
+  useUpdateReleaseMutation
 } from '../../store/services/communityApi';
 import type {
   MyVote,
@@ -38,10 +40,24 @@ type ReleaseWithVote = {
   releaseTags?: ReleaseTag[];
 };
 
-const formatHistoryValue = (value: unknown) => {
+const FIELD_LABELS: Record<string, string> = {
+  title: 'Title',
+  description: 'Description',
+  image: 'Cover art',
+  year: 'Year',
+  isEdition: 'Edition',
+  edition: 'Edition data'
+};
+
+const formatFieldValue = (field: string, value: unknown): string => {
   if (value === null || value === undefined) return '—';
-  if (typeof value === 'string') return value;
-  return JSON.stringify(value, null, 2);
+  if (field === 'description' && typeof value === 'string') {
+    return value.length > 120 ? value.slice(0, 120) + '…' : value;
+  }
+  if (field === 'isEdition') return value ? 'Yes' : 'No';
+  if (typeof value === 'string' || typeof value === 'number')
+    return String(value);
+  return JSON.stringify(value);
 };
 
 const ReleasePage = () => {
@@ -57,6 +73,17 @@ const ReleasePage = () => {
   const [reportingId, setReportingId] = useState<number | null>(null);
   const [pendingTag, setPendingTag] = useState('');
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [revertingId, setRevertingId] = useState<number | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editForm, setEditForm] = useState({
+    title: '',
+    description: '',
+    year: 0,
+    image: '',
+    isEdition: false,
+    editSummary: ''
+  });
+  const [editError, setEditError] = useState<string | null>(null);
 
   const {
     data: release,
@@ -78,6 +105,8 @@ const ReleasePage = () => {
   const [voteTag, { isLoading: votingTag }] = useVoteOnReleaseTagMutation();
   const [removeTag, { isLoading: removingTag }] =
     useRemoveTagFromReleaseMutation();
+  const [revertHistory] = useRevertReleaseHistoryMutation();
+  const [updateRelease, { isLoading: saving }] = useUpdateReleaseMutation();
   const { data: commentSubData } = useGetCommentSubscriptionQuery(
     { page: 'release', pageId: rId },
     { skip: !user }
@@ -187,6 +216,46 @@ const ReleasePage = () => {
       user?.userRank?.permissions?.staff ||
       user?.userRank?.permissions?.admin
   );
+  const isContributor = Boolean(
+    (release as { isContributor?: boolean }).isContributor
+  );
+  const canEdit = canManageTags || isContributor;
+
+  const handleEditOpen = () => {
+    setEditForm({
+      title: release.title ?? '',
+      description: release.description ?? '',
+      year: release.year ?? new Date().getFullYear(),
+      image: release.image ?? '',
+      isEdition: Boolean((release as { isEdition?: boolean }).isEdition),
+      editSummary: ''
+    });
+    setEditError(null);
+    setEditOpen(true);
+  };
+
+  const handleEditSave = async () => {
+    setEditError(null);
+    try {
+      await updateRelease({
+        communityId: cId,
+        releaseId: rId,
+        title: editForm.title.trim() || undefined,
+        description: editForm.description.trim() || undefined,
+        year: editForm.year || undefined,
+        image: editForm.image.trim() || undefined,
+        isEdition: editForm.isEdition,
+        editSummary: editForm.editSummary.trim() || undefined
+      }).unwrap();
+      dispatch(addAlert('Release updated.', 'success'));
+      setEditOpen(false);
+    } catch (e: unknown) {
+      const msg =
+        (e as { data?: { msg?: string } })?.data?.msg ??
+        'Failed to save changes.';
+      setEditError(msg);
+    }
+  };
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-6">
@@ -232,6 +301,15 @@ const ReleasePage = () => {
         >
           [Add format]
         </button>
+        {canEdit && (
+          <button
+            type="button"
+            onClick={handleEditOpen}
+            className="hover:text-indigo-300 transition-colors"
+          >
+            [Edit release]
+          </button>
+        )}
         {user && (
           <button
             type="button"
@@ -380,7 +458,20 @@ const ReleasePage = () => {
                 ) : historyEntries.length > 0 ? (
                   <div className="divide-y divide-gray-800">
                     {historyEntries.map((entry) => {
-                      const hasSnapshot = entry.before || entry.after;
+                      const beforeSnap = entry.before as
+                        | Record<string, unknown>
+                        | null
+                        | undefined;
+                      const afterSnap = entry.after as
+                        | Record<string, unknown>
+                        | null
+                        | undefined;
+                      const showDiff =
+                        entry.action === 'edit' &&
+                        beforeSnap &&
+                        afterSnap &&
+                        entry.changedFields.length > 0;
+                      const isReverting = revertingId === entry.id;
                       return (
                         <div key={entry.id} className="px-4 py-3 text-sm">
                           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-gray-300">
@@ -395,36 +486,92 @@ const ReleasePage = () => {
                             <span className="text-gray-600">
                               <Time date={entry.createdAt} />
                             </span>
+                            {canManageTags && entry.action === 'edit' && (
+                              <span className="ml-auto flex items-center gap-1">
+                                {isReverting ? (
+                                  <>
+                                    <span className="text-gray-400 text-xs">
+                                      Confirm?
+                                    </span>
+                                    <button
+                                      type="button"
+                                      className="text-xs text-red-400 hover:text-red-300"
+                                      onClick={async () => {
+                                        try {
+                                          await revertHistory({
+                                            communityId: cId,
+                                            releaseId: rId,
+                                            historyId: entry.id
+                                          }).unwrap();
+                                          dispatch(
+                                            addAlert(
+                                              'Release reverted successfully',
+                                              'success'
+                                            )
+                                          );
+                                        } catch {
+                                          dispatch(
+                                            addAlert(
+                                              'Failed to revert release',
+                                              'danger'
+                                            )
+                                          );
+                                        }
+                                        setRevertingId(null);
+                                      }}
+                                    >
+                                      Yes
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="text-xs text-gray-400 hover:text-gray-300"
+                                      onClick={() => setRevertingId(null)}
+                                    >
+                                      Cancel
+                                    </button>
+                                  </>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    className="text-xs text-gray-500 hover:text-gray-300"
+                                    onClick={() => setRevertingId(entry.id)}
+                                  >
+                                    Revert
+                                  </button>
+                                )}
+                              </span>
+                            )}
                           </div>
-                          {entry.changedFields.length > 0 && (
-                            <p className="mt-1 text-xs text-gray-500">
-                              Fields: {entry.changedFields.join(', ')}
-                            </p>
-                          )}
-                          {hasSnapshot && (
-                            <details className="mt-2">
-                              <summary className="cursor-pointer text-xs text-indigo-300 hover:text-indigo-200">
-                                View snapshot
-                              </summary>
-                              <div className="mt-2 grid gap-3 md:grid-cols-2">
-                                <div className="rounded border border-gray-800 bg-gray-950/60 p-3">
-                                  <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
-                                    Before
-                                  </p>
-                                  <pre className="whitespace-pre-wrap break-words text-xs text-gray-300">
-                                    {formatHistoryValue(entry.before)}
-                                  </pre>
-                                </div>
-                                <div className="rounded border border-gray-800 bg-gray-950/60 p-3">
-                                  <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
-                                    After
-                                  </p>
-                                  <pre className="whitespace-pre-wrap break-words text-xs text-gray-300">
-                                    {formatHistoryValue(entry.after)}
-                                  </pre>
-                                </div>
-                              </div>
-                            </details>
+                          {showDiff && (
+                            <table className="mt-2 w-full text-xs border-collapse">
+                              <tbody>
+                                {entry.changedFields.map((field) => (
+                                  <tr
+                                    key={field}
+                                    className="border-t border-gray-800"
+                                  >
+                                    <td className="py-1 pr-3 text-gray-500 whitespace-nowrap">
+                                      {FIELD_LABELS[field] ?? field}
+                                    </td>
+                                    <td className="py-1 pr-2 text-gray-400 max-w-xs break-words">
+                                      {formatFieldValue(
+                                        field,
+                                        beforeSnap[field]
+                                      )}
+                                    </td>
+                                    <td className="py-1 pr-2 text-gray-500">
+                                      →
+                                    </td>
+                                    <td className="py-1 text-gray-200 max-w-xs break-words">
+                                      {formatFieldValue(
+                                        field,
+                                        afterSnap[field]
+                                      )}
+                                    </td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
                           )}
                         </div>
                       );
@@ -657,6 +804,141 @@ const ReleasePage = () => {
           contributionId={reportingId}
           onClose={() => setReportingId(null)}
         />
+      )}
+
+      {editOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+          <div className="bg-gray-900 border border-gray-700 rounded-lg w-full max-w-lg mx-4 shadow-2xl">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-gray-700">
+              <h2 className="text-sm font-semibold text-gray-100">
+                Edit release
+              </h2>
+              <button
+                type="button"
+                onClick={() => setEditOpen(false)}
+                className="text-gray-500 hover:text-gray-300 text-lg leading-none"
+              >
+                ×
+              </button>
+            </div>
+            <div className="px-5 py-4 space-y-4">
+              <label className="block">
+                <span className="text-xs text-gray-400 block mb-1">Title</span>
+                <input
+                  type="text"
+                  value={editForm.title}
+                  onChange={(e) =>
+                    setEditForm((f) => ({ ...f, title: e.target.value }))
+                  }
+                  className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                />
+              </label>
+              <label className="block">
+                <span className="text-xs text-gray-400 block mb-1">
+                  Description
+                </span>
+                <textarea
+                  value={editForm.description}
+                  rows={5}
+                  onChange={(e) =>
+                    setEditForm((f) => ({ ...f, description: e.target.value }))
+                  }
+                  className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-y"
+                />
+              </label>
+              <div className="flex gap-3">
+                <label className="block flex-1">
+                  <span className="text-xs text-gray-400 block mb-1">Year</span>
+                  <input
+                    type="number"
+                    min={1900}
+                    max={2100}
+                    value={editForm.year}
+                    onChange={(e) =>
+                      setEditForm((f) => ({
+                        ...f,
+                        year: parseInt(e.target.value) || 0
+                      }))
+                    }
+                    className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  />
+                </label>
+                <label className="flex items-center gap-2 mt-5 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={editForm.isEdition}
+                    onChange={(e) =>
+                      setEditForm((f) => ({
+                        ...f,
+                        isEdition: e.target.checked
+                      }))
+                    }
+                    className="accent-indigo-500 w-4 h-4"
+                  />
+                  <span className="text-xs text-gray-300">Edition</span>
+                </label>
+              </div>
+              <label className="block">
+                <span className="text-xs text-gray-400 block mb-1">
+                  Cover image URL
+                </span>
+                <div className="flex gap-2">
+                  <input
+                    type="url"
+                    value={editForm.image}
+                    onChange={(e) =>
+                      setEditForm((f) => ({ ...f, image: e.target.value }))
+                    }
+                    placeholder="https://…"
+                    className="flex-1 bg-gray-800 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  />
+                  {editForm.image && (
+                    <button
+                      type="button"
+                      onClick={() => setEditForm((f) => ({ ...f, image: '' }))}
+                      className="text-xs text-gray-500 hover:text-red-400 px-2"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+              </label>
+              <label className="block">
+                <span className="text-xs text-gray-400 block mb-1">
+                  Edit summary <span className="text-gray-600">(optional)</span>
+                </span>
+                <input
+                  type="text"
+                  value={editForm.editSummary}
+                  maxLength={255}
+                  onChange={(e) =>
+                    setEditForm((f) => ({ ...f, editSummary: e.target.value }))
+                  }
+                  placeholder="Brief description of changes…"
+                  className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                />
+              </label>
+              {editError && <p className="text-xs text-red-400">{editError}</p>}
+            </div>
+            <div className="flex justify-end gap-2 px-5 py-3 border-t border-gray-700">
+              <button
+                type="button"
+                onClick={() => setEditOpen(false)}
+                className="px-3 py-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={handleEditSave}
+                className="px-4 py-1.5 bg-indigo-700 hover:bg-indigo-600 disabled:opacity-50 text-white text-xs rounded transition-colors"
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/store/services/communityApi.ts
+++ b/src/store/services/communityApi.ts
@@ -1,5 +1,5 @@
 import { api } from '../api';
-import type { paths } from '../../types/api';
+import type { components, paths } from '../../types/api';
 
 export interface VoteAggregate {
   releaseId: number;
@@ -15,35 +15,8 @@ export interface VoteResponse {
   voteAggregate: VoteAggregate | null;
 }
 
-export interface ReleaseTag {
-  id: number;
-  tagId: number;
-  name: string;
-  occurrences: number;
-  score: number;
-  positiveVotes: number;
-  negativeVotes: number;
-  createdAt: string | null;
-  addedBy?: { id: number; username: string } | null;
-  myVotes: {
-    up: boolean;
-    down: boolean;
-  };
-}
-
-export interface ReleaseHistoryEntry {
-  id: number;
-  action: 'edit' | 'tag_added' | 'tag_removed';
-  summary: string;
-  changedFields: string[];
-  before?: Record<string, unknown> | null;
-  after?: Record<string, unknown> | null;
-  createdAt: string;
-  actor: {
-    id: number;
-    username: string;
-  };
-}
+export type ReleaseTag = components['schemas']['ReleaseTagEnriched'];
+export type ReleaseHistoryEntry = components['schemas']['ReleaseHistoryEntry'];
 
 interface ReleaseArgs {
   communityId: number;
@@ -56,12 +29,10 @@ type CommunityResponse =
   paths['/communities/{id}']['get']['responses'][200]['content']['application/json'];
 type CommunityReleasesResponse =
   paths['/communities/{id}/releases']['get']['responses'][200]['content']['application/json'];
-type GeneratedReleaseResponse =
+export type ReleaseResponse =
   paths['/communities/{communityId}/releases/{releaseId}']['get']['responses'][200]['content']['application/json'];
-export type ReleaseResponse = GeneratedReleaseResponse & {
-  releaseTags?: ReleaseTag[];
-  historyEntries?: ReleaseHistoryEntry[];
-};
+type ReleaseHistoryResponse =
+  paths['/communities/{communityId}/releases/{releaseId}/history']['get']['responses'][200]['content']['application/json'];
 type ContributionsResponse =
   paths['/contributions']['get']['responses'][200]['content']['application/json'];
 type CreateContributionArgs = NonNullable<
@@ -311,7 +282,18 @@ export const communityApi = api.injectEndpoints({
           'Top10'
         ]
       }
-    )
+    ),
+
+    getReleaseHistory: build.query<
+      ReleaseHistoryResponse,
+      ReleaseArgs & { page?: number }
+    >({
+      query: ({ communityId, releaseId, page = 1 }) =>
+        `/communities/${communityId}/releases/${releaseId}/history?page=${page}`,
+      providesTags: (_, __, { releaseId }) => [
+        { type: 'Release', id: releaseId }
+      ]
+    })
   })
 });
 
@@ -336,5 +318,6 @@ export const {
   useRemoveVoteOnReleaseMutation,
   useAddTagToReleaseMutation,
   useVoteOnReleaseTagMutation,
-  useRemoveTagFromReleaseMutation
+  useRemoveTagFromReleaseMutation,
+  useGetReleaseHistoryQuery
 } = communityApi;

--- a/src/store/services/communityApi.ts
+++ b/src/store/services/communityApi.ts
@@ -113,7 +113,13 @@ export const communityApi = api.injectEndpoints({
     }),
     updateRelease: build.mutation<
       ReleaseResponse,
-      ReleaseArgs & Partial<ReleaseResponse>
+      ReleaseArgs &
+        Partial<
+          Pick<
+            ReleaseResponse,
+            'title' | 'description' | 'image' | 'year' | 'isEdition' | 'edition'
+          >
+        > & { editSummary?: string }
     >({
       query: ({ communityId, releaseId, ...data }) => ({
         url: `/communities/${communityId}/releases/${releaseId}`,
@@ -293,6 +299,19 @@ export const communityApi = api.injectEndpoints({
       providesTags: (_, __, { releaseId }) => [
         { type: 'Release', id: releaseId }
       ]
+    }),
+
+    revertReleaseHistory: build.mutation<
+      ReleaseResponse,
+      ReleaseArgs & { historyId: number }
+    >({
+      query: ({ communityId, releaseId, historyId }) => ({
+        url: `/communities/${communityId}/releases/${releaseId}/history/${historyId}/revert`,
+        method: 'POST'
+      }),
+      invalidatesTags: (_, __, { releaseId }) => [
+        { type: 'Release', id: releaseId }
+      ]
     })
   })
 });
@@ -319,5 +338,6 @@ export const {
   useAddTagToReleaseMutation,
   useVoteOnReleaseTagMutation,
   useRemoveTagFromReleaseMutation,
-  useGetReleaseHistoryQuery
+  useGetReleaseHistoryQuery,
+  useRevertReleaseHistoryMutation
 } = communityApi;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -2857,6 +2857,219 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/communities/{communityId}/releases/{releaseId}/history': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          communityId: string;
+          releaseId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated release history */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['ReleaseHistoryEntry'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+        /** @description Not a community member */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/communities/{communityId}/releases/{releaseId}/tags': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          communityId: string;
+          releaseId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            name: string;
+          };
+        };
+      };
+      responses: {
+        /** @description Tag added */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ReleaseTag'];
+          };
+        };
+        /** @description Release already has this tag */
+        409: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/communities/{communityId}/releases/{releaseId}/tags/{tagId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          communityId: string;
+          releaseId: string;
+          tagId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Tag removed */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/communities/{communityId}/releases/{releaseId}/tags/{tagId}/vote': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          communityId: string;
+          releaseId: string;
+          tagId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            /** @enum {string} */
+            direction: 'up' | 'down';
+          };
+        };
+      };
+      responses: {
+        /** @description Updated tag with vote counts */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ReleaseTagEnriched'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/communities/{communityId}/releases/{releaseId}/contributions': {
     parameters: {
       query?: never;
@@ -7111,17 +7324,69 @@ export interface components {
       releaseDescription?: string | null;
       createdAt?: string;
     };
+    ReleaseTagEnriched: {
+      id: number;
+      tagId: number;
+      name: string;
+      occurrences: number;
+      score: number;
+      positiveVotes: number;
+      negativeVotes: number;
+      addedBy?: {
+        id: number;
+        username: string;
+      } | null;
+      createdAt?: string | null;
+      myVotes?: {
+        up: boolean;
+        down: boolean;
+      };
+    };
+    ReleaseHistoryEntry: {
+      id: number;
+      /** @enum {string} */
+      action:
+        | 'created'
+        | 'edit'
+        | 'tag_added'
+        | 'tag_removed'
+        | 'contribution_added';
+      summary: string;
+      changedFields: string[];
+      before?: {
+        [key: string]: unknown;
+      } | null;
+      after?: {
+        [key: string]: unknown;
+      } | null;
+      createdAt: string;
+      actor: {
+        id: number;
+        username: string;
+      };
+    };
     Release: {
       id: number;
       title: string;
       communityId: number | null;
       year?: number | null;
       type?: string | null;
+      releaseType?: string | null;
       image?: string | null;
       description?: string | null;
+      isEdition?: boolean;
+      edition?: unknown;
       createdAt?: string;
       artist?: components['schemas']['ReleaseArtist'];
       tags?: components['schemas']['ReleaseTag'][];
+      releaseTags?: components['schemas']['ReleaseTagEnriched'][];
+      /** @enum {string|null} */
+      myVote?: 'up' | 'down' | null;
+      voteAggregate?: {
+        ups: number;
+        total: number;
+        score: number;
+      } | null;
       contributions?: components['schemas']['ReleaseContribution'][];
     };
     UserRank: {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -2916,6 +2916,63 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/communities/{communityId}/releases/{releaseId}/history/{historyId}/revert': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          communityId: string;
+          releaseId: string;
+          historyId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Release after revert */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['Release'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Not an edit revision */
+        422: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/communities/{communityId}/releases/{releaseId}/tags': {
     parameters: {
       query?: never;
@@ -7342,6 +7399,16 @@ export interface components {
         down: boolean;
       };
     };
+    ReleaseSnapshot: {
+      title: string;
+      description: string;
+      image: string | null;
+      year: number;
+      isEdition: boolean;
+      edition?: unknown;
+      tagIds: number[];
+      tagNames: string[];
+    };
     ReleaseHistoryEntry: {
       id: number;
       /** @enum {string} */
@@ -7359,6 +7426,7 @@ export interface components {
       after?: {
         [key: string]: unknown;
       } | null;
+      snapshot?: components['schemas']['ReleaseSnapshot'] & unknown;
       createdAt: string;
       actor: {
         id: number;
@@ -7388,6 +7456,7 @@ export interface components {
         score: number;
       } | null;
       contributions?: components['schemas']['ReleaseContribution'][];
+      isContributor?: boolean;
     };
     UserRank: {
       id: number;


### PR DESCRIPTION
## Summary

- Adds an **[Edit release]** button on the release detail page, visible to contributors and staff with `communities_manage`. Opens a modal pre-filled with current values: title, description, year, cover image URL, edition flag, and an optional edit summary.
- History section (lazy-loaded, collapsible) shows all edit entries with field-level before/after diffs. Staff can revert to any prior edit via a two-step confirmation.
- `isContributor` field consumed from the release detail response to gate the edit button without a separate fetch.
- Regenerated `src/types/api.ts` from updated OpenAPI spec (`isContributor` on Release, `ReleaseSnapshot` type, revert path).

## Frontend surfaces changed

| Surface | Change |
|---------|--------|
| `ReleasePage.tsx` | Edit button + modal; `isContributor` flag; `useUpdateReleaseMutation` wired |
| `communityApi.ts` | `updateRelease` arg type narrowed to editable fields + `editSummary` |
| `src/types/api.ts` | Regenerated — `isContributor`, `ReleaseSnapshot`, revert path |

## Test plan

- [ ] `npx jest --runInBand` — 1113 tests passing
- [ ] Open a release as a contributor — confirm `[Edit release]` button appears
- [ ] Open a release as a non-contributor non-staff user — confirm button is hidden
- [ ] Edit title and submit — confirm success alert, modal closes, title updates
- [ ] Expand history section — confirm new edit entry with before/after diff
- [ ] Click Revert → Confirm — verify release fields restored and history section updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)