### PR TITLE
Bug fixes and admin tooling: May 2026

### DIFF
--- a/src/components/admin/Toolbox.tsx
+++ b/src/components/admin/Toolbox.tsx
@@ -49,14 +49,24 @@ const sections: SectionProps[] = [
         permissions: ['admin']
       },
       {
+        label: 'Site settings',
+        to: '/private/staff/tools/settings',
+        permissions: ['admin']
+      }
+    ]
+  },
+  {
+    title: 'User Management',
+    links: [
+      {
         label: 'Create user',
         to: '/private/staff/tools/user/new',
         permissions: ['users_edit']
       },
       {
-        label: 'Site settings',
-        to: '/private/staff/tools/settings',
-        permissions: ['admin']
+        label: 'Recovery queue',
+        to: '/private/staff/tools/recovery-queue',
+        permissions: ['users_edit', 'admin']
       }
     ]
   },
@@ -67,6 +77,16 @@ const sections: SectionProps[] = [
         label: 'News post',
         to: '/private/staff/tools/news',
         permissions: ['news_manage']
+      },
+      {
+        label: 'Mass PM',
+        to: '/private/staff/mass-pm',
+        permissions: ['staff', 'admin']
+      },
+      {
+        label: 'Site History',
+        to: '/private/staff/site-history',
+        permissions: ['staff', 'admin']
       }
     ]
   },
@@ -91,17 +111,7 @@ const sections: SectionProps[] = [
     ]
   },
   {
-    title: 'Users',
-    links: [
-      {
-        label: 'Ratio policy override',
-        to: '/private/staff/tools/ratio-policy',
-        permissions: ['staff', 'admin']
-      }
-    ]
-  },
-  {
-    title: 'Support',
+    title: 'Managers',
     links: [
       {
         label: 'Ticket queue',
@@ -117,31 +127,21 @@ const sections: SectionProps[] = [
         label: 'Reports queue',
         to: '/private/staff/reports',
         permissions: ['staff', 'admin']
-      },
-      {
-        label: 'Recovery queue',
-        to: '/private/staff/tools/recovery-queue',
-        permissions: ['users_edit', 'admin']
       }
     ]
   },
   {
-    title: 'Communications',
+    title: 'Users',
     links: [
       {
-        label: 'Mass PM',
-        to: '/private/staff/mass-pm',
-        permissions: ['staff', 'admin']
-      },
-      {
-        label: 'Site History',
-        to: '/private/staff/site-history',
+        label: 'Ratio policy override',
+        to: '/private/staff/tools/ratio-policy',
         permissions: ['staff', 'admin']
       }
     ]
   },
   {
-    title: 'Donor System',
+    title: 'Finances',
     links: [
       {
         label: 'Donor ranks',

--- a/src/components/admin/Toolbox.tsx
+++ b/src/components/admin/Toolbox.tsx
@@ -137,6 +137,31 @@ const sections: SectionProps[] = [
         label: 'Ratio policy override',
         to: '/private/staff/tools/ratio-policy',
         permissions: ['staff', 'admin']
+      },
+      {
+        label: 'Duplicate IPs',
+        to: '/private/staff/duplicate-ips',
+        permissions: ['staff', 'admin']
+      },
+      {
+        label: 'Registration log',
+        to: '/private/staff/registration-log',
+        permissions: ['staff', 'admin']
+      }
+    ]
+  },
+  {
+    title: 'Moderation',
+    links: [
+      {
+        label: 'IP address bans',
+        to: '/private/staff/ip-bans',
+        permissions: ['admin']
+      },
+      {
+        label: 'Email blacklist',
+        to: '/private/staff/email-blacklist',
+        permissions: ['admin']
       }
     ]
   },
@@ -146,6 +171,11 @@ const sections: SectionProps[] = [
       {
         label: 'Donor ranks',
         to: '/private/staff/donor-ranks',
+        permissions: ['admin']
+      },
+      {
+        label: 'Donation log',
+        to: '/private/staff/donation-log',
         permissions: ['admin']
       }
     ]

--- a/src/components/layout/CommentsSection.tsx
+++ b/src/components/layout/CommentsSection.tsx
@@ -73,100 +73,90 @@ const CommentsSection = ({
   };
 
   return (
-    <div className="box">
-      <div className="head colhead_dark">Comments</div>
+    <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+      <div className="bg-gray-800 border-b border-gray-700 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
+        Comments
+      </div>
+
       {isLoading ? (
-        <div className="pad">Loading…</div>
+        <div className="px-3 py-2 text-xs text-gray-500">Loading…</div>
       ) : !comments?.length ? (
-        <div className="pad small">No comments yet.</div>
+        <div className="px-3 py-2 text-xs text-gray-500">No comments yet.</div>
       ) : (
-        <table className="m_table">
-          <tbody>
-            {comments.map((c) => (
-              <tr key={c.id}>
-                <td
-                  style={{ width: 120, verticalAlign: 'top' }}
-                  className="small"
-                >
-                  <strong>{c.author?.username ?? 'Unknown'}</strong>
-                  <br />
-                  <span className="time">
-                    <Time date={c.createdAt} />
-                  </span>
-                </td>
-                <td
-                  dangerouslySetInnerHTML={{
-                    __html: DOMPurify.sanitize(c.body)
-                  }}
-                />
-                <td
-                  style={{
-                    width: 40,
-                    textAlign: 'center',
-                    verticalAlign: 'top'
-                  }}
-                >
-                  {currentUser && currentUser.id !== c.authorId && (
-                    <Link
-                      to={`/private/reports/new?targetType=Comment&targetId=${c.id}`}
-                      className="brackets btn-link text-gray-600 hover:text-gray-400"
-                      aria-label="Report comment"
-                      title="Report this comment"
-                    >
-                      !
-                    </Link>
-                  )}
-                  {currentUser?.id === c.authorId && (
-                    <button
-                      type="button"
-                      onClick={() => deleteComment(c.id)}
-                      className="brackets btn-link"
-                      aria-label="Delete comment"
-                    >
-                      ×
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <div className="divide-y divide-gray-700/40">
+          {comments.map((c) => (
+            <div key={c.id} className="px-3 py-2 text-xs">
+              <div className="flex items-center justify-between gap-1 mb-1">
+                <span className="font-semibold text-gray-200 truncate">
+                  {c.author?.username ?? 'Unknown'}
+                </span>
+                <span className="text-gray-500 shrink-0">
+                  <Time date={c.createdAt} />
+                </span>
+              </div>
+              <div
+                className="text-gray-300 leading-relaxed break-words"
+                dangerouslySetInnerHTML={{
+                  __html: DOMPurify.sanitize(c.body)
+                }}
+              />
+              <div className="flex gap-2 mt-1">
+                {currentUser && currentUser.id !== c.authorId && (
+                  <Link
+                    to={`/private/reports/new?targetType=Comment&targetId=${c.id}`}
+                    className="text-gray-600 hover:text-gray-400 text-xs"
+                    aria-label="Report comment"
+                    title="Report this comment"
+                  >
+                    [!]
+                  </Link>
+                )}
+                {currentUser?.id === c.authorId && (
+                  <button
+                    type="button"
+                    onClick={() => deleteComment(c.id)}
+                    className="text-gray-600 hover:text-red-400 text-xs"
+                    aria-label="Delete comment"
+                  >
+                    [×]
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
       )}
+
       {currentUser && (
-        <form className="pad" onSubmit={handleSubmit}>
+        <form
+          className="px-3 py-2 border-t border-gray-700/40"
+          onSubmit={handleSubmit}
+        >
           <textarea
             value={body}
             onChange={(e) => setBody(e.target.value)}
-            rows={4}
-            cols={60}
+            className="w-full bg-gray-800 border border-gray-700 rounded text-xs text-gray-200 px-2 py-1.5 focus:outline-none focus:border-indigo-500 resize-none h-20"
             placeholder="Add a comment…"
             required
           />
-          <br />
           {canSubscribe && (
-            <label
-              className="small"
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 4,
-                marginBottom: 4
-              }}
-            >
+            <label className="flex items-center gap-1.5 text-xs text-gray-400 mt-1.5 mb-1">
               <input
                 type="checkbox"
                 checked={subscribe}
                 onChange={(e) => setSubscribe(e.target.checked)}
+                className="accent-indigo-500"
               />
               Subscribe to comments
             </label>
           )}
-          {canSubscribe && <br />}
-          <input
+          <button
             type="submit"
-            value="Post comment"
             disabled={posting || subscribing}
-          />
+            className="mt-1.5 px-3 py-1 bg-indigo-700 hover:bg-indigo-600 disabled:opacity-50 text-white text-xs rounded transition-colors"
+          >
+            Post comment
+          </button>
         </form>
       )}
     </div>

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -58,6 +58,11 @@ import SiteHistoryPage from '../../../staff/SiteHistoryPage';
 import MassPmPage from '../../../staff/MassPmPage';
 import DonorRanksPage from '../../../staff/DonorRanksPage';
 import RecoveryQueuePage from '../../../staff/RecoveryQueuePage';
+import IpBansPage from '../../../staff/IpBansPage';
+import EmailBlacklistPage from '../../../staff/EmailBlacklistPage';
+import DonationLogPage from '../../../staff/DonationLogPage';
+import DuplicateIpsPage from '../../../staff/DuplicateIpsPage';
+import RegistrationLogPage from '../../../staff/RegistrationLogPage';
 import SnatchList from '../snatch/SnatchList';
 import BookmarksPage from '../bookmarks/BookmarksPage';
 import WikiListPage from '../../../wiki/WikiListPage';
@@ -242,6 +247,46 @@ const PrivateContent = () => (
       element={
         <StaffGate permissions={['users_edit']}>
           <RecoveryQueuePage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/ip-bans"
+      element={
+        <StaffGate permissions={['admin']}>
+          <IpBansPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/email-blacklist"
+      element={
+        <StaffGate permissions={['admin']}>
+          <EmailBlacklistPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/donation-log"
+      element={
+        <StaffGate permissions={['admin']}>
+          <DonationLogPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/duplicate-ips"
+      element={
+        <StaffGate permissions={['staff', 'admin']}>
+          <DuplicateIpsPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/registration-log"
+      element={
+        <StaffGate permissions={['staff', 'admin']}>
+          <RegistrationLogPage />
         </StaffGate>
       }
     />

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -80,7 +80,7 @@ const WarnModal = ({
       await warnUser({
         id: userId,
         reason,
-        expiresAt: expiresAt || undefined
+        expiresAt: expiresAt ? new Date(expiresAt).toISOString() : undefined
       }).unwrap();
       dispatch(addAlert('Warning issued.', 'success'));
       onClose();
@@ -179,7 +179,7 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
   });
 
   const { data: profile } = useGetProfileByUserIdQuery(String(profileId));
-  const isDisabled = (profile as { disabled?: boolean } | undefined)?.disabled;
+  const isDisabled = profile?.disabled;
   const staffPmOverview = profile?.staffPmOverview;
 
   const [disableUser, { isLoading: isDisabling }] = useDisableUserMutation();
@@ -818,10 +818,9 @@ const UserProfile = () => {
     'users_disable'
   ]);
 
-  const profileAny = profile as Record<string, unknown>;
-  const profileDisabled = profileAny.disabled as boolean | undefined;
-  const profileWarned = profileAny.warned as string | null | undefined;
-  const profileIsDonor = profileAny.isDonor as boolean | undefined;
+  const profileDisabled = profile.disabled;
+  const profileWarned = profile.warned;
+  const profileIsDonor = profile.isDonor;
   const profileStats = profile.stats;
   const activitySummary = profile.activitySummary;
   const donorPresentation = profile.donorPresentation;

--- a/src/components/staff/DonationLogPage.tsx
+++ b/src/components/staff/DonationLogPage.tsx
@@ -1,0 +1,292 @@
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  useGetDonationsQuery,
+  useCreateDonationMutation,
+  useDeleteDonationMutation
+} from '../../store/services/adminApi';
+import { addAlert } from '../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../utils/apiError';
+import Spinner from '../layout/Spinner';
+
+const DonationLogPage = () => {
+  const dispatch = useDispatch();
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useGetDonationsQuery(page);
+  const [createDonation, { isLoading: isCreating }] =
+    useCreateDonationMutation();
+  const [deleteDonation] = useDeleteDonationMutation();
+
+  const [showForm, setShowForm] = useState(false);
+  const [userId, setUserId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [email, setEmail] = useState('');
+  const [donatedAt, setDonatedAt] = useState('');
+  const [currency, setCurrency] = useState('USD');
+  const [source, setSource] = useState('');
+  const [reason, setReason] = useState('');
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createDonation({
+        userId: Number(userId),
+        amount: parseFloat(amount),
+        email,
+        donatedAt: new Date(donatedAt).toISOString(),
+        currency: currency || undefined,
+        source: source || undefined,
+        reason
+      }).unwrap();
+      dispatch(addAlert('Donation recorded.', 'success'));
+      setUserId('');
+      setAmount('');
+      setEmail('');
+      setDonatedAt('');
+      setCurrency('USD');
+      setSource('');
+      setReason('');
+      setShowForm(false);
+    } catch (err) {
+      dispatch(
+        addAlert(
+          getApiErrorMessage(err) ?? 'Failed to record donation.',
+          'danger'
+        )
+      );
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteDonation(id).unwrap();
+      dispatch(addAlert('Donation removed.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(
+          getApiErrorMessage(err) ?? 'Failed to remove donation.',
+          'danger'
+        )
+      );
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-white">Donation Log</h2>
+        <button
+          onClick={() => setShowForm((v) => !v)}
+          className="px-3 py-1.5 bg-indigo-700 hover:bg-indigo-600 text-white text-sm rounded transition-colors"
+        >
+          {showForm ? 'Cancel' : '+ Manual entry'}
+        </button>
+      </div>
+
+      {showForm && (
+        <form
+          onSubmit={handleCreate}
+          className="bg-gray-900 border border-gray-700 rounded-lg p-4 space-y-3"
+        >
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label
+                htmlFor="don-userId"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                User ID <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="don-userId"
+                type="number"
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+                placeholder="123"
+                required
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="don-amount"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                Amount <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="don-amount"
+                type="number"
+                step="0.01"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="10.00"
+                required
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="don-email"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                Donor email <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="don-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="donor@example.com"
+                required
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="don-date"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                Date <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="don-date"
+                type="datetime-local"
+                value={donatedAt}
+                onChange={(e) => setDonatedAt(e.target.value)}
+                required
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="don-currency"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                Currency
+              </label>
+              <input
+                id="don-currency"
+                type="text"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value)}
+                placeholder="USD"
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="don-source"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                Source
+              </label>
+              <input
+                id="don-source"
+                type="text"
+                value={source}
+                onChange={(e) => setSource(e.target.value)}
+                placeholder="PayPal, Stripe…"
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+            <div className="col-span-2">
+              <label
+                htmlFor="don-reason"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                Reason <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="don-reason"
+                type="text"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder="General donation"
+                required
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={isCreating}
+            className="px-4 py-1.5 bg-green-700 hover:bg-green-600 disabled:opacity-50 text-white text-sm rounded transition-colors"
+          >
+            {isCreating ? 'Saving…' : 'Record donation'}
+          </button>
+        </form>
+      )}
+
+      <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+        <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 grid grid-cols-[auto_1fr_auto_auto_auto] gap-4 text-xs font-semibold uppercase tracking-wider text-gray-400">
+          <span>User</span>
+          <span>Email</span>
+          <span>Amount</span>
+          <span>Date</span>
+          <span />
+        </div>
+        {isLoading ? (
+          <div className="p-6 flex justify-center">
+            <Spinner />
+          </div>
+        ) : !data?.data.length ? (
+          <div className="px-4 py-6 text-sm text-gray-500 text-center">
+            No donations.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-700/40">
+            {data.data.map((d) => (
+              <div
+                key={d.id}
+                className="px-4 py-2 grid grid-cols-[auto_1fr_auto_auto_auto] gap-4 items-center text-sm"
+              >
+                <span className="text-gray-300">
+                  {d.user ? d.user.username : `#${d.userId}`}
+                </span>
+                <span className="text-gray-400 font-mono text-xs truncate">
+                  {d.email}
+                </span>
+                <span className="text-green-400 font-medium">
+                  {d.amount.toFixed(2)} {d.currency}
+                </span>
+                <span className="text-gray-500 text-xs">
+                  {new Date(d.donatedAt).toLocaleDateString()}
+                </span>
+                <button
+                  onClick={() => handleDelete(d.id)}
+                  className="text-xs text-red-500 hover:text-red-400 transition-colors"
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {data && data.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 text-sm">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="px-3 py-1 bg-gray-800 hover:bg-gray-700 disabled:opacity-40 text-gray-300 rounded transition-colors"
+          >
+            Prev
+          </button>
+          <span className="text-gray-500">
+            {page} / {data.totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+            disabled={page === data.totalPages}
+            className="px-3 py-1 bg-gray-800 hover:bg-gray-700 disabled:opacity-40 text-gray-300 rounded transition-colors"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DonationLogPage;

--- a/src/components/staff/DuplicateIpsPage.tsx
+++ b/src/components/staff/DuplicateIpsPage.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetDuplicateIpsQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+
+const DuplicateIpsPage = () => {
+  const { data: groups, isLoading } = useGetDuplicateIpsQuery();
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggle = (ip: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(ip)) next.delete(ip);
+      else next.add(ip);
+      return next;
+    });
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+      <h2 className="text-2xl font-bold text-white">Duplicate IP Detection</h2>
+
+      <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+        <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 grid grid-cols-[1fr_auto_auto] gap-4 text-xs font-semibold uppercase tracking-wider text-gray-400">
+          <span>IP Address</span>
+          <span className="text-right">Users</span>
+          <span />
+        </div>
+        {isLoading ? (
+          <div className="p-6 flex justify-center">
+            <Spinner />
+          </div>
+        ) : !groups?.length ? (
+          <div className="px-4 py-6 text-sm text-gray-500 text-center">
+            No duplicate IPs found.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-700/40">
+            {groups.map((group) => (
+              <div key={group.ip}>
+                <div className="px-4 py-2 grid grid-cols-[1fr_auto_auto] gap-4 items-center text-sm">
+                  <span className="font-mono text-gray-200">{group.ip}</span>
+                  <span className="text-gray-400 text-right">
+                    {group.count}
+                  </span>
+                  <button
+                    onClick={() => toggle(group.ip)}
+                    className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+                  >
+                    {expanded.has(group.ip) ? 'Hide' : 'Show'}
+                  </button>
+                </div>
+                {expanded.has(group.ip) && (
+                  <div className="bg-gray-950 border-t border-gray-700/40 px-6 py-2 space-y-1">
+                    {group.users.map((user) => (
+                      <div
+                        key={user.id}
+                        className="flex items-center gap-4 text-xs py-1"
+                      >
+                        <Link
+                          to={`/private/users/${user.id}`}
+                          className="text-indigo-400 hover:text-indigo-300 font-medium"
+                        >
+                          {user.username}
+                        </Link>
+                        <span className="text-gray-500">
+                          Registered{' '}
+                          {new Date(user.dateRegistered).toLocaleDateString()}
+                        </span>
+                        {user.disabled && (
+                          <span className="px-1.5 py-0.5 bg-red-900/50 text-red-400 rounded text-xs">
+                            Disabled
+                          </span>
+                        )}
+                        {user.lastLogin && (
+                          <span className="text-gray-600">
+                            Last login{' '}
+                            {new Date(user.lastLogin).toLocaleDateString()}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DuplicateIpsPage;

--- a/src/components/staff/EmailBlacklistPage.tsx
+++ b/src/components/staff/EmailBlacklistPage.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  useGetEmailBlacklistQuery,
+  useCreateEmailBlacklistEntryMutation,
+  useDeleteEmailBlacklistEntryMutation
+} from '../../store/services/adminApi';
+import { addAlert } from '../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../utils/apiError';
+import Spinner from '../layout/Spinner';
+
+const EmailBlacklistPage = () => {
+  const dispatch = useDispatch();
+  const { data: entries, isLoading } = useGetEmailBlacklistQuery();
+  const [createEntry, { isLoading: isCreating }] =
+    useCreateEmailBlacklistEntryMutation();
+  const [deleteEntry] = useDeleteEmailBlacklistEntryMutation();
+
+  const [email, setEmail] = useState('');
+  const [comment, setComment] = useState('');
+  const [showForm, setShowForm] = useState(false);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createEntry({ email, comment }).unwrap();
+      dispatch(addAlert('Email blacklisted.', 'success'));
+      setEmail('');
+      setComment('');
+      setShowForm(false);
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to add entry.', 'danger')
+      );
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteEntry(id).unwrap();
+      dispatch(addAlert('Entry removed.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to remove entry.', 'danger')
+      );
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-white">Email Blacklist</h2>
+        <button
+          onClick={() => setShowForm((v) => !v)}
+          className="px-3 py-1.5 bg-indigo-700 hover:bg-indigo-600 text-white text-sm rounded transition-colors"
+        >
+          {showForm ? 'Cancel' : '+ Add entry'}
+        </button>
+      </div>
+
+      {showForm && (
+        <form
+          onSubmit={handleCreate}
+          className="bg-gray-900 border border-gray-700 rounded-lg p-4 space-y-3"
+        >
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label
+                htmlFor="bl-email"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                Email <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="bl-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="bad@example.com"
+                required
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="bl-comment"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                Comment
+              </label>
+              <input
+                id="bl-comment"
+                type="text"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                placeholder="Reason for blacklisting"
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={isCreating}
+            className="px-4 py-1.5 bg-red-700 hover:bg-red-600 disabled:opacity-50 text-white text-sm rounded transition-colors"
+          >
+            {isCreating ? 'Adding…' : 'Add entry'}
+          </button>
+        </form>
+      )}
+
+      <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+        <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 grid grid-cols-[1fr_1fr_auto] gap-4 text-xs font-semibold uppercase tracking-wider text-gray-400">
+          <span>Email</span>
+          <span>Comment</span>
+          <span />
+        </div>
+        {isLoading ? (
+          <div className="p-6 flex justify-center">
+            <Spinner />
+          </div>
+        ) : !entries?.length ? (
+          <div className="px-4 py-6 text-sm text-gray-500 text-center">
+            No blacklisted emails.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-700/40">
+            {entries.map((entry) => (
+              <div
+                key={entry.id}
+                className="px-4 py-2 grid grid-cols-[1fr_1fr_auto] gap-4 items-center text-sm"
+              >
+                <span className="font-mono text-gray-200">{entry.email}</span>
+                <span className="text-gray-400">{entry.comment || '—'}</span>
+                <button
+                  onClick={() => handleDelete(entry.id)}
+                  className="text-xs text-red-500 hover:text-red-400 transition-colors"
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EmailBlacklistPage;

--- a/src/components/staff/IpBansPage.tsx
+++ b/src/components/staff/IpBansPage.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  useGetIpBansQuery,
+  useCreateIpBanMutation,
+  useDeleteIpBanMutation
+} from '../../store/services/adminApi';
+import { addAlert } from '../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../utils/apiError';
+import Spinner from '../layout/Spinner';
+
+const IpBansPage = () => {
+  const dispatch = useDispatch();
+  const { data: bans, isLoading } = useGetIpBansQuery();
+  const [createBan, { isLoading: isCreating }] = useCreateIpBanMutation();
+  const [deleteBan] = useDeleteIpBanMutation();
+
+  const [fromIp, setFromIp] = useState('');
+  const [toIp, setToIp] = useState('');
+  const [showForm, setShowForm] = useState(false);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createBan({ fromIp, toIp: toIp || undefined }).unwrap();
+      dispatch(addAlert('IP ban added.', 'success'));
+      setFromIp('');
+      setToIp('');
+      setShowForm(false);
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to add ban.', 'danger')
+      );
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteBan(id).unwrap();
+      dispatch(addAlert('IP ban removed.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to remove ban.', 'danger')
+      );
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-white">IP Address Bans</h2>
+        <button
+          onClick={() => setShowForm((v) => !v)}
+          className="px-3 py-1.5 bg-indigo-700 hover:bg-indigo-600 text-white text-sm rounded transition-colors"
+        >
+          {showForm ? 'Cancel' : '+ Add ban'}
+        </button>
+      </div>
+
+      {showForm && (
+        <form
+          onSubmit={handleCreate}
+          className="bg-gray-900 border border-gray-700 rounded-lg p-4 space-y-3"
+        >
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label
+                htmlFor="fromIp"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                From IP <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="fromIp"
+                type="text"
+                value={fromIp}
+                onChange={(e) => setFromIp(e.target.value)}
+                placeholder="192.168.1.1"
+                required
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="toIp"
+                className="block text-xs text-gray-400 mb-1"
+              >
+                To IP{' '}
+                <span className="text-gray-500">(optional — for ranges)</span>
+              </label>
+              <input
+                id="toIp"
+                type="text"
+                value={toIp}
+                onChange={(e) => setToIp(e.target.value)}
+                placeholder="192.168.1.255"
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={isCreating}
+            className="px-4 py-1.5 bg-red-700 hover:bg-red-600 disabled:opacity-50 text-white text-sm rounded transition-colors"
+          >
+            {isCreating ? 'Adding…' : 'Add ban'}
+          </button>
+        </form>
+      )}
+
+      <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+        <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 grid grid-cols-[1fr_1fr_auto] gap-4 text-xs font-semibold uppercase tracking-wider text-gray-400">
+          <span>From IP</span>
+          <span>To IP</span>
+          <span />
+        </div>
+        {isLoading ? (
+          <div className="p-6 flex justify-center">
+            <Spinner />
+          </div>
+        ) : !bans?.length ? (
+          <div className="px-4 py-6 text-sm text-gray-500 text-center">
+            No IP bans configured.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-700/40">
+            {bans.map((ban) => (
+              <div
+                key={ban.id}
+                className="px-4 py-2 grid grid-cols-[1fr_1fr_auto] gap-4 items-center text-sm"
+              >
+                <span className="font-mono text-gray-200">{ban.fromIp}</span>
+                <span className="font-mono text-gray-200">{ban.toIp}</span>
+                <button
+                  onClick={() => handleDelete(ban.id)}
+                  className="text-xs text-red-500 hover:text-red-400 transition-colors"
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default IpBansPage;

--- a/src/components/staff/RegistrationLogPage.tsx
+++ b/src/components/staff/RegistrationLogPage.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetRegistrationLogQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+
+const RegistrationLogPage = () => {
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useGetRegistrationLogQuery(page);
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-4">
+      <h2 className="text-2xl font-bold text-white">Registration Log</h2>
+
+      <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+        <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 grid grid-cols-[1fr_1fr_auto_auto_auto] gap-4 text-xs font-semibold uppercase tracking-wider text-gray-400">
+          <span>Username</span>
+          <span>Email</span>
+          <span>Rank</span>
+          <span>Registered</span>
+          <span>Last IP</span>
+        </div>
+        {isLoading ? (
+          <div className="p-6 flex justify-center">
+            <Spinner />
+          </div>
+        ) : !data?.data.length ? (
+          <div className="px-4 py-6 text-sm text-gray-500 text-center">
+            No users found.
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-700/40">
+            {data.data.map((user) => (
+              <div
+                key={user.id}
+                className="px-4 py-2 grid grid-cols-[1fr_1fr_auto_auto_auto] gap-4 items-center text-sm"
+              >
+                <div className="flex items-center gap-2">
+                  <Link
+                    to={`/private/users/${user.id}`}
+                    className="text-indigo-400 hover:text-indigo-300 font-medium"
+                  >
+                    {user.username}
+                  </Link>
+                  {user.disabled && (
+                    <span className="px-1 py-0.5 bg-red-900/50 text-red-400 rounded text-xs">
+                      Disabled
+                    </span>
+                  )}
+                </div>
+                <span className="text-gray-400 text-xs truncate">
+                  {user.email ?? '—'}
+                </span>
+                <span className="text-gray-400 text-xs">
+                  {user.userRank?.name ?? '—'}
+                </span>
+                <span className="text-gray-500 text-xs whitespace-nowrap">
+                  {new Date(user.dateRegistered).toLocaleDateString()}
+                </span>
+                <span className="font-mono text-gray-600 text-xs">
+                  {user.lastIp ?? '—'}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {data && data.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 text-sm">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="px-3 py-1 bg-gray-800 hover:bg-gray-700 disabled:opacity-40 text-gray-300 rounded transition-colors"
+          >
+            Prev
+          </button>
+          <span className="text-gray-500">
+            {page} / {data.totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+            disabled={page === data.totalPages}
+            className="px-3 py-1 bg-gray-800 hover:bg-gray-700 disabled:opacity-40 text-gray-300 rounded transition-colors"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RegistrationLogPage;

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -56,7 +56,10 @@ export const api = createApi({
     'ArtistSubscription',
     'RecoveryRequest',
     'StatsHistory',
-    'UserStats'
+    'UserStats',
+    'IpBan',
+    'EmailBlacklist',
+    'Donation'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/adminApi.ts
+++ b/src/store/services/adminApi.ts
@@ -1,0 +1,150 @@
+import { api } from '../api';
+
+export interface IpBan {
+  id: number;
+  fromIp: string;
+  toIp: string;
+}
+
+export interface EmailBlacklistEntry {
+  id: number;
+  userId: number;
+  email: string;
+  comment: string;
+  addedAt: string;
+}
+
+export interface Donation {
+  id: number;
+  userId: number;
+  user: { id: number; username: string } | null;
+  amount: number;
+  email: string;
+  donatedAt: string;
+  currency: string;
+  source: string;
+  reason: string;
+}
+
+export interface DuplicateIpUser {
+  id: number;
+  username: string;
+  dateRegistered: string;
+  disabled: boolean;
+  lastLogin: string | null;
+}
+
+export interface DuplicateIpGroup {
+  ip: string;
+  count: number;
+  users: DuplicateIpUser[];
+}
+
+export interface RegistrationLogUser {
+  id: number;
+  username: string;
+  email: string | null;
+  dateRegistered: string;
+  disabled: boolean;
+  lastIp: string | null;
+  userRank: { id: number; name: string } | null;
+}
+
+interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export const adminApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    // IP Bans
+    getIpBans: build.query<IpBan[], void>({
+      query: () => '/ip-bans',
+      providesTags: ['IpBan']
+    }),
+    createIpBan: build.mutation<IpBan, { fromIp: string; toIp?: string }>({
+      query: (data) => ({ url: '/ip-bans', method: 'POST', body: data }),
+      invalidatesTags: ['IpBan']
+    }),
+    deleteIpBan: build.mutation<void, number>({
+      query: (id) => ({ url: `/ip-bans/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['IpBan']
+    }),
+
+    // Email Blacklist
+    getEmailBlacklist: build.query<EmailBlacklistEntry[], void>({
+      query: () => '/email-blacklist',
+      providesTags: ['EmailBlacklist']
+    }),
+    createEmailBlacklistEntry: build.mutation<
+      EmailBlacklistEntry,
+      { email: string; comment: string }
+    >({
+      query: (data) => ({
+        url: '/email-blacklist',
+        method: 'POST',
+        body: data
+      }),
+      invalidatesTags: ['EmailBlacklist']
+    }),
+    deleteEmailBlacklistEntry: build.mutation<void, number>({
+      query: (id) => ({ url: `/email-blacklist/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['EmailBlacklist']
+    }),
+
+    // Donations
+    getDonations: build.query<PaginatedResponse<Donation>, number | void>({
+      query: (page = 1) => `/donations?page=${page}`,
+      providesTags: ['Donation']
+    }),
+    createDonation: build.mutation<
+      Donation,
+      {
+        userId: number;
+        amount: number;
+        email: string;
+        donatedAt: string;
+        currency?: string;
+        source?: string;
+        reason: string;
+      }
+    >({
+      query: (data) => ({ url: '/donations', method: 'POST', body: data }),
+      invalidatesTags: ['Donation']
+    }),
+    deleteDonation: build.mutation<void, number>({
+      query: (id) => ({ url: `/donations/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['Donation']
+    }),
+
+    // Duplicate IPs (read-only)
+    getDuplicateIps: build.query<DuplicateIpGroup[], void>({
+      query: () => '/users/duplicate-ips'
+    }),
+
+    // Registration Log (read-only, paginated)
+    getRegistrationLog: build.query<
+      PaginatedResponse<RegistrationLogUser>,
+      number | void
+    >({
+      query: (page = 1) => `/users/registration-log?page=${page}`
+    })
+  })
+});
+
+export const {
+  useGetIpBansQuery,
+  useCreateIpBanMutation,
+  useDeleteIpBanMutation,
+  useGetEmailBlacklistQuery,
+  useCreateEmailBlacklistEntryMutation,
+  useDeleteEmailBlacklistEntryMutation,
+  useGetDonationsQuery,
+  useCreateDonationMutation,
+  useDeleteDonationMutation,
+  useGetDuplicateIpsQuery,
+  useGetRegistrationLogQuery
+} = adminApi;

--- a/src/store/services/userApi.ts
+++ b/src/store/services/userApi.ts
@@ -137,11 +137,19 @@ export const userApi = api.injectEndpoints({
     }),
     disableUser: build.mutation<{ msg: string }, number>({
       query: (id) => ({ url: `/users/${id}/disable`, method: 'POST' }),
-      invalidatesTags: (_, __, id) => [{ type: 'User', id }, 'Profile']
+      invalidatesTags: (_, __, id) => [
+        { type: 'User', id },
+        { type: 'Profile', id },
+        'Profile'
+      ]
     }),
     enableUser: build.mutation<{ msg: string }, number>({
       query: (id) => ({ url: `/users/${id}/enable`, method: 'POST' }),
-      invalidatesTags: (_, __, id) => [{ type: 'User', id }, 'Profile']
+      invalidatesTags: (_, __, id) => [
+        { type: 'User', id },
+        { type: 'Profile', id },
+        'Profile'
+      ]
     }),
     setUserRank: build.mutation<
       { msg: string },


### PR DESCRIPTION
## Summary

- **Toolbox reorganization**: Staff Toolbox sections reordered and grouped (Administration, User Management, Announcements, Community, Managers, Users, Moderation, Finances)
- **Badge fixes**: disabled/warned/donor badges now use direct typed profile access instead of a cast workaround
- **Warning datetime**: converts `datetime-local` value to UTC ISO string before submitting
- **Disable/Enable toggle**: explicit `{ type: 'Profile', id }` invalidation ensures the button updates after disabling a user
- **Comments sidebar width**: `CommentsSection` rewritten in Tailwind — removes `cols={60}` that forced overflow in the collage sidebar
- **IP bans page**: list, add, and remove IP ban ranges
- **Email blacklist page**: list, add, and remove blacklisted emails
- **Donation log page**: paginated log with manual entry form
- **Duplicate IPs page**: expandable groups of users sharing the same last-seen IP
- **Registration log page**: paginated registration history with user rank and last IP

## Test plan

- [ ] Navigate to `/private/staff/tools` — verify section groupings match expected order
- [ ] View profile of a disabled user — X badge visible; warned user — triangle badge; donor — heart badge
- [ ] Warn a user with expiry set — no datetime validation error
- [ ] Disable a user — button immediately changes to "Enable Account"
- [ ] View a collage with sidebar comments — comment box stays within sidebar width
- [ ] Visit each new staff page (IP bans, Email blacklist, Donation log, Duplicate IPs, Registration log) — data loads correctly and CRUD actions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)