### PR TITLE
Add friends feature

### DIFF
--- a/src/__tests__/profile/UserProfile.integration.test.tsx
+++ b/src/__tests__/profile/UserProfile.integration.test.tsx
@@ -182,6 +182,8 @@ const setupFetch = (opts: FetchOpts = {}) => {
       return Promise.resolve(makeResponse({ body: [] }));
     if (pathname === '/api/users/me/snatch-list')
       return Promise.resolve(makeResponse({ body: [] }));
+    if (pathname === `/api/friends/status/42`)
+      return Promise.resolve(makeResponse({ body: { isFriend: false } }));
 
     return Promise.resolve(
       makeResponse({

--- a/src/__tests__/profile/UserProfile.test.tsx
+++ b/src/__tests__/profile/UserProfile.test.tsx
@@ -199,6 +199,12 @@ jest.mock('../../store/services/profileApi', () => ({
   useGetMyRatioStatsQuery: () => ({ data: mockMyRatioStats, isLoading: false })
 }));
 
+jest.mock('../../store/services/friendApi', () => ({
+  useGetFriendStatusQuery: () => ({ data: { isFriend: false } }),
+  useAddFriendMutation: () => [jest.fn(), { isLoading: false }],
+  useRemoveFriendMutation: () => [jest.fn(), { isLoading: false }]
+}));
+
 describe('UserProfile', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/components/pages/private/friends/FriendsPage.tsx
+++ b/src/components/pages/private/friends/FriendsPage.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import {
+  useGetMyFriendsQuery,
+  useRemoveFriendMutation,
+  useUpdateFriendCommentMutation
+} from '../../../../store/services/friendApi';
+import { addAlert } from '../../../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../../../utils/apiError';
+import Spinner from '../../../layout/Spinner';
+
+const FriendsPage = () => {
+  const dispatch = useDispatch();
+  const [page, setPage] = useState(1);
+  const [editingComment, setEditingComment] = useState<Record<number, string>>(
+    {}
+  );
+
+  const { data, isLoading, error } = useGetMyFriendsQuery(page);
+  const [removeFriend] = useRemoveFriendMutation();
+  const [updateComment] = useUpdateFriendCommentMutation();
+
+  const totalPages = data?.meta.totalPages ?? 1;
+
+  const handleRemove = async (userId: number, username: string) => {
+    if (!window.confirm(`Remove ${username} from your friends list?`)) return;
+    try {
+      await removeFriend(userId).unwrap();
+      dispatch(addAlert(`${username} removed from friends.`, 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(
+          getApiErrorMessage(err) ?? 'Failed to remove friend.',
+          'danger'
+        )
+      );
+    }
+  };
+
+  const handleCommentUpdate = async (userId: number) => {
+    const comment = editingComment[userId] ?? '';
+    try {
+      await updateComment({ userId, comment }).unwrap();
+      dispatch(addAlert('Note updated.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to update note.', 'danger')
+      );
+    }
+  };
+
+  if (isLoading) return <Spinner />;
+  if (error)
+    return (
+      <p className="p-6 text-red-400 text-sm">Failed to load friends list.</p>
+    );
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-4">
+      <h1 className="text-xl font-semibold text-white">Friends</h1>
+
+      {!data || data.data.length === 0 ? (
+        <div className="rounded border border-gray-700 bg-gray-900 px-6 py-10 text-center">
+          <p className="text-gray-500 text-sm">
+            You haven&apos;t added any friends yet.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded border border-gray-700 bg-gray-900 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-700 text-gray-400 text-left">
+                <th className="px-4 py-3 font-medium">User</th>
+                <th className="px-4 py-3 font-medium">Note</th>
+                <th className="px-4 py-3 font-medium text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800">
+              {data.data.map((entry) => {
+                const { friend, comment } = entry;
+                const draft =
+                  editingComment[friend.id] !== undefined
+                    ? editingComment[friend.id]
+                    : comment;
+                const isDirty = draft !== comment;
+
+                return (
+                  <tr
+                    key={friend.id}
+                    className="hover:bg-gray-800/30 transition-colors"
+                  >
+                    <td className="px-4 py-3">
+                      <Link
+                        to={`/private/user/${friend.id}`}
+                        className="text-indigo-400 hover:text-indigo-300 transition-colors font-medium"
+                      >
+                        {friend.username}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3">
+                      <textarea
+                        rows={2}
+                        maxLength={500}
+                        value={draft}
+                        onChange={(e) =>
+                          setEditingComment((prev) => ({
+                            ...prev,
+                            [friend.id]: e.target.value
+                          }))
+                        }
+                        className="w-full rounded bg-gray-700 border border-gray-600 text-white text-sm px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-none"
+                        placeholder="Private note…"
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-right whitespace-nowrap space-x-3">
+                      {isDirty && (
+                        <button
+                          onClick={() => handleCommentUpdate(friend.id)}
+                          className="text-indigo-400 hover:text-indigo-300 text-sm transition-colors"
+                        >
+                          Save
+                        </button>
+                      )}
+                      <Link
+                        to={`/private/messages/new?to=${friend.username}`}
+                        className="text-gray-400 hover:text-white text-sm transition-colors"
+                      >
+                        Message
+                      </Link>
+                      <button
+                        onClick={() => handleRemove(friend.id, friend.username)}
+                        className="text-red-500 hover:text-red-400 text-sm transition-colors"
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2 mt-4 text-sm">
+          <button
+            disabled={page === 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40 text-white"
+          >
+            Previous
+          </button>
+          <span className="px-3 py-1 text-gray-400">
+            {page} / {totalPages}
+          </span>
+          <button
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40 text-white"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FriendsPage;

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -67,6 +67,7 @@ import DuplicateIpsPage from '../../../staff/DuplicateIpsPage';
 import RegistrationLogPage from '../../../staff/RegistrationLogPage';
 import SnatchList from '../snatch/SnatchList';
 import BookmarksPage from '../bookmarks/BookmarksPage';
+import FriendsPage from '../friends/FriendsPage';
 import WikiListPage from '../../../wiki/WikiListPage';
 import WikiViewPage from '../../../wiki/WikiViewPage';
 import WikiEditPage from '../../../wiki/WikiEditPage';
@@ -124,6 +125,7 @@ const PrivateContent = () => (
     <Route path="invite" element={<InviteForm />} />
     <Route path="ratio" element={wrap(RatioRulesPage)} />
     <Route path="bookmarks" element={wrap(BookmarksPage)} />
+    <Route path="friends" element={wrap(FriendsPage)} />
 
     <Route path="staff" element={wrap(StaffPage)} />
     <Route

--- a/src/components/pages/private/layout/PrivateHeader.tsx
+++ b/src/components/pages/private/layout/PrivateHeader.tsx
@@ -125,6 +125,12 @@ const PrivateHeader = ({ user }: Props) => {
             >
               Bookmarks
             </Link>
+            <Link
+              to="/private/friends"
+              className="hover:text-gray-200 transition-colors"
+            >
+              Friends
+            </Link>
           </div>
         </div>
       </div>

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -28,6 +28,11 @@ import {
   useTriggerUserRecoveryMutation,
   useSetStaffBioMutation
 } from '../../store/services/userApi';
+import {
+  useGetFriendStatusQuery,
+  useAddFriendMutation,
+  useRemoveFriendMutation
+} from '../../store/services/friendApi';
 import { addAlert } from '../../store/slices/alertSlice';
 import { getApiErrorMessage } from '../../utils/apiError';
 import { hasAnyPermission } from '../../utils/permissions';
@@ -854,6 +859,12 @@ const UserProfile = () => {
   const { data: myRatioStats } = useGetMyRatioStatsQuery(undefined, {
     skip: !isOwnProfile
   });
+  const dispatch = useDispatch();
+  const { data: friendStatus } = useGetFriendStatusQuery(Number(id), {
+    skip: isOwnProfile || !currentUser
+  });
+  const [addFriend] = useAddFriendMutation();
+  const [removeFriend] = useRemoveFriendMutation();
 
   if (isLoading) return <Spinner />;
   if (error) {
@@ -941,6 +952,55 @@ const UserProfile = () => {
               >
                 Send Message
               </Link>
+              {friendStatus?.isFriend ? (
+                <button
+                  onClick={async () => {
+                    try {
+                      await removeFriend(profile.id).unwrap();
+                      dispatch(
+                        addAlert(
+                          `${profile.username} removed from friends.`,
+                          'success'
+                        )
+                      );
+                    } catch (err) {
+                      dispatch(
+                        addAlert(
+                          getApiErrorMessage(err) ?? 'Failed to remove friend.',
+                          'danger'
+                        )
+                      );
+                    }
+                  }}
+                  className="text-indigo-400 hover:text-indigo-300 transition-colors"
+                >
+                  Remove Friend
+                </button>
+              ) : (
+                <button
+                  onClick={async () => {
+                    try {
+                      await addFriend(profile.id).unwrap();
+                      dispatch(
+                        addAlert(
+                          `${profile.username} added to friends.`,
+                          'success'
+                        )
+                      );
+                    } catch (err) {
+                      dispatch(
+                        addAlert(
+                          getApiErrorMessage(err) ?? 'Failed to add friend.',
+                          'danger'
+                        )
+                      );
+                    }
+                  }}
+                  className="text-indigo-400 hover:text-indigo-300 transition-colors"
+                >
+                  Add to Friends
+                </button>
+              )}
               <Link
                 to={`/private/reports/new?targetType=User&targetId=${profile.id}`}
                 className="text-gray-500 hover:text-gray-300 transition-colors"

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -61,7 +61,8 @@ export const api = createApi({
     'EmailBlacklist',
     'Donation',
     'StaffGroup',
-    'RulesPage'
+    'RulesPage',
+    'Friend'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/friendApi.ts
+++ b/src/store/services/friendApi.ts
@@ -1,0 +1,56 @@
+import { api } from '../api';
+import type { paths } from '../../types/api';
+
+type FriendsListResponse =
+  paths['/friends']['get']['responses'][200]['content']['application/json'];
+
+type FriendStatusResponse =
+  paths['/friends/status/{userId}']['get']['responses'][200]['content']['application/json'];
+
+type UpdateCommentArgs = {
+  userId: number;
+  comment: string;
+};
+
+export const friendApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getMyFriends: build.query<FriendsListResponse, number>({
+      query: (page) => `/friends?page=${page}`,
+      providesTags: [{ type: 'Friend', id: 'LIST' }]
+    }),
+    getFriendStatus: build.query<FriendStatusResponse, number>({
+      query: (userId) => `/friends/status/${userId}`,
+      providesTags: (_r, _e, userId) => [{ type: 'Friend', id: userId }]
+    }),
+    addFriend: build.mutation<void, number>({
+      query: (userId) => ({ url: `/friends/${userId}`, method: 'POST' }),
+      invalidatesTags: (_r, _e, userId) => [
+        { type: 'Friend', id: 'LIST' },
+        { type: 'Friend', id: userId }
+      ]
+    }),
+    removeFriend: build.mutation<void, number>({
+      query: (userId) => ({ url: `/friends/${userId}`, method: 'DELETE' }),
+      invalidatesTags: (_r, _e, userId) => [
+        { type: 'Friend', id: 'LIST' },
+        { type: 'Friend', id: userId }
+      ]
+    }),
+    updateFriendComment: build.mutation<void, UpdateCommentArgs>({
+      query: ({ userId, comment }) => ({
+        url: `/friends/${userId}/comment`,
+        method: 'PUT',
+        body: { comment }
+      }),
+      invalidatesTags: [{ type: 'Friend', id: 'LIST' }]
+    })
+  })
+});
+
+export const {
+  useGetMyFriendsQuery,
+  useGetFriendStatusQuery,
+  useAddFriendMutation,
+  useRemoveFriendMutation,
+  useUpdateFriendCommentMutation
+} = friendApi;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -7527,6 +7527,253 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/friends': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: number;
+          limit?: number;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated friends list */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['FriendEntry'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+        /** @description Not authenticated */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/friends/status/{userId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          userId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Friend status */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              isFriend: boolean;
+            };
+          };
+        };
+        /** @description Not authenticated */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/friends/{userId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          userId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Friend added */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Cannot add self */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description User not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Already friends */
+        409: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          userId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Friend removed */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Not authenticated */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/friends/{userId}/comment': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          userId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            comment: string;
+          };
+        };
+      };
+      responses: {
+        /** @description Comment updated */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Validation error */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ValidationError'];
+          };
+        };
+        /** @description Friend not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -8520,6 +8767,17 @@ export interface components {
       };
       createdAt: string;
       updatedAt: string;
+    };
+    FriendEntry: {
+      id: number;
+      userId: number;
+      friendId: number;
+      comment: string;
+      friend: {
+        id: number;
+        username: string;
+        avatar: string | null;
+      };
     };
   };
   responses: never;


### PR DESCRIPTION
## Summary

- Friends list page at `/private/friends` — paginated table with inline note editing, remove action, and message link per entry
- Add/Remove Friend buttons on user profiles, toggling based on live status query with alert feedback
- Friends link added to the subnav quicklinks bar after Bookmarks (not in primary nav)
- `friendApi` RTK Query service using generated OpenAPI types; `Friend` tag type added
- `src/types/api.ts` regenerated from updated OpenAPI spec (requires stellar-api#38)

## Test plan

- [ ] `npx jest --runInBand --no-coverage` — 1116 tests, all passing
- [ ] `npx tsc --noEmit` — clean
- [ ] Visit another user's profile → "Add to Friends" button visible
- [ ] Click Add → button toggles to "Remove Friend", success alert shown
- [ ] Navigate to `/private/friends` → user appears with empty note field
- [ ] Edit note → Save button appears on change → click Save → note persists on reload
- [ ] Click Remove → confirm dialog → user removed from list
- [ ] Friends link visible in subnav after Bookmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)