### PR TITLE
Add historical stats chart pages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,8 @@ module.exports = {
           '^@reduxjs/toolkit$',
           'dompurify',
           '^@reduxjs/toolkit/query$',
-          '^@reduxjs/toolkit/query/react$'
+          '^@reduxjs/toolkit/query/react$',
+          'recharts'
         ]
       }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/ui",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/ui",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.6",
@@ -27,6 +27,7 @@
         "react-hook-form": "^7.73.1",
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.14.2",
+        "recharts": "^3.8.1",
         "reselect": "^4.1.8",
         "tailwindcss": "^4.2.4"
       },
@@ -4677,6 +4678,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/dompurify": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
@@ -7064,6 +7128,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7669,6 +7742,127 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7758,6 +7952,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -8368,6 +8568,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -10523,6 +10733,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/interpret": {
@@ -16311,6 +16530,58 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/recharts/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/recharts/node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/rechoir": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -18235,6 +18506,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -18783,6 +19060,28 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@stellar/ui",
   "version": "0.5.0",
   "description": "",
-  "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>", 
+  "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",
   "scripts": {
     "api:generate": "npm --prefix ../stellar-api run openapi:export && npx --no-install openapi-typescript ../stellar-api/openapi.json -o src/types/api.ts && npx --no-install prettier --write src/types/api.ts",
@@ -45,6 +45,7 @@
     "react-hook-form": "^7.73.1",
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.14.2",
+    "recharts": "^3.8.1",
     "reselect": "^4.1.8",
     "tailwindcss": "^4.2.4"
   },

--- a/src/components/pages/private/PrivateHomepage.tsx
+++ b/src/components/pages/private/PrivateHomepage.tsx
@@ -148,6 +148,14 @@ const PrivateHomepage = () => {
               <StatRow label="Blog posts" value={stats?.blogPosts} />
               <StatRow label="Comments" value={stats?.comments} />
             </div>
+            <div className="px-4 pb-3 text-right">
+              <Link
+                to="/private/stats/history"
+                className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+              >
+                Details
+              </Link>
+            </div>
           </div>
 
           {/* Album of the Month */}

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -74,6 +74,8 @@ import TopUsersPage from '../../../top10/TopUsersPage';
 import TopTagsPage from '../../../top10/TopTagsPage';
 import TopVotesPage from '../../../top10/TopVotesPage';
 import TopHistoryPage from '../../../top10/TopHistoryPage';
+import SiteStatsHistoryPage from '../stats/SiteStatsHistoryPage';
+import UserStatsHistoryPage from '../stats/UserStatsHistoryPage';
 import DraftsPage from '../../../messages/DraftsPage';
 import { useGetMeQuery } from '../../../../store/services/authApi';
 import {
@@ -355,6 +357,9 @@ const PrivateContent = () => (
         }
       />
     </Route>
+
+    <Route path="stats/history" element={wrap(SiteStatsHistoryPage)} />
+    <Route path="users/:id/stats" element={wrap(UserStatsHistoryPage)} />
 
     <Route path="" element={<PrivateHomepage />} />
     <Route path="*" element={<NotFound />} />

--- a/src/components/pages/private/stats/SiteStatsHistoryPage.tsx
+++ b/src/components/pages/private/stats/SiteStatsHistoryPage.tsx
@@ -1,0 +1,155 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from 'recharts';
+import { useGetSiteStatsHistoryQuery } from '../../../../store/services/siteApi';
+import Spinner from '../../../layout/Spinner';
+
+const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+};
+
+const SiteStatsHistoryPage = () => {
+  const { data, isLoading, error } = useGetSiteStatsHistoryQuery();
+
+  if (isLoading) return <Spinner />;
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-6">
+        <div className="bg-red-900/30 border border-red-700 rounded-lg p-6 text-red-300">
+          Failed to load site stats history.
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-6">
+        <h2 className="text-xl font-semibold text-white mb-4">
+          Site Stats History
+        </h2>
+        <div className="bg-gray-900 border border-gray-700 rounded-lg p-8 text-center text-gray-500 text-sm">
+          No historical snapshots yet. Snapshots are captured hourly.
+        </div>
+      </div>
+    );
+  }
+
+  const chartData = data.map((s) => ({
+    time: formatDate(s.capturedAt),
+    'Total Users': s.totalUsers,
+    'Active Today': s.activeToday,
+    'Active This Week': s.activeThisWeek,
+    Releases: s.releases,
+    Communities: s.communities
+  }));
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
+      <h2 className="text-xl font-semibold text-white">Site Stats History</h2>
+      <p className="text-gray-400 text-sm">
+        Hourly snapshots of site-wide metrics. Showing {data.length} data point
+        {data.length !== 1 ? 's' : ''}.
+      </p>
+
+      <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+        <h3 className="text-sm font-medium text-gray-300 mb-4">
+          Users &amp; Activity
+        </h3>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 5, right: 30, left: 0, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+            <XAxis dataKey="time" tick={{ fill: '#9ca3af', fontSize: 11 }} />
+            <YAxis tick={{ fill: '#9ca3af', fontSize: 11 }} />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: '#111827',
+                border: '1px solid #374151',
+                borderRadius: '6px'
+              }}
+              labelStyle={{ color: '#e5e7eb' }}
+            />
+            <Legend />
+            <Line
+              type="monotone"
+              dataKey="Total Users"
+              stroke="#6366f1"
+              dot={false}
+              strokeWidth={2}
+            />
+            <Line
+              type="monotone"
+              dataKey="Active Today"
+              stroke="#10b981"
+              dot={false}
+              strokeWidth={2}
+            />
+            <Line
+              type="monotone"
+              dataKey="Active This Week"
+              stroke="#f59e0b"
+              dot={false}
+              strokeWidth={2}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+        <h3 className="text-sm font-medium text-gray-300 mb-4">Content</h3>
+        <ResponsiveContainer width="100%" height={250}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 5, right: 30, left: 0, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+            <XAxis dataKey="time" tick={{ fill: '#9ca3af', fontSize: 11 }} />
+            <YAxis tick={{ fill: '#9ca3af', fontSize: 11 }} />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: '#111827',
+                border: '1px solid #374151',
+                borderRadius: '6px'
+              }}
+              labelStyle={{ color: '#e5e7eb' }}
+            />
+            <Legend />
+            <Line
+              type="monotone"
+              dataKey="Releases"
+              stroke="#8b5cf6"
+              dot={false}
+              strokeWidth={2}
+            />
+            <Line
+              type="monotone"
+              dataKey="Communities"
+              stroke="#ec4899"
+              dot={false}
+              strokeWidth={2}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default SiteStatsHistoryPage;

--- a/src/components/pages/private/stats/UserStatsHistoryPage.tsx
+++ b/src/components/pages/private/stats/UserStatsHistoryPage.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from 'recharts';
+import { useGetUserStatsHistoryQuery } from '../../../../store/services/siteApi';
+import Spinner from '../../../layout/Spinner';
+import type { UserStatSnapshot } from '../../../../store/services/siteApi';
+
+type Period = 'Daily' | 'Monthly' | 'Yearly';
+
+const PERIODS: { label: string; value: Period; description: string }[] = [
+  { label: 'Daily', value: 'Daily', description: 'Last 24 hours' },
+  { label: 'Monthly', value: 'Monthly', description: 'Last 30 days' },
+  { label: 'Yearly', value: 'Yearly', description: 'Last year' }
+];
+
+const bytesToGB = (bytes: string): string =>
+  (parseInt(bytes, 10) / 1_073_741_824).toFixed(2);
+
+const formatDate = (iso: string, period: Period): string => {
+  const d = new Date(iso);
+  if (period === 'Daily')
+    return d.toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  if (period === 'Monthly')
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return d.toLocaleDateString(undefined, { month: 'short', year: '2-digit' });
+};
+
+const buildChartData = (snapshots: UserStatSnapshot[], period: Period) =>
+  snapshots.map((s) => ({
+    time: formatDate(s.capturedAt, period),
+    ...(s.contributed !== null
+      ? { 'Contributed (GB)': parseFloat(bytesToGB(s.contributed)) }
+      : {}),
+    ...(s.consumed !== null
+      ? { 'Consumed (GB)': parseFloat(bytesToGB(s.consumed)) }
+      : {}),
+    ...(s.contributed !== null && s.consumed !== null
+      ? {
+          'Buffer (GB)': parseFloat(
+            parseInt(s.contributed, 10) - parseInt(s.consumed, 10) > 0
+              ? bytesToGB(
+                  String(parseInt(s.contributed, 10) - parseInt(s.consumed, 10))
+                )
+              : '0'
+          )
+        }
+      : {})
+  }));
+
+const UserStatsHistoryPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const userId = parseInt(id ?? '0', 10);
+  const [period, setPeriod] = useState<Period>('Daily');
+
+  const { data, isLoading, error } = useGetUserStatsHistoryQuery(
+    { userId, period },
+    { skip: !userId }
+  );
+
+  const is403 = error && 'status' in error && error.status === 403;
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-6">
+      <h2 className="text-xl font-semibold text-white">Stats History</h2>
+
+      {/* Period tabs */}
+      <div className="flex gap-2">
+        {PERIODS.map((p) => (
+          <button
+            key={p.value}
+            onClick={() => setPeriod(p.value)}
+            className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
+              period === p.value
+                ? 'bg-indigo-600 text-white'
+                : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+            }`}
+          >
+            {p.label}
+            <span className="ml-1 text-xs opacity-60">({p.description})</span>
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <Spinner />}
+
+      {is403 && (
+        <div className="bg-gray-900 border border-gray-700 rounded-lg p-8 text-center">
+          <p className="text-gray-400 text-sm">
+            This user&apos;s stats are private.
+          </p>
+        </div>
+      )}
+
+      {error && !is403 && (
+        <div className="bg-red-900/30 border border-red-700 rounded-lg p-6 text-red-300">
+          Failed to load stats history.
+        </div>
+      )}
+
+      {data && data.length === 0 && !isLoading && (
+        <div className="bg-gray-900 border border-gray-700 rounded-lg p-8 text-center text-gray-500 text-sm">
+          No snapshots for this period yet.
+        </div>
+      )}
+
+      {data && data.length > 0 && (
+        <>
+          <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+            <h3 className="text-sm font-medium text-gray-300 mb-4">
+              Contributed &amp; Consumed (GB)
+            </h3>
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart
+                data={buildChartData(data, period)}
+                margin={{ top: 5, right: 30, left: 0, bottom: 5 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                <XAxis
+                  dataKey="time"
+                  tick={{ fill: '#9ca3af', fontSize: 11 }}
+                />
+                <YAxis tick={{ fill: '#9ca3af', fontSize: 11 }} unit=" GB" />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: '#111827',
+                    border: '1px solid #374151',
+                    borderRadius: '6px'
+                  }}
+                  labelStyle={{ color: '#e5e7eb' }}
+                />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="Contributed (GB)"
+                  stroke="#10b981"
+                  dot={false}
+                  strokeWidth={2}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="Consumed (GB)"
+                  stroke="#f59e0b"
+                  dot={false}
+                  strokeWidth={2}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="Buffer (GB)"
+                  stroke="#6366f1"
+                  dot={false}
+                  strokeWidth={2}
+                  strokeDasharray="4 2"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          {data[data.length - 1]?.contributed === null && (
+            <p className="text-xs text-gray-500">
+              * Contributed data is not public for this user.
+            </p>
+          )}
+          {data[data.length - 1]?.consumed === null && (
+            <p className="text-xs text-gray-500">
+              * Consumed data is not public for this user.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default UserStatsHistoryPage;

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -859,6 +859,14 @@ const UserProfile = () => {
               Settings
             </Link>
           )}
+          {(isOwnProfile || isStaff) && (
+            <Link
+              to={`/private/users/${profile.id}/stats`}
+              className="text-indigo-400 hover:text-indigo-300 transition-colors"
+            >
+              Stats
+            </Link>
+          )}
           {!isOwnProfile && (
             <>
               <Link

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -54,7 +54,9 @@ export const api = createApi({
     'WikiPage',
     'Top10',
     'ArtistSubscription',
-    'RecoveryRequest'
+    'RecoveryRequest',
+    'StatsHistory',
+    'UserStats'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/siteApi.ts
+++ b/src/store/services/siteApi.ts
@@ -17,6 +17,35 @@ interface SiteStatsResponse {
   blogPosts: number;
   comments: number;
 }
+
+export interface SiteStatSnapshot {
+  id: number;
+  capturedAt: string;
+  maxUsers: number;
+  totalUsers: number;
+  enabledUsers: number;
+  activeToday: number;
+  activeThisWeek: number;
+  activeThisMonth: number;
+  communities: number;
+  releases: number;
+  artists: number;
+  blogPosts: number;
+  announcements: number;
+  comments: number;
+  contributedLinks: number;
+  contributedLinkDownloads: number;
+}
+
+export interface UserStatSnapshot {
+  id: number;
+  userId: number;
+  period: 'Daily' | 'Monthly' | 'Yearly';
+  capturedAt: string;
+  contributed: string | null;
+  consumed: string | null;
+  contributionCount: number;
+}
 type StylesheetsResponse =
   paths['/stylesheet']['get']['responses'][200]['content']['application/json'];
 interface SiteSettingsResponse {
@@ -54,6 +83,24 @@ export const siteApi = api.injectEndpoints({
     >({
       query: (body) => ({ url: '/settings', method: 'PUT', body }),
       invalidatesTags: ['SiteSettings']
+    }),
+    getSiteStatsHistory: build.query<SiteStatSnapshot[], void>({
+      query: () => '/stats/history',
+      providesTags: ['StatsHistory']
+    }),
+    triggerSiteSnapshot: build.mutation<void, void>({
+      query: () => ({ url: '/stats/snapshot', method: 'POST' }),
+      invalidatesTags: ['StatsHistory']
+    }),
+    getUserStatsHistory: build.query<
+      UserStatSnapshot[],
+      { userId: number; period: 'Daily' | 'Monthly' | 'Yearly' }
+    >({
+      query: ({ userId, period }) =>
+        `/users/${userId}/stats/history?period=${period}`,
+      providesTags: (_r, _e, { userId }) => [
+        { type: 'UserStats' as const, id: userId }
+      ]
     })
   })
 });
@@ -62,5 +109,8 @@ export const {
   useGetSiteStatsQuery,
   useGetStylesheetsQuery,
   useGetSiteSettingsQuery,
-  useUpdateSiteSettingsMutation
+  useUpdateSiteSettingsMutation,
+  useGetSiteStatsHistoryQuery,
+  useTriggerSiteSnapshotMutation,
+  useGetUserStatsHistoryQuery
 } = siteApi;


### PR DESCRIPTION
## Summary

- Adds `recharts` dependency; adds `SiteStatsHistoryPage` (hourly site-wide timeline, two line charts) and `UserStatsHistoryPage` (period tabs: Daily / Monthly / Yearly; contributed, consumed, and buffer lines in GB)
- Registers `stats/history` and `users/:id/stats` routes in `PrivateContent.tsx` (relative paths, before catch-all)
- Extends `siteApi.ts` with `getSiteStatsHistory`, `getUserStatsHistory`, and `triggerSiteSnapshot` RTK Query endpoints; adds `StatsHistory` and `UserStats` to tag types
- Surfaces entry points matching legacy behavior: "Stats" link in the user profile action bar (own profile or staff only); "Details" link in the homepage Stats widget

## Test plan

- [ ] `npm run build` — no TypeScript errors
- [ ] Navigate to a user profile as yourself — confirm "Stats" link appears; confirm it is absent on another user's profile when viewed as a non-staff member
- [ ] Navigate to a user profile as staff — confirm "Stats" link appears on any profile
- [ ] Click homepage Stats widget "Details" link — confirm it routes to site stats history page
- [ ] On user stats page, switch between Daily / Monthly / Yearly tabs — confirm each tab fetches its own period
- [ ] Verify 403 case (user with private stats, viewed by non-owner non-staff) renders an error card without logging out

🤖 Generated with [Claude Code](https://claude.com/claude-code)