### PR TITLE
Add rules pages: public view, sub-pages, and staff toolbox manager

### DIFF
--- a/src/components/admin/RulesManager.tsx
+++ b/src/components/admin/RulesManager.tsx
@@ -1,0 +1,288 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetRulesIndexQuery,
+  useCreateRulesPageMutation,
+  useUpdateRulesPageMutation,
+  useDeleteRulesPageMutation,
+  type RulesPage
+} from '../../store/services/rulesApi';
+import { useDispatch } from 'react-redux';
+import { addAlert } from '../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../utils/apiError';
+import Spinner from '../layout/Spinner';
+
+const inputClass =
+  'rounded bg-gray-700 border border-gray-600 text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+const MainPageEditor = ({ page }: { page: RulesPage | null }) => {
+  const dispatch = useDispatch();
+  const [createPage, { isLoading: creating }] = useCreateRulesPageMutation();
+  const [updatePage, { isLoading: updating }] = useUpdateRulesPageMutation();
+
+  const [title, setTitle] = useState(page?.title ?? '');
+  const [body, setBody] = useState(page?.body ?? '');
+
+  const saving = creating || updating;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (page) {
+        await updatePage({ id: page.id, title, body }).unwrap();
+      } else {
+        await createPage({ title, body, isMain: true, slug: 'main' }).unwrap();
+      }
+      dispatch(addAlert('Main rules page saved.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to save.', 'danger')
+      );
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Page title"
+        required
+        className={`${inputClass} w-full`}
+      />
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Body (HTML supported: p, b, i, a, ul, li, code, blockquote…)"
+        rows={12}
+        required
+        className={`${inputClass} w-full font-mono`}
+      />
+      <button
+        type="submit"
+        disabled={saving}
+        className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-4 py-2 rounded text-sm font-medium transition-colors"
+      >
+        {saving ? 'Saving…' : page ? 'Save Changes' : 'Create Main Page'}
+      </button>
+    </form>
+  );
+};
+
+const SubPageForm = ({ onDone }: { onDone: () => void }) => {
+  const dispatch = useDispatch();
+  const [createPage, { isLoading }] = useCreateRulesPageMutation();
+
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [sortOrder, setSortOrder] = useState(0);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createPage({ title, body, sortOrder }).unwrap();
+      dispatch(addAlert('Sub-page created.', 'success'));
+      setTitle('');
+      setBody('');
+      setSortOrder(0);
+      onDone();
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to create.', 'danger')
+      );
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="p-4 border-t border-gray-700 space-y-3"
+    >
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-400">
+        New Sub-page
+      </h4>
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Title (slug auto-generated)"
+        required
+        className={`${inputClass} w-full`}
+      />
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Body (HTML supported: p, b, i, a, ul, li, code, blockquote…)"
+        rows={8}
+        required
+        className={`${inputClass} w-full font-mono`}
+      />
+      <div className="flex items-center gap-3">
+        <label
+          htmlFor="subpage-sort-order"
+          className="text-sm text-gray-400 whitespace-nowrap"
+        >
+          Sort order
+        </label>
+        <input
+          id="subpage-sort-order"
+          type="number"
+          min={0}
+          value={sortOrder}
+          onChange={(e) => setSortOrder(Number(e.target.value))}
+          className={`${inputClass} w-24`}
+        />
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-4 py-2 rounded text-sm font-medium transition-colors"
+        >
+          {isLoading ? 'Creating…' : 'Create Sub-page'}
+        </button>
+        <button
+          type="button"
+          onClick={onDone}
+          className="text-gray-400 hover:text-gray-200 px-4 py-2 rounded text-sm transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
+const RulesManager = () => {
+  const { data, isLoading, error } = useGetRulesIndexQuery();
+  const dispatch = useDispatch();
+  const [deletePage] = useDeleteRulesPageMutation();
+  const [showNewForm, setShowNewForm] = useState(false);
+
+  const handleDelete = async (id: number, title: string) => {
+    if (!confirm(`Delete "${title}"? This cannot be undone.`)) return;
+    try {
+      await deletePage(id).unwrap();
+      dispatch(addAlert('Sub-page deleted.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to delete.', 'danger')
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Rules Manager</h2>
+      </div>
+
+      {/* Main rules page editor */}
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        <div className="bg-gray-700/60 px-4 py-2 border-b border-gray-700">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-300">
+            Main Rules Page
+          </h3>
+        </div>
+        <div className="p-4">
+          {isLoading ? (
+            <Spinner />
+          ) : error ? (
+            <p className="text-sm text-red-400">Failed to load.</p>
+          ) : (
+            <MainPageEditor page={data?.main ?? null} />
+          )}
+        </div>
+      </div>
+
+      {/* Sub-pages */}
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        <div className="bg-gray-700/60 px-4 py-2 border-b border-gray-700 flex items-center justify-between">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-300">
+            Sub-pages
+          </h3>
+          {!showNewForm && (
+            <button
+              type="button"
+              onClick={() => setShowNewForm(true)}
+              className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+            >
+              + New sub-page
+            </button>
+          )}
+        </div>
+
+        {isLoading ? (
+          <Spinner />
+        ) : error ? (
+          <p className="p-4 text-sm text-red-400">Failed to load sub-pages.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">Title</th>
+                <th className="text-left px-4 py-2 font-semibold">Slug</th>
+                <th className="text-left px-4 py-2 font-semibold">Order</th>
+                <th className="px-4 py-2 font-semibold">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.pages.length ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No sub-pages yet.
+                  </td>
+                </tr>
+              ) : (
+                data.pages.map((page) => (
+                  <tr
+                    key={page.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2 text-gray-200 font-medium">
+                      <Link
+                        to={`/private/rules/${page.slug}`}
+                        className="hover:text-indigo-400 transition-colors"
+                      >
+                        {page.title}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 font-mono text-xs">
+                      {page.slug}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400">
+                      {page.sortOrder}
+                    </td>
+                    <td className="px-4 py-2 text-center">
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(page.id, page.title)}
+                        className="text-red-400 hover:text-red-300 transition-colors text-sm"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+
+        {showNewForm && <SubPageForm onDone={() => setShowNewForm(false)} />}
+      </div>
+    </div>
+  );
+};
+
+export default RulesManager;

--- a/src/components/admin/Toolbox.tsx
+++ b/src/components/admin/Toolbox.tsx
@@ -76,6 +76,16 @@ const sections: SectionProps[] = [
     ]
   },
   {
+    title: 'Content',
+    links: [
+      {
+        label: 'Rules manager',
+        to: '/private/staff/tools/rules',
+        permissions: ['rules_manage']
+      }
+    ]
+  },
+  {
     title: 'Announcements',
     links: [
       {

--- a/src/components/admin/UserRankFormPage.tsx
+++ b/src/components/admin/UserRankFormPage.tsx
@@ -34,7 +34,7 @@ const PERM_GROUPS: { title: string; perms: string[] }[] = [
   },
   {
     title: 'System',
-    perms: ['news_manage', 'staff', 'admin']
+    perms: ['news_manage', 'rules_manage', 'staff', 'admin']
   }
 ];
 

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -71,6 +71,9 @@ import WikiListPage from '../../../wiki/WikiListPage';
 import WikiViewPage from '../../../wiki/WikiViewPage';
 import WikiEditPage from '../../../wiki/WikiEditPage';
 import WikiHistoryPage from '../../../wiki/WikiHistoryPage';
+import RulesPage from '../../../rules/RulesPage';
+import RulesSubPage from '../../../rules/RulesSubPage';
+import RulesManager from '../../../admin/RulesManager';
 import ReleaseBrowsePage from '../../../releases/ReleaseBrowsePage';
 import ArtistBrowsePage from '../../../artists/ArtistBrowsePage';
 import LogBrowsePage from '../../../log/LogBrowsePage';
@@ -222,6 +225,7 @@ const PrivateContent = () => (
             'forums_moderate',
             'communities_manage',
             'news_manage',
+            'rules_manage',
             'users_edit'
           ]}
         >
@@ -387,6 +391,18 @@ const PrivateContent = () => (
     <Route path="reports/new" element={wrap(ReportForm)} />
     <Route path="reports/mine" element={wrap(MyReportsPage)} />
     <Route path="reports/:id" element={wrap(ReportDetailPage)} />
+
+    <Route
+      path="staff/tools/rules"
+      element={
+        <StaffGate permissions={['rules_manage']}>
+          <RulesManager />
+        </StaffGate>
+      }
+    />
+
+    <Route path="rules/:slug" element={wrap(RulesSubPage)} />
+    <Route path="rules" element={wrap(RulesPage)} />
 
     <Route path="wiki/new" element={wrap(WikiEditPage)} />
     <Route path="wiki/:id/edit" element={wrap(WikiEditPage)} />

--- a/src/components/pages/private/layout/PrivateHeader.tsx
+++ b/src/components/pages/private/layout/PrivateHeader.tsx
@@ -24,6 +24,7 @@ const navLinks = [
   { label: 'Forums', to: '/private/forums' },
   { label: 'Top 10', to: '/private/top10' },
   { label: 'Wiki', to: '/private/wiki' },
+  { label: 'Rules', to: '/private/rules' },
   { label: 'Staff', to: '/private/staff', end: true }
 ];
 

--- a/src/components/rules/RulesPage.tsx
+++ b/src/components/rules/RulesPage.tsx
@@ -1,0 +1,77 @@
+import { Link } from 'react-router-dom';
+import DOMPurify from 'dompurify';
+import { useGetRulesIndexQuery } from '../../store/services/rulesApi';
+import Spinner from '../layout/Spinner';
+
+const ALLOWED_TAGS = [
+  'b',
+  'i',
+  'u',
+  'em',
+  'strong',
+  'a',
+  'p',
+  'br',
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'code',
+  'pre',
+  'span'
+];
+
+const RulesPage = () => {
+  const { data, isLoading, error } = useGetRulesIndexQuery();
+
+  if (isLoading) return <Spinner />;
+
+  if (error)
+    return <div className="text-red-400 p-4">Failed to load rules.</div>;
+
+  const { main, pages } = data ?? { main: null, pages: [] };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold text-white mb-6">Rules</h1>
+
+      {main ? (
+        <div
+          className="prose prose-invert max-w-none mb-8 text-gray-200"
+          dangerouslySetInnerHTML={{
+            __html: DOMPurify.sanitize(main.body, {
+              ALLOWED_TAGS,
+              ALLOWED_ATTR: ['href', 'class']
+            })
+          }}
+        />
+      ) : (
+        <p className="text-gray-400 mb-8">
+          No rules content has been published yet.
+        </p>
+      )}
+
+      {pages.length > 0 && (
+        <div>
+          <h2 className="text-xl font-semibold text-white mb-4">
+            Rule Categories
+          </h2>
+          <ul className="space-y-2">
+            {pages.map((page) => (
+              <li key={page.id}>
+                <Link
+                  to={`/private/rules/${page.slug}`}
+                  className="text-indigo-400 hover:text-indigo-300 transition-colors"
+                >
+                  {page.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RulesPage;

--- a/src/components/rules/RulesSubPage.tsx
+++ b/src/components/rules/RulesSubPage.tsx
@@ -1,0 +1,65 @@
+import { Link, useParams } from 'react-router-dom';
+import DOMPurify from 'dompurify';
+import { useGetRulesPageQuery } from '../../store/services/rulesApi';
+import Spinner from '../layout/Spinner';
+
+const ALLOWED_TAGS = [
+  'b',
+  'i',
+  'u',
+  'em',
+  'strong',
+  'a',
+  'p',
+  'br',
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'code',
+  'pre',
+  'span'
+];
+
+const RulesSubPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const { data: page, isLoading, error } = useGetRulesPageQuery(slug!);
+
+  if (isLoading) return <Spinner />;
+
+  if (error || !page)
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <Link
+          to="/private/rules"
+          className="text-indigo-400 hover:text-indigo-300 text-sm mb-4 inline-block"
+        >
+          ← Back to Rules
+        </Link>
+        <p className="text-red-400 mt-4">Page not found.</p>
+      </div>
+    );
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <Link
+        to="/private/rules"
+        className="text-indigo-400 hover:text-indigo-300 text-sm mb-4 inline-block"
+      >
+        ← Back to Rules
+      </Link>
+      <h1 className="text-3xl font-bold text-white mb-6">{page.title}</h1>
+      <div
+        className="prose prose-invert max-w-none text-gray-200"
+        dangerouslySetInnerHTML={{
+          __html: DOMPurify.sanitize(page.body, {
+            ALLOWED_TAGS,
+            ALLOWED_ATTR: ['href', 'class']
+          })
+        }}
+      />
+    </div>
+  );
+};
+
+export default RulesSubPage;

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -60,7 +60,8 @@ export const api = createApi({
     'IpBan',
     'EmailBlacklist',
     'Donation',
-    'StaffGroup'
+    'StaffGroup',
+    'RulesPage'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/rulesApi.ts
+++ b/src/store/services/rulesApi.ts
@@ -1,0 +1,77 @@
+import { api } from '../api';
+
+export interface RulesPageAuthor {
+  id: number;
+  username: string;
+}
+
+export interface RulesPage {
+  id: number;
+  slug: string;
+  title: string;
+  body: string;
+  isMain: boolean;
+  sortOrder: number;
+  authorId: number;
+  author: RulesPageAuthor;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RulesIndex {
+  main: RulesPage | null;
+  pages: RulesPage[];
+}
+
+export interface CreateRulesPageArgs {
+  title: string;
+  slug?: string;
+  body: string;
+  isMain?: boolean;
+  sortOrder?: number;
+}
+
+export interface UpdateRulesPageArgs {
+  id: number;
+  title?: string;
+  body?: string;
+  isMain?: boolean;
+  sortOrder?: number;
+}
+
+export const rulesApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getRulesIndex: build.query<RulesIndex, void>({
+      query: () => '/rules',
+      providesTags: ['RulesPage']
+    }),
+    getRulesPage: build.query<RulesPage, string>({
+      query: (slug) => `/rules/${slug}`,
+      providesTags: (_result, _err, slug) => [{ type: 'RulesPage', id: slug }]
+    }),
+    createRulesPage: build.mutation<RulesPage, CreateRulesPageArgs>({
+      query: (body) => ({ url: '/rules', method: 'POST', body }),
+      invalidatesTags: ['RulesPage']
+    }),
+    updateRulesPage: build.mutation<RulesPage, UpdateRulesPageArgs>({
+      query: ({ id, ...body }) => ({
+        url: `/rules/${id}`,
+        method: 'PUT',
+        body
+      }),
+      invalidatesTags: ['RulesPage']
+    }),
+    deleteRulesPage: build.mutation<void, number>({
+      query: (id) => ({ url: `/rules/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['RulesPage']
+    })
+  })
+});
+
+export const {
+  useGetRulesIndexQuery,
+  useGetRulesPageQuery,
+  useCreateRulesPageMutation,
+  useUpdateRulesPageMutation,
+  useDeleteRulesPageMutation
+} = rulesApi;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -7302,6 +7302,231 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/rules': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Main rules page and sub-pages */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              main: components['schemas']['RulesPage'] & unknown;
+              pages: components['schemas']['RulesPage'][];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            title: string;
+            slug?: string;
+            body: string;
+            /** @default false */
+            isMain?: boolean;
+            /** @default 0 */
+            sortOrder?: number;
+          };
+        };
+      };
+      responses: {
+        /** @description Page created */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['RulesPage'];
+          };
+        };
+        /** @description Validation error */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ValidationError'];
+          };
+        };
+        /** @description Conflict */
+        409: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rules/{slug}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          slug: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Single rules page */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['RulesPage'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/rules/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            title?: string;
+            body?: string;
+            isMain?: boolean;
+            sortOrder?: number;
+          };
+        };
+      };
+      responses: {
+        /** @description Page updated */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['RulesPage'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    post?: never;
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Page deleted */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Cannot delete main page */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -8280,6 +8505,21 @@ export interface components {
       type: 'Daily' | 'Weekly';
       date: string;
       entries: components['schemas']['Top10SnapshotEntry'][];
+    };
+    RulesPage: {
+      id: number;
+      slug: string;
+      title: string;
+      body: string;
+      isMain: boolean;
+      sortOrder: number;
+      authorId: number;
+      author: {
+        id: number;
+        username: string;
+      };
+      createdAt: string;
+      updatedAt: string;
     };
   };
   responses: never;

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -15,6 +15,7 @@ export const VALID_PERMISSIONS = [
   'users_disable',
   'wiki_edit',
   'wiki_manage',
+  'rules_manage',
   'advanced_search',
   'users_search',
   'staff',


### PR DESCRIPTION
## Summary

- Public `/rules` landing page renders main rules body + linked sub-category list
- `/rules/:slug` renders individual category pages with breadcrumb
- Staff toolbox `Rules Manager` at `/staff/tools/rules`: inline main-page editor (create or update on first visit), sub-page list with delete, new sub-page form with title/body/sort-order
- `rules_manage` permission wired into the toolbox access gate, `UserRankFormPage` System group, and the manager route `StaffGate` — does not admit plain staff
- `Rules` nav link added between Wiki and Staff in the primary header
- Client-side DOMPurify sanitization before `dangerouslySetInnerHTML` in both view components
- `rulesApi` RTK Query slice; `RulesPage` cache tag; OpenAPI types regenerated

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run lint` — clean on changed files
- [ ] Manual: navigate to `/rules` (empty state), open toolbox as rules_manage user, create main page, create sub-page, verify public nav link and sub-page render, verify non-rules_manage user cannot access `/staff/tools/rules`
- [ ] Pair with stellar-api PR #37 — migration must run before testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)