### PR TITLE
Add donor system: settings tab, donate page, rank management, and API fixes

### DIFF
--- a/src/__tests__/staff/DonorRanksPage.test.tsx
+++ b/src/__tests__/staff/DonorRanksPage.test.tsx
@@ -6,6 +6,8 @@ import DonorRanksPage from '../../components/staff/DonorRanksPage';
 
 const mockGetDonorRanksQuery = jest.fn();
 const mockCreateDonorRank = jest.fn();
+const mockUpdateDonorRank = jest.fn();
+const mockDeleteDonorRank = jest.fn();
 const mockDispatch = jest.fn();
 
 let mockIsCreating = false;
@@ -15,7 +17,9 @@ jest.mock('../../store/services/userApi', () => ({
   useCreateDonorRankMutation: () => [
     mockCreateDonorRank,
     { isLoading: mockIsCreating }
-  ]
+  ],
+  useUpdateDonorRankMutation: () => [mockUpdateDonorRank, { isLoading: false }],
+  useDeleteDonorRankMutation: () => [mockDeleteDonorRank, { isLoading: false }]
 }));
 
 jest.mock('react-redux', () => ({
@@ -36,6 +40,8 @@ describe('DonorRanksPage', () => {
     jest.clearAllMocks();
     mockIsCreating = false;
     mockCreateDonorRank.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockUpdateDonorRank.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockDeleteDonorRank.mockReturnValue({ unwrap: () => Promise.resolve({}) });
   });
 
   it('shows spinner while loading', () => {

--- a/src/components/donate/DonatePage.tsx
+++ b/src/components/donate/DonatePage.tsx
@@ -1,0 +1,157 @@
+import { Link } from 'react-router-dom';
+import { useGetDonorRanksQuery } from '../../store/services/userApi';
+import Spinner from '../layout/Spinner';
+
+const PERK_LABELS: Record<string, string> = {
+  iconMouseOverText: 'Custom icon mouseover text',
+  avatarMouseOverText: 'Donor avatar mouseover text',
+  customIcon: 'Custom donor icon',
+  customIconLink: 'Custom icon link',
+  secondAvatar: 'Second (donor) avatar',
+  forumTitle: 'Custom forum title prefix and suffix',
+  profileInfo1: 'Profile info block 1',
+  profileInfo2: 'Profile info block 2',
+  profileInfo3: 'Profile info block 3',
+  profileInfo4: 'Profile info block 4'
+};
+
+const Section = ({
+  title,
+  children
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <div>
+    <h2 className="text-lg font-semibold text-white mb-3">{title}</h2>
+    <div className="bg-gray-900 border border-gray-700 rounded-lg p-5 text-sm text-gray-300 leading-relaxed">
+      {children}
+    </div>
+  </div>
+);
+
+const DonatePage = () => {
+  const { data: ranks, isLoading } = useGetDonorRanksQuery();
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+      <h1 className="text-2xl font-bold text-white">Donate</h1>
+
+      <Section title="Why donate?">
+        <p>
+          This site has no advertisements, is not sponsored, and provides its
+          services free of charge. For these reasons, its financial obligations
+          can only be met with the help of voluntary user donations. Supporting
+          the site is and will always remain voluntary. If you are financially
+          able, help pay the site&apos;s bills by donating. The site&apos;s
+          survival is up to you.
+        </p>
+        <p className="mt-3">
+          All voluntary donations are used exclusively to cover the costs of
+          running the site and tracker — server hardware, hosting, bandwidth,
+          and related operating expenses. No staff member or other individual
+          responsible for the site&apos;s operation personally profits from user
+          donations.
+        </p>
+        <p className="mt-3">
+          When you donate you aren&apos;t paying the staff, purchasing upload
+          credit, or buying the ability to download. When you donate you are
+          paying the site&apos;s bills.
+        </p>
+      </Section>
+
+      <Section title="How to donate">
+        <p>
+          To make a donation, contact a staff member via private message. You
+          can find the current staff list on the{' '}
+          <Link
+            to="/private/staff"
+            className="text-indigo-400 hover:text-indigo-300 transition-colors"
+          >
+            Staff page
+          </Link>
+          . A staff member will provide payment details and process your
+          donation manually.
+        </p>
+      </Section>
+
+      <Section title="What you will receive">
+        <p>
+          Donors are granted a Donor Rank by staff after a donation is
+          processed. Each rank comes with a set of cosmetic and customization
+          perks.
+        </p>
+
+        {isLoading ? (
+          <div className="mt-4">
+            <Spinner />
+          </div>
+        ) : ranks && ranks.length > 0 ? (
+          <div className="mt-4 space-y-4">
+            {ranks.map((rank) => {
+              const perks =
+                (rank.perks as Record<string, boolean> | null) ?? {};
+              const enabledPerks = Object.entries(perks)
+                .filter(([, enabled]) => enabled)
+                .map(([key]) => PERK_LABELS[key] ?? key);
+
+              return (
+                <div
+                  key={rank.id}
+                  className="rounded border border-gray-700 bg-gray-800/60 p-4"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    {rank.badge && (
+                      <span className="text-base">{rank.badge}</span>
+                    )}
+                    <span
+                      className="font-semibold text-white"
+                      style={{ color: rank.color || undefined }}
+                    >
+                      {rank.name}
+                    </span>
+                    <span className="text-xs text-gray-500 ml-auto">
+                      ${rank.minDonation} minimum
+                      {rank.expiresAfterDays != null &&
+                        ` · expires after ${rank.expiresAfterDays} days`}
+                    </span>
+                  </div>
+                  {enabledPerks.length > 0 ? (
+                    <ul className="list-disc list-inside space-y-0.5 text-gray-300">
+                      {enabledPerks.map((label) => (
+                        <li key={label}>{label}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-gray-500 text-xs">
+                      No additional perks configured for this rank.
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="mt-4 text-gray-500">
+            No donor ranks are currently configured.
+          </p>
+        )}
+
+        <p className="mt-4 text-gray-400">
+          All donor perks are cosmetic or customization options. They are
+          subject to change or cancellation at any time without notice.
+        </p>
+      </Section>
+
+      <Section title="What you won't receive">
+        <ul className="list-disc list-inside space-y-1">
+          <li>Immunity from the rules</li>
+          <li>Additional upload credit</li>
+          <li>The ability to break or circumvent site policies</li>
+        </ul>
+      </Section>
+    </div>
+  );
+};
+
+export default DonatePage;

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -56,6 +56,12 @@ const UserMenu = ({ user }: Props) => {
       >
         Invite ({inviteDisplay})
       </Link>
+      <Link
+        to="/private/donate"
+        className="px-3 py-1.5 rounded text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+      >
+        Donate
+      </Link>
     </div>
   );
 };

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -68,6 +68,7 @@ import RegistrationLogPage from '../../../staff/RegistrationLogPage';
 import SnatchList from '../snatch/SnatchList';
 import BookmarksPage from '../bookmarks/BookmarksPage';
 import FriendsPage from '../friends/FriendsPage';
+import DonatePage from '../../../donate/DonatePage';
 import WikiListPage from '../../../wiki/WikiListPage';
 import WikiViewPage from '../../../wiki/WikiViewPage';
 import WikiEditPage from '../../../wiki/WikiEditPage';
@@ -123,6 +124,7 @@ const PrivateContent = () => (
     <Route path="user/invite-tree" element={<InviteTree />} />
     <Route path="user/:id" element={wrap(UserProfile)} />
     <Route path="invite" element={<InviteForm />} />
+    <Route path="donate" element={wrap(DonatePage)} />
     <Route path="ratio" element={wrap(RatioRulesPage)} />
     <Route path="bookmarks" element={wrap(BookmarksPage)} />
     <Route path="friends" element={wrap(FriendsPage)} />

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -1065,6 +1065,9 @@ const UserProfile = () => {
                             <img
                               src={donorPresentation.customIcon}
                               alt=""
+                              title={
+                                donorPresentation.iconMouseOverText ?? undefined
+                              }
                               className="h-12 w-12 object-contain rounded border border-pink-900/40 bg-black/20"
                             />
                           </a>
@@ -1072,6 +1075,9 @@ const UserProfile = () => {
                           <img
                             src={donorPresentation.customIcon}
                             alt=""
+                            title={
+                              donorPresentation.iconMouseOverText ?? undefined
+                            }
                             className="h-12 w-12 object-contain rounded border border-pink-900/40 bg-black/20"
                           />
                         )}
@@ -1085,6 +1091,9 @@ const UserProfile = () => {
                         <img
                           src={donorPresentation.secondAvatar}
                           alt=""
+                          title={
+                            donorPresentation.avatarMouseOverText ?? undefined
+                          }
                           className="h-20 w-20 object-cover rounded border border-pink-900/40"
                         />
                       </div>

--- a/src/components/profile/settings/DonorSettingsTab.tsx
+++ b/src/components/profile/settings/DonorSettingsTab.tsx
@@ -1,0 +1,393 @@
+import { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  useGetDonorRewardsQuery,
+  useUpdateDonorRewardsMutation,
+  useUpdateDonorForumTitleMutation
+} from '../../../store/services/profileApi';
+import { addAlert } from '../../../store/slices/alertSlice';
+import { getApiErrorMessage } from '../../../utils/apiError';
+import Spinner from '../../layout/Spinner';
+
+const inputClass =
+  'w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500';
+const labelClass = 'block text-sm text-gray-300 mb-1';
+const lockedClass = 'block text-sm text-gray-600 mb-1 cursor-not-allowed';
+
+const LockedNote = () => (
+  <p className="text-xs text-gray-600 mt-1">
+    Not included in your current donor rank.
+  </p>
+);
+
+const DonorSettingsTab = () => {
+  const dispatch = useDispatch();
+  const { data, isLoading } = useGetDonorRewardsQuery();
+  const [updateRewards, { isLoading: isSavingRewards }] =
+    useUpdateDonorRewardsMutation();
+  const [updateTitle, { isLoading: isSavingTitle }] =
+    useUpdateDonorForumTitleMutation();
+
+  const perks = data?.perks ?? {};
+  const rewards = data?.rewards;
+  const forumTitle = data?.forumTitle;
+
+  const [iconMouseOverText, setIconMouseOverText] = useState('');
+  const [avatarMouseOverText, setAvatarMouseOverText] = useState('');
+  const [customIcon, setCustomIcon] = useState('');
+  const [customIconLink, setCustomIconLink] = useState('');
+  const [secondAvatar, setSecondAvatar] = useState('');
+  const [profileInfoTitle1, setProfileInfoTitle1] = useState('');
+  const [profileInfo1, setProfileInfo1] = useState('');
+  const [profileInfoTitle2, setProfileInfoTitle2] = useState('');
+  const [profileInfo2, setProfileInfo2] = useState('');
+  const [profileInfoTitle3, setProfileInfoTitle3] = useState('');
+  const [profileInfo3, setProfileInfo3] = useState('');
+  const [profileInfoTitle4, setProfileInfoTitle4] = useState('');
+  const [profileInfo4, setProfileInfo4] = useState('');
+  const [titlePrefix, setTitlePrefix] = useState('');
+  const [titleSuffix, setTitleSuffix] = useState('');
+  const [titleUseComma, setTitleUseComma] = useState(false);
+
+  useEffect(() => {
+    if (!rewards) return;
+    setIconMouseOverText(rewards.iconMouseOverText ?? '');
+    setAvatarMouseOverText(rewards.avatarMouseOverText ?? '');
+    setCustomIcon(rewards.customIcon ?? '');
+    setCustomIconLink(rewards.customIconLink ?? '');
+    setSecondAvatar(rewards.secondAvatar ?? '');
+    setProfileInfoTitle1(rewards.profileInfoTitle1 ?? '');
+    setProfileInfo1(rewards.profileInfo1 ?? '');
+    setProfileInfoTitle2(rewards.profileInfoTitle2 ?? '');
+    setProfileInfo2(rewards.profileInfo2 ?? '');
+    setProfileInfoTitle3(rewards.profileInfoTitle3 ?? '');
+    setProfileInfo3(rewards.profileInfo3 ?? '');
+    setProfileInfoTitle4(rewards.profileInfoTitle4 ?? '');
+    setProfileInfo4(rewards.profileInfo4 ?? '');
+    if (forumTitle) {
+      setTitlePrefix(forumTitle.prefix ?? '');
+      setTitleSuffix(forumTitle.suffix ?? '');
+      setTitleUseComma(forumTitle.useComma ?? false);
+    }
+  }, [rewards, forumTitle]);
+
+  const handleSaveRewards = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await updateRewards({
+        iconMouseOverText: iconMouseOverText || undefined,
+        avatarMouseOverText: avatarMouseOverText || undefined,
+        customIcon: customIcon || undefined,
+        customIconLink: customIconLink || undefined,
+        secondAvatar: secondAvatar || undefined,
+        profileInfoTitle1: profileInfoTitle1 || undefined,
+        profileInfo1: profileInfo1 || undefined,
+        profileInfoTitle2: profileInfoTitle2 || undefined,
+        profileInfo2: profileInfo2 || undefined,
+        profileInfoTitle3: profileInfoTitle3 || undefined,
+        profileInfo3: profileInfo3 || undefined,
+        profileInfoTitle4: profileInfoTitle4 || undefined,
+        profileInfo4: profileInfo4 || undefined
+      }).unwrap();
+      dispatch(addAlert('Donor settings saved.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(
+          getApiErrorMessage(err) ?? 'Failed to save donor settings.',
+          'danger'
+        )
+      );
+    }
+  };
+
+  const handleSaveTitle = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await updateTitle({
+        prefix: titlePrefix || undefined,
+        suffix: titleSuffix || undefined,
+        useComma: titleUseComma
+      }).unwrap();
+      dispatch(addAlert('Forum title saved.', 'success'));
+    } catch (err) {
+      dispatch(
+        addAlert(
+          getApiErrorMessage(err) ?? 'Failed to save forum title.',
+          'danger'
+        )
+      );
+    }
+  };
+
+  if (isLoading) return <Spinner />;
+
+  return (
+    <div className="space-y-6">
+      <form
+        onSubmit={handleSaveRewards}
+        className="bg-gray-800 rounded-lg border border-gray-700 p-5 space-y-5"
+      >
+        <h3 className="text-sm font-semibold text-gray-200 uppercase tracking-wider">
+          Donor Rewards
+        </h3>
+
+        {/* Icons */}
+        <div className="space-y-3">
+          <div>
+            <label
+              htmlFor="donor-custom-icon"
+              className={perks.customIcon ? labelClass : lockedClass}
+            >
+              Custom icon URL
+            </label>
+            <input
+              id="donor-custom-icon"
+              type="text"
+              value={customIcon}
+              onChange={(e) => setCustomIcon(e.target.value)}
+              disabled={!perks.customIcon}
+              placeholder="https://…"
+              className={inputClass + (!perks.customIcon ? ' opacity-40' : '')}
+            />
+            {!perks.customIcon && <LockedNote />}
+          </div>
+
+          <div>
+            <label
+              htmlFor="donor-custom-icon-link"
+              className={perks.customIconLink ? labelClass : lockedClass}
+            >
+              Custom icon link URL
+            </label>
+            <input
+              id="donor-custom-icon-link"
+              type="text"
+              value={customIconLink}
+              onChange={(e) => setCustomIconLink(e.target.value)}
+              disabled={!perks.customIconLink}
+              placeholder="https://…"
+              className={
+                inputClass + (!perks.customIconLink ? ' opacity-40' : '')
+              }
+            />
+            {!perks.customIconLink && <LockedNote />}
+          </div>
+
+          <div>
+            <label
+              htmlFor="donor-icon-mouseover"
+              className={perks.iconMouseOverText ? labelClass : lockedClass}
+            >
+              Icon mouseover text
+            </label>
+            <input
+              id="donor-icon-mouseover"
+              type="text"
+              value={iconMouseOverText}
+              onChange={(e) => setIconMouseOverText(e.target.value)}
+              disabled={!perks.iconMouseOverText}
+              maxLength={256}
+              className={
+                inputClass + (!perks.iconMouseOverText ? ' opacity-40' : '')
+              }
+            />
+            {!perks.iconMouseOverText && <LockedNote />}
+          </div>
+        </div>
+
+        {/* Second avatar */}
+        <div>
+          <label
+            htmlFor="donor-second-avatar"
+            className={perks.secondAvatar ? labelClass : lockedClass}
+          >
+            Second (donor) avatar URL
+          </label>
+          <input
+            id="donor-second-avatar"
+            type="text"
+            value={secondAvatar}
+            onChange={(e) => setSecondAvatar(e.target.value)}
+            disabled={!perks.secondAvatar}
+            placeholder="https://…"
+            className={inputClass + (!perks.secondAvatar ? ' opacity-40' : '')}
+          />
+          {!perks.secondAvatar && <LockedNote />}
+        </div>
+
+        {/* Avatar mouseover text */}
+        <div>
+          <label
+            htmlFor="donor-avatar-mouseover"
+            className={perks.avatarMouseOverText ? labelClass : lockedClass}
+          >
+            Avatar mouseover text
+          </label>
+          <input
+            id="donor-avatar-mouseover"
+            type="text"
+            value={avatarMouseOverText}
+            onChange={(e) => setAvatarMouseOverText(e.target.value)}
+            disabled={!perks.avatarMouseOverText}
+            maxLength={256}
+            className={
+              inputClass + (!perks.avatarMouseOverText ? ' opacity-40' : '')
+            }
+          />
+          {!perks.avatarMouseOverText && <LockedNote />}
+        </div>
+
+        {/* Profile info blocks */}
+        {([1, 2, 3, 4] as const).map((n) => {
+          const perkKey = `profileInfo${n}` as const;
+          const locked = !perks[perkKey];
+          const titleState = [
+            profileInfoTitle1,
+            profileInfoTitle2,
+            profileInfoTitle3,
+            profileInfoTitle4
+          ][n - 1];
+          const bodyState = [
+            profileInfo1,
+            profileInfo2,
+            profileInfo3,
+            profileInfo4
+          ][n - 1];
+          const setTitle = [
+            setProfileInfoTitle1,
+            setProfileInfoTitle2,
+            setProfileInfoTitle3,
+            setProfileInfoTitle4
+          ][n - 1];
+          const setBody = [
+            setProfileInfo1,
+            setProfileInfo2,
+            setProfileInfo3,
+            setProfileInfo4
+          ][n - 1];
+          return (
+            <div key={n} className="space-y-2">
+              <p
+                className={
+                  locked ? 'text-sm text-gray-600' : 'text-sm text-gray-300'
+                }
+              >
+                Profile info block {n}
+                {locked && (
+                  <span className="ml-2 text-xs text-gray-600">
+                    (not in your rank)
+                  </span>
+                )}
+              </p>
+              <input
+                type="text"
+                value={titleState}
+                onChange={(e) => setTitle(e.target.value)}
+                disabled={locked}
+                placeholder="Title (optional)"
+                maxLength={128}
+                className={inputClass + (locked ? ' opacity-40' : '')}
+              />
+              <textarea
+                value={bodyState}
+                onChange={(e) => setBody(e.target.value)}
+                disabled={locked}
+                placeholder="Body…"
+                maxLength={5000}
+                rows={3}
+                className={inputClass + (locked ? ' opacity-40' : '')}
+              />
+            </div>
+          );
+        })}
+
+        <button
+          type="submit"
+          disabled={isSavingRewards}
+          className="w-full bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white font-medium py-2.5 px-4 rounded-lg transition-colors text-sm"
+        >
+          {isSavingRewards ? 'Saving…' : 'Save donor settings'}
+        </button>
+      </form>
+
+      {/* Forum title */}
+      <form
+        onSubmit={handleSaveTitle}
+        className="bg-gray-800 rounded-lg border border-gray-700 p-5 space-y-4"
+      >
+        <h3 className="text-sm font-semibold text-gray-200 uppercase tracking-wider">
+          Forum Title
+          {!perks.forumTitle && (
+            <span className="ml-2 text-xs text-gray-600 font-normal normal-case">
+              — not in your current rank
+            </span>
+          )}
+        </h3>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label
+              htmlFor="donor-title-prefix"
+              className={perks.forumTitle ? labelClass : lockedClass}
+            >
+              Prefix
+            </label>
+            <input
+              id="donor-title-prefix"
+              type="text"
+              value={titlePrefix}
+              onChange={(e) => setTitlePrefix(e.target.value)}
+              disabled={!perks.forumTitle}
+              maxLength={64}
+              className={inputClass + (!perks.forumTitle ? ' opacity-40' : '')}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="donor-title-suffix"
+              className={perks.forumTitle ? labelClass : lockedClass}
+            >
+              Suffix
+            </label>
+            <input
+              id="donor-title-suffix"
+              type="text"
+              value={titleSuffix}
+              onChange={(e) => setTitleSuffix(e.target.value)}
+              disabled={!perks.forumTitle}
+              maxLength={64}
+              className={inputClass + (!perks.forumTitle ? ' opacity-40' : '')}
+            />
+          </div>
+        </div>
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={titleUseComma}
+            onChange={(e) => setTitleUseComma(e.target.checked)}
+            disabled={!perks.forumTitle}
+            className="accent-indigo-500 disabled:opacity-40"
+          />
+          <span
+            className={`text-sm ${
+              perks.forumTitle ? 'text-gray-300' : 'text-gray-600'
+            }`}
+          >
+            Separate prefix/suffix with comma
+          </span>
+        </label>
+
+        <button
+          type="submit"
+          disabled={isSavingTitle || !perks.forumTitle}
+          className="w-full bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white font-medium py-2.5 px-4 rounded-lg transition-colors text-sm"
+        >
+          {isSavingTitle ? 'Saving…' : 'Save forum title'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default DonorSettingsTab;

--- a/src/components/profile/settings/Settings.tsx
+++ b/src/components/profile/settings/Settings.tsx
@@ -16,6 +16,7 @@ import { addAlert } from '../../../store/slices/alertSlice';
 import { selectCurrentUser } from '../../../store/slices/authSlice';
 import { getApiErrorMessage } from '../../../utils/apiError';
 import Spinner from '../../layout/Spinner';
+import DonorSettingsTab from './DonorSettingsTab';
 import type { paths } from '../../../types/api';
 
 type ProfileForm = NonNullable<
@@ -24,7 +25,7 @@ type ProfileForm = NonNullable<
 type MyProfileResponse =
   paths['/profile/me']['get']['responses'][200]['content']['application/json'];
 
-type Tab = 'appearance' | 'privacy' | 'security';
+type Tab = 'appearance' | 'privacy' | 'security' | 'donor';
 
 const PARANOIA_LABELS: Record<number, string> = {
   0: 'No restrictions — profile fully visible',
@@ -199,6 +200,14 @@ const Settings = () => {
         >
           Security
         </button>
+        {currentUser?.isDonor && (
+          <button
+            className={tabClass('donor')}
+            onClick={() => setActiveTab('donor')}
+          >
+            Donor
+          </button>
+        )}
       </div>
 
       {/* Appearance tab */}
@@ -441,6 +450,9 @@ const Settings = () => {
           </button>
         </form>
       )}
+
+      {/* Donor tab */}
+      {activeTab === 'donor' && currentUser?.isDonor && <DonorSettingsTab />}
 
       {/* Security tab */}
       {activeTab === 'security' && (

--- a/src/components/staff/DonationLogPage.tsx
+++ b/src/components/staff/DonationLogPage.tsx
@@ -12,7 +12,11 @@ import Spinner from '../layout/Spinner';
 const DonationLogPage = () => {
   const dispatch = useDispatch();
   const [page, setPage] = useState(1);
-  const { data, isLoading } = useGetDonationsQuery(page);
+  const [filterUserId, setFilterUserId] = useState('');
+  const { data, isLoading } = useGetDonationsQuery({
+    page,
+    userId: filterUserId ? Number(filterUserId) : undefined
+  });
   const [createDonation, { isLoading: isCreating }] =
     useCreateDonationMutation();
   const [deleteDonation] = useDeleteDonationMutation();
@@ -81,6 +85,30 @@ const DonationLogPage = () => {
         >
           {showForm ? 'Cancel' : '+ Manual entry'}
         </button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="number"
+          value={filterUserId}
+          onChange={(e) => {
+            setFilterUserId(e.target.value);
+            setPage(1);
+          }}
+          placeholder="Filter by user ID…"
+          className="w-48 bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:outline-none focus:border-indigo-500"
+        />
+        {filterUserId && (
+          <button
+            onClick={() => {
+              setFilterUserId('');
+              setPage(1);
+            }}
+            className="text-xs text-gray-400 hover:text-white"
+          >
+            Clear
+          </button>
+        )}
       </div>
 
       {showForm && (
@@ -264,7 +292,7 @@ const DonationLogPage = () => {
         )}
       </div>
 
-      {data && data.totalPages > 1 && (
+      {data && data.meta.totalPages > 1 && (
         <div className="flex items-center justify-center gap-2 text-sm">
           <button
             onClick={() => setPage((p) => Math.max(1, p - 1))}
@@ -274,11 +302,13 @@ const DonationLogPage = () => {
             Prev
           </button>
           <span className="text-gray-500">
-            {page} / {data.totalPages}
+            {page} / {data.meta.totalPages}
           </span>
           <button
-            onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
-            disabled={page === data.totalPages}
+            onClick={() =>
+              setPage((p) => Math.min(data.meta.totalPages, p + 1))
+            }
+            disabled={page === data.meta.totalPages}
             className="px-3 py-1 bg-gray-800 hover:bg-gray-700 disabled:opacity-40 text-gray-300 rounded transition-colors"
           >
             Next

--- a/src/components/staff/DonorRanksPage.tsx
+++ b/src/components/staff/DonorRanksPage.tsx
@@ -2,24 +2,69 @@ import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import {
   useGetDonorRanksQuery,
-  useCreateDonorRankMutation
+  useCreateDonorRankMutation,
+  useUpdateDonorRankMutation,
+  useDeleteDonorRankMutation
 } from '../../store/services/userApi';
 import { addAlert } from '../../store/slices/alertSlice';
 import { getApiErrorMessage } from '../../utils/apiError';
 import Spinner from '../layout/Spinner';
 
+const PERK_KEYS = [
+  'iconMouseOverText',
+  'avatarMouseOverText',
+  'customIcon',
+  'customIconLink',
+  'secondAvatar',
+  'forumTitle',
+  'profileInfo1',
+  'profileInfo2',
+  'profileInfo3',
+  'profileInfo4'
+] as const;
+
+const PERK_LABELS: Record<string, string> = {
+  iconMouseOverText: 'Custom icon mouseover text',
+  avatarMouseOverText: 'Avatar mouseover text',
+  customIcon: 'Custom icon',
+  customIconLink: 'Custom icon link',
+  secondAvatar: 'Second avatar',
+  forumTitle: 'Forum title prefix/suffix',
+  profileInfo1: 'Profile info block 1',
+  profileInfo2: 'Profile info block 2',
+  profileInfo3: 'Profile info block 3',
+  profileInfo4: 'Profile info block 4'
+};
+
+type RankForm = {
+  name: string;
+  minDonation: string;
+  badge: string;
+  color: string;
+  expiresAfterDays: string;
+  perks: Record<string, boolean>;
+};
+
+const emptyForm = (): RankForm => ({
+  name: '',
+  minDonation: '',
+  badge: '',
+  color: '',
+  expiresAfterDays: '',
+  perks: {}
+});
+
 const DonorRanksPage = () => {
   const dispatch = useDispatch();
   const { data: ranks, isLoading, error } = useGetDonorRanksQuery();
   const [createRank, { isLoading: isCreating }] = useCreateDonorRankMutation();
+  const [updateRank, { isLoading: isUpdating }] = useUpdateDonorRankMutation();
+  const [deleteRank] = useDeleteDonorRankMutation();
 
   const [showForm, setShowForm] = useState(false);
-  const [form, setForm] = useState({
-    name: '',
-    minDonation: '',
-    badge: '',
-    expiresAfterDays: ''
-  });
+  const [form, setForm] = useState<RankForm>(emptyForm());
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<RankForm>(emptyForm());
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -28,12 +73,14 @@ const DonorRanksPage = () => {
         name: form.name,
         minDonation: Number(form.minDonation),
         badge: form.badge || undefined,
+        color: form.color || undefined,
         expiresAfterDays: form.expiresAfterDays
           ? Number(form.expiresAfterDays)
-          : undefined
+          : undefined,
+        perks: Object.keys(form.perks).length > 0 ? form.perks : undefined
       }).unwrap();
       dispatch(addAlert('Donor rank created.', 'success'));
-      setForm({ name: '', minDonation: '', badge: '', expiresAfterDays: '' });
+      setForm(emptyForm());
       setShowForm(false);
     } catch (err) {
       dispatch(
@@ -44,6 +91,77 @@ const DonorRanksPage = () => {
       );
     }
   };
+
+  const handleStartEdit = (rank: NonNullable<typeof ranks>[number]) => {
+    setEditingId(rank.id);
+    setEditForm({
+      name: rank.name,
+      minDonation: String(rank.minDonation),
+      badge: rank.badge ?? '',
+      color: rank.color ?? '',
+      expiresAfterDays:
+        rank.expiresAfterDays != null ? String(rank.expiresAfterDays) : '',
+      perks: (rank.perks as Record<string, boolean>) ?? {}
+    });
+  };
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editingId == null) return;
+    try {
+      await updateRank({
+        rankId: editingId,
+        name: editForm.name,
+        minDonation: Number(editForm.minDonation),
+        badge: editForm.badge || undefined,
+        color: editForm.color || undefined,
+        expiresAfterDays: editForm.expiresAfterDays
+          ? Number(editForm.expiresAfterDays)
+          : undefined,
+        perks:
+          Object.keys(editForm.perks).length > 0 ? editForm.perks : undefined
+      }).unwrap();
+      dispatch(addAlert('Donor rank updated.', 'success'));
+      setEditingId(null);
+    } catch (err) {
+      dispatch(
+        addAlert(
+          getApiErrorMessage(err) ?? 'Failed to update donor rank.',
+          'danger'
+        )
+      );
+    }
+  };
+
+  const handleDelete = async (id: number, name: string) => {
+    if (!confirm(`Delete donor rank "${name}"? This cannot be undone.`)) return;
+    try {
+      await deleteRank(id).unwrap();
+      dispatch(addAlert('Donor rank deleted.', 'success'));
+      if (editingId === id) setEditingId(null);
+    } catch (err) {
+      dispatch(
+        addAlert(
+          getApiErrorMessage(err) ?? 'Failed to delete donor rank.',
+          'danger'
+        )
+      );
+    }
+  };
+
+  const togglePerk = (
+    key: string,
+    current: Record<string, boolean>,
+    setter: (updater: (f: RankForm) => RankForm) => void
+  ) => {
+    setter((f) => ({
+      ...f,
+      perks: { ...current, [key]: !current[key] }
+    }));
+  };
+
+  const fieldClass =
+    'w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500';
 
   if (isLoading) return <Spinner />;
   if (error)
@@ -83,7 +201,7 @@ const DonorRanksPage = () => {
                     setForm((f) => ({ ...f, name: e.target.value }))
                   }
                   required
-                  className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  className={fieldClass}
                 />
               </div>
               <div>
@@ -103,7 +221,7 @@ const DonorRanksPage = () => {
                     setForm((f) => ({ ...f, minDonation: e.target.value }))
                   }
                   required
-                  className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  className={fieldClass}
                 />
               </div>
               <div>
@@ -120,7 +238,25 @@ const DonorRanksPage = () => {
                   onChange={(e) =>
                     setForm((f) => ({ ...f, badge: e.target.value }))
                   }
-                  className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  className={fieldClass}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="donor-rank-color"
+                  className="block text-xs text-gray-400 mb-1"
+                >
+                  Badge color (hex, optional)
+                </label>
+                <input
+                  id="donor-rank-color"
+                  type="text"
+                  value={form.color}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, color: e.target.value }))
+                  }
+                  placeholder="#ff69b4"
+                  className={fieldClass}
                 />
               </div>
               <div>
@@ -141,8 +277,27 @@ const DonorRanksPage = () => {
                       expiresAfterDays: e.target.value
                     }))
                   }
-                  className="w-full rounded-lg bg-gray-700 border border-gray-600 text-white px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  className={fieldClass}
                 />
+              </div>
+            </div>
+            <div>
+              <p className="text-xs text-gray-400 mb-2">Perks</p>
+              <div className="grid grid-cols-2 gap-1.5">
+                {PERK_KEYS.map((key) => (
+                  <label
+                    key={key}
+                    className="flex items-center gap-2 text-xs text-gray-300 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={!!form.perks[key]}
+                      onChange={() => togglePerk(key, form.perks, setForm)}
+                      className="accent-indigo-500"
+                    />
+                    {PERK_LABELS[key]}
+                  </label>
+                ))}
               </div>
             </div>
             <div className="flex justify-end">
@@ -163,38 +318,188 @@ const DonorRanksPage = () => {
           <p className="text-gray-500 text-sm">No donor ranks defined yet.</p>
         </div>
       ) : (
-        <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-700 text-left text-gray-400 text-xs">
-                <th className="px-4 py-3 font-medium">Name</th>
-                <th className="px-4 py-3 font-medium">Min Donation</th>
-                <th className="px-4 py-3 font-medium">Badge</th>
-                <th className="px-4 py-3 font-medium">Expires After</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ranks.map((rank) => (
-                <tr
-                  key={rank.id}
-                  className="border-b border-gray-800 hover:bg-gray-800/30 transition-colors"
-                >
-                  <td className="px-4 py-3 text-gray-200">{rank.name}</td>
-                  <td className="px-4 py-3 text-gray-400">
+        <div className="space-y-2">
+          {ranks.map((rank) => (
+            <div
+              key={rank.id}
+              className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden"
+            >
+              <div className="px-4 py-3 flex items-center gap-3">
+                <div className="flex-1 min-w-0">
+                  <span
+                    className="font-medium text-sm"
+                    style={{ color: rank.color || undefined }}
+                  >
+                    {rank.badge && <span className="mr-1">{rank.badge}</span>}
+                    {rank.name}
+                  </span>
+                  <span className="ml-3 text-xs text-gray-500">
                     ${rank.minDonation}
-                  </td>
-                  <td className="px-4 py-3 text-gray-300">
-                    {rank.badge ?? '—'}
-                  </td>
-                  <td className="px-4 py-3 text-gray-500">
-                    {rank.expiresAfterDays != null
-                      ? `${rank.expiresAfterDays} days`
-                      : 'Never'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                    {rank.expiresAfterDays != null &&
+                      ` · ${rank.expiresAfterDays}d`}
+                  </span>
+                </div>
+                <button
+                  onClick={() =>
+                    editingId === rank.id
+                      ? setEditingId(null)
+                      : handleStartEdit(rank)
+                  }
+                  className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+                >
+                  {editingId === rank.id ? 'Cancel' : 'Edit'}
+                </button>
+                <button
+                  onClick={() => handleDelete(rank.id, rank.name)}
+                  className="text-xs text-red-500 hover:text-red-400 transition-colors"
+                >
+                  Delete
+                </button>
+              </div>
+
+              {editingId === rank.id && (
+                <div className="border-t border-gray-700 px-4 py-3 bg-gray-950">
+                  <form onSubmit={handleUpdate} className="space-y-3">
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label
+                          htmlFor={`edit-rank-name-${rank.id}`}
+                          className="block text-xs text-gray-400 mb-1"
+                        >
+                          Name
+                        </label>
+                        <input
+                          id={`edit-rank-name-${rank.id}`}
+                          type="text"
+                          value={editForm.name}
+                          onChange={(e) =>
+                            setEditForm((f) => ({ ...f, name: e.target.value }))
+                          }
+                          required
+                          className={fieldClass}
+                        />
+                      </div>
+                      <div>
+                        <label
+                          htmlFor={`edit-rank-min-${rank.id}`}
+                          className="block text-xs text-gray-400 mb-1"
+                        >
+                          Min Donation ($)
+                        </label>
+                        <input
+                          id={`edit-rank-min-${rank.id}`}
+                          type="number"
+                          min={0}
+                          step={0.01}
+                          value={editForm.minDonation}
+                          onChange={(e) =>
+                            setEditForm((f) => ({
+                              ...f,
+                              minDonation: e.target.value
+                            }))
+                          }
+                          required
+                          className={fieldClass}
+                        />
+                      </div>
+                      <div>
+                        <label
+                          htmlFor={`edit-rank-badge-${rank.id}`}
+                          className="block text-xs text-gray-400 mb-1"
+                        >
+                          Badge
+                        </label>
+                        <input
+                          id={`edit-rank-badge-${rank.id}`}
+                          type="text"
+                          value={editForm.badge}
+                          onChange={(e) =>
+                            setEditForm((f) => ({
+                              ...f,
+                              badge: e.target.value
+                            }))
+                          }
+                          className={fieldClass}
+                        />
+                      </div>
+                      <div>
+                        <label
+                          htmlFor={`edit-rank-color-${rank.id}`}
+                          className="block text-xs text-gray-400 mb-1"
+                        >
+                          Color (hex)
+                        </label>
+                        <input
+                          id={`edit-rank-color-${rank.id}`}
+                          type="text"
+                          value={editForm.color}
+                          onChange={(e) =>
+                            setEditForm((f) => ({
+                              ...f,
+                              color: e.target.value
+                            }))
+                          }
+                          placeholder="#ff69b4"
+                          className={fieldClass}
+                        />
+                      </div>
+                      <div>
+                        <label
+                          htmlFor={`edit-rank-expires-${rank.id}`}
+                          className="block text-xs text-gray-400 mb-1"
+                        >
+                          Expires after (days)
+                        </label>
+                        <input
+                          id={`edit-rank-expires-${rank.id}`}
+                          type="number"
+                          min={0}
+                          value={editForm.expiresAfterDays}
+                          onChange={(e) =>
+                            setEditForm((f) => ({
+                              ...f,
+                              expiresAfterDays: e.target.value
+                            }))
+                          }
+                          className={fieldClass}
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <p className="text-xs text-gray-400 mb-2">Perks</p>
+                      <div className="grid grid-cols-2 gap-1.5">
+                        {PERK_KEYS.map((key) => (
+                          <label
+                            key={key}
+                            className="flex items-center gap-2 text-xs text-gray-300 cursor-pointer"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={!!editForm.perks[key]}
+                              onChange={() =>
+                                togglePerk(key, editForm.perks, setEditForm)
+                              }
+                              className="accent-indigo-500"
+                            />
+                            {PERK_LABELS[key]}
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="flex justify-end">
+                      <button
+                        type="submit"
+                        disabled={isUpdating}
+                        className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-sm rounded-lg transition-colors"
+                      >
+                        {isUpdating ? 'Saving…' : 'Save Changes'}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/components/staff/DonorRanksPage.tsx
+++ b/src/components/staff/DonorRanksPage.tsx
@@ -246,7 +246,7 @@ const DonorRanksPage = () => {
                   htmlFor="donor-rank-color"
                   className="block text-xs text-gray-400 mb-1"
                 >
-                  Badge color (hex, optional)
+                  Color (hex, optional)
                 </label>
                 <input
                   id="donor-rank-color"
@@ -330,13 +330,16 @@ const DonorRanksPage = () => {
                     className="font-medium text-sm"
                     style={{ color: rank.color || undefined }}
                   >
-                    {rank.badge && <span className="mr-1">{rank.badge}</span>}
+                    <span className="mr-1">{rank.badge ?? '—'}</span>
                     {rank.name}
                   </span>
                   <span className="ml-3 text-xs text-gray-500">
                     ${rank.minDonation}
-                    {rank.expiresAfterDays != null &&
-                      ` · ${rank.expiresAfterDays}d`}
+                  </span>
+                  <span className="ml-2 text-xs text-gray-500">
+                    {rank.expiresAfterDays != null
+                      ? `${rank.expiresAfterDays} days`
+                      : 'Never'}
                   </span>
                 </div>
                 <button

--- a/src/components/staff/RegistrationLogPage.tsx
+++ b/src/components/staff/RegistrationLogPage.tsx
@@ -65,7 +65,7 @@ const RegistrationLogPage = () => {
         )}
       </div>
 
-      {data && data.totalPages > 1 && (
+      {data && data.meta.totalPages > 1 && (
         <div className="flex items-center justify-center gap-2 text-sm">
           <button
             onClick={() => setPage((p) => Math.max(1, p - 1))}
@@ -75,11 +75,13 @@ const RegistrationLogPage = () => {
             Prev
           </button>
           <span className="text-gray-500">
-            {page} / {data.totalPages}
+            {page} / {data.meta.totalPages}
           </span>
           <button
-            onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
-            disabled={page === data.totalPages}
+            onClick={() =>
+              setPage((p) => Math.min(data.meta.totalPages, p + 1))
+            }
+            disabled={page === data.meta.totalPages}
             className="px-3 py-1 bg-gray-800 hover:bg-gray-700 disabled:opacity-40 text-gray-300 rounded transition-colors"
           >
             Next

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -60,6 +60,7 @@ export const api = createApi({
     'IpBan',
     'EmailBlacklist',
     'Donation',
+    'DonorReward',
     'StaffGroup',
     'RulesPage',
     'Friend'

--- a/src/store/services/adminApi.ts
+++ b/src/store/services/adminApi.ts
@@ -52,10 +52,12 @@ export interface RegistrationLogUser {
 
 interface PaginatedResponse<T> {
   data: T[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
 }
 
 export const adminApi = api.injectEndpoints({
@@ -96,8 +98,16 @@ export const adminApi = api.injectEndpoints({
     }),
 
     // Donations
-    getDonations: build.query<PaginatedResponse<Donation>, number | void>({
-      query: (page = 1) => `/donations?page=${page}`,
+    getDonations: build.query<
+      PaginatedResponse<Donation>,
+      { page?: number; userId?: number } | void
+    >({
+      query: (args) => {
+        const params = new URLSearchParams();
+        if (args?.page) params.set('page', String(args.page));
+        if (args?.userId) params.set('userId', String(args.userId));
+        return `/donations?${params.toString()}`;
+      },
       providesTags: ['Donation']
     }),
     createDonation: build.mutation<

--- a/src/store/services/profileApi.ts
+++ b/src/store/services/profileApi.ts
@@ -1,5 +1,5 @@
 import { api } from '../api';
-import type { paths } from '../../types/api';
+import type { paths, components } from '../../types/api';
 import type { RatioStats } from '../../types';
 
 type MyProfileResponse =
@@ -14,6 +14,14 @@ type CreateInviteArgs = NonNullable<
 >['content']['application/json'];
 type CreateInviteResponse =
   paths['/profile/referral/create-invite']['post']['responses'][201]['content']['application/json'];
+
+type DonorRewardsResponse = components['schemas']['DonorRewards'];
+type UpdateDonorRewardsArgs = NonNullable<
+  paths['/profile/me/donor-rewards']['put']['requestBody']
+>['content']['application/json'];
+type UpdateDonorForumTitleArgs = NonNullable<
+  paths['/profile/me/donor-title']['put']['requestBody']
+>['content']['application/json'];
 
 export const profileApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -44,6 +52,32 @@ export const profileApi = api.injectEndpoints({
     getMyRatioStats: build.query<RatioStats, void>({
       query: () => '/profile/me/ratio',
       providesTags: ['Profile']
+    }),
+    getDonorRewards: build.query<DonorRewardsResponse, void>({
+      query: () => '/profile/me/donor-rewards',
+      providesTags: ['DonorReward']
+    }),
+    updateDonorRewards: build.mutation<
+      DonorRewardsResponse,
+      UpdateDonorRewardsArgs
+    >({
+      query: (body) => ({
+        url: '/profile/me/donor-rewards',
+        method: 'PUT',
+        body
+      }),
+      invalidatesTags: ['DonorReward', 'Profile']
+    }),
+    updateDonorForumTitle: build.mutation<
+      DonorRewardsResponse,
+      UpdateDonorForumTitleArgs
+    >({
+      query: (body) => ({
+        url: '/profile/me/donor-title',
+        method: 'PUT',
+        body
+      }),
+      invalidatesTags: ['DonorReward', 'Profile']
     })
   })
 });
@@ -54,5 +88,8 @@ export const {
   useUpdateMyProfileMutation,
   useDeleteMyProfileMutation,
   useCreateInviteMutation,
-  useGetMyRatioStatsQuery
+  useGetMyRatioStatsQuery,
+  useGetDonorRewardsQuery,
+  useUpdateDonorRewardsMutation,
+  useUpdateDonorForumTitleMutation
 } = profileApi;

--- a/src/store/services/userApi.ts
+++ b/src/store/services/userApi.ts
@@ -198,7 +198,9 @@ export const userApi = api.injectEndpoints({
         name: string;
         minDonation: number;
         badge: string | null;
+        color: string | null;
         expiresAfterDays: number | null;
+        perks: Record<string, boolean> | null;
       }>,
       void
     >({
@@ -211,10 +213,38 @@ export const userApi = api.injectEndpoints({
         name: string;
         minDonation: number;
         badge?: string;
+        color?: string;
         expiresAfterDays?: number;
+        perks?: Record<string, boolean>;
       }
     >({
       query: (body) => ({ url: '/users/donor-ranks', method: 'POST', body }),
+      invalidatesTags: ['User']
+    }),
+    updateDonorRank: build.mutation<
+      { id: number; name: string },
+      {
+        rankId: number;
+        name?: string;
+        minDonation?: number;
+        badge?: string;
+        color?: string;
+        expiresAfterDays?: number;
+        perks?: Record<string, boolean>;
+      }
+    >({
+      query: ({ rankId, ...body }) => ({
+        url: `/users/donor-ranks/${rankId}`,
+        method: 'PUT',
+        body
+      }),
+      invalidatesTags: ['User']
+    }),
+    deleteDonorRank: build.mutation<void, number>({
+      query: (rankId) => ({
+        url: `/users/donor-ranks/${rankId}`,
+        method: 'DELETE'
+      }),
       invalidatesTags: ['User']
     }),
     grantDonor: build.mutation<
@@ -356,6 +386,8 @@ export const {
   useGetSnatchListQuery,
   useGetDonorRanksQuery,
   useCreateDonorRankMutation,
+  useUpdateDonorRankMutation,
+  useDeleteDonorRankMutation,
   useGrantDonorMutation,
   useRevokeDonorMutation,
   useRemoveUserWarningMutation,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -914,6 +914,193 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/profile/me/donor-rewards': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Donor reward settings and active perks */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['DonorRewards'];
+          };
+        };
+        /** @description Not authenticated */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description No active donor rank */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            iconMouseOverText?: string;
+            avatarMouseOverText?: string;
+            customIcon?: string | '';
+            customIconLink?: string | '';
+            secondAvatar?: string | '';
+            profileInfoTitle1?: string;
+            profileInfo1?: string;
+            profileInfoTitle2?: string;
+            profileInfo2?: string;
+            profileInfoTitle3?: string;
+            profileInfo3?: string;
+            profileInfoTitle4?: string;
+            profileInfo4?: string;
+          };
+        };
+      };
+      responses: {
+        /** @description Updated donor reward settings */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['DonorRewards'];
+          };
+        };
+        /** @description Validation error */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ValidationError'];
+          };
+        };
+        /** @description Not authenticated */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description No active donor rank */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/profile/me/donor-title': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            prefix?: string;
+            suffix?: string;
+            useComma?: boolean;
+          };
+        };
+      };
+      responses: {
+        /** @description Updated forum title */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['DonorForumTitle'];
+          };
+        };
+        /** @description Validation error */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ValidationError'];
+          };
+        };
+        /** @description Not authenticated */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Perk not enabled for this rank */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/home/featured': {
     parameters: {
       query?: never;
@@ -7952,6 +8139,8 @@ export interface components {
       customIcon: string | null;
       customIconLink: string | null;
       secondAvatar: string | null;
+      iconMouseOverText: string | null;
+      avatarMouseOverText: string | null;
       profileBlocks: {
         title: string;
         body: string;
@@ -8078,6 +8267,36 @@ export interface components {
       expiresAt: string;
       /** Format: date-time */
       usedAt: string | null;
+    };
+    DonorRewards: {
+      rewards: {
+        iconMouseOverText: string;
+        avatarMouseOverText: string;
+        customIcon: string;
+        customIconLink: string;
+        secondAvatar: string;
+        profileInfoTitle1: string;
+        profileInfo1: string;
+        profileInfoTitle2: string;
+        profileInfo2: string;
+        profileInfoTitle3: string;
+        profileInfo3: string;
+        profileInfoTitle4: string;
+        profileInfo4: string;
+      };
+      perks: {
+        [key: string]: boolean;
+      };
+      forumTitle: {
+        prefix: string;
+        suffix: string;
+        useComma: boolean;
+      } | null;
+    };
+    DonorForumTitle: {
+      prefix: string;
+      suffix: string;
+      useComma: boolean;
     };
     HomepageFeaturedRelease: {
       id: number;


### PR DESCRIPTION
## Summary

- **DonorSettingsTab** (`src/components/profile/settings/DonorSettingsTab.tsx`): perk-gated form for donors to customize icon, avatar, mouseover text, profile info blocks, and forum title; shown only when `currentUser.isDonor`
- **Settings.tsx**: adds a conditional `Donor` tab that renders `DonorSettingsTab`
- **DonatePage** (`src/components/donate/DonatePage.tsx`): informational page with four sections (Why donate, How to donate, What you receive, What you won't receive); the "What you receive" section is driven live from `useGetDonorRanksQuery` so it always reflects current configured ranks and perks
- **UserMenu.tsx**: `Donate` nav link added after `Invite`
- **DonorRanksPage.tsx**: full rewrite with inline edit/delete, per-rank perk checkboxes, and color field
- **API layer**: add `getDonorRewards`, `updateDonorRewards`, `updateDonorForumTitle` endpoints to `profileApi`; add `updateDonorRank`, `deleteDonorRank` to `userApi`; extend `getDonorRanks` type with `perks` and `color` fields
- **Pagination fix**: `PaginatedResponse<T>` corrected to `{ data, meta }` shape matching the backend `paginatedResponse` helper; fixes `DonationLogPage` and `RegistrationLogPage` pagination controls
- **DonationLogPage**: adds `?userId` filter input
- **UserProfile.tsx**: `title` attributes on donor icon and second avatar for mouseover text display
- **`src/types/api.ts`**: regenerated from updated OpenAPI spec (includes `DonorRewards`, `DonorPresentation` with mouseover fields, new profile routes)

## Test plan

- [ ] `npx tsc --noEmit` — passes clean
- [ ] `npx eslint src/components/donate/DonatePage.tsx src/components/profile/settings/DonorSettingsTab.tsx src/components/staff/DonorRanksPage.tsx` — no errors
- [ ] Navigate to `/private/donate` — page loads with rank list
- [ ] Navigate to `/private/user/edit/:id` as a donor — Donor tab visible and submits successfully
- [ ] Admin: DonorRanksPage edit/delete works; perks and color save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)