### PR TITLE
Add site_news and global_notice notification types

### DIFF
--- a/src/components/layout/NotificationCorner.tsx
+++ b/src/components/layout/NotificationCorner.tsx
@@ -31,6 +31,10 @@ function renderNotificationText(
       return `${actor} commented on ${title}`;
     case 'artist_release':
       return `${actor} added a new contribution for ${title}`;
+    case 'site_news':
+      return `New announcement: ${title}`;
+    case 'global_notice':
+      return title;
     default:
       return `New notification in ${title}`;
   }
@@ -53,6 +57,10 @@ function sourcePath(n: Notification): string | null {
       return `/private/requests/${n.pageId}`;
     case 'communities':
       return `/private/communities/${n.pageId}`;
+    case 'news':
+      return `/private/announcements`;
+    case 'global_notices':
+      return n.source?.url ?? null;
     default:
       return null;
   }

--- a/src/store/services/notificationApi.ts
+++ b/src/store/services/notificationApi.ts
@@ -6,7 +6,9 @@ export type NotificationType =
   | 'request_filled'
   | 'collage_updated'
   | 'comment_sub'
-  | 'artist_release';
+  | 'artist_release'
+  | 'site_news'
+  | 'global_notice';
 
 export interface NotificationActor {
   id: number;
@@ -19,6 +21,7 @@ export interface NotificationSource {
   forumId?: number;
   releaseId?: number;
   communityId?: number;
+  url?: string;
 }
 
 export interface Notification {


### PR DESCRIPTION
## Summary

- Adds `site_news` and `global_notice` to the `NotificationType` union in `notificationApi.ts`.
- Adds `url` field to `NotificationSource` to support global notice deep links.
- `NotificationCorner` renders human-readable text for both new types: news shows "New announcement: [title]", global notices display the message directly.
- `sourcePath` routes news notifications to `/private/announcements` and global notice notifications to the notice's optional URL.

## Dependencies

Requires stellar-api PR #40.

## Test plan

- [ ] Receive a `site_news` notification — corner shows "New announcement: [title]" linking to /private/announcements
- [ ] Receive a `global_notice` notification with a URL — notification text shows the message and links to the provided URL
- [ ] Receive a `global_notice` without a URL — notification renders non-linked text
- [ ] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)