### PR TITLE
Add staff toolbox UI: site information, invite tools, and DNC warnings

### DIFF
--- a/src/__tests__/contribute/ContributeForm.test.tsx
+++ b/src/__tests__/contribute/ContributeForm.test.tsx
@@ -23,7 +23,8 @@ jest.mock('../../store/services/communityApi', () => ({
   useCreateContributionMutation: () => [
     mockCreateContribution,
     { isLoading: mockIsSubmitting }
-  ]
+  ],
+  useGetDncListQuery: () => ({ data: undefined })
 }));
 
 jest.mock('react-redux', () => ({

--- a/src/components/admin/NewsManager.tsx
+++ b/src/components/admin/NewsManager.tsx
@@ -25,7 +25,6 @@ const NewsManager = () => {
   const [createBlogPost, { isLoading: creatingBlog }] =
     useCreateBlogPostMutation();
   const [deleteBlogPost] = useDeleteBlogPostMutation();
-
   const [newsTitle, setNewsTitle] = useState('');
   const [newsBody, setNewsBody] = useState('');
   const [blogTitle, setBlogTitle] = useState('');

--- a/src/components/admin/Toolbox.tsx
+++ b/src/components/admin/Toolbox.tsx
@@ -57,6 +57,11 @@ const sections: SectionProps[] = [
         label: 'Site settings',
         to: '/private/staff/tools/settings',
         permissions: ['admin']
+      },
+      {
+        label: 'Login Watch',
+        to: '/private/staff/login-watch',
+        permissions: ['admin']
       }
     ]
   },
@@ -72,6 +77,26 @@ const sections: SectionProps[] = [
         label: 'Recovery queue',
         to: '/private/staff/tools/recovery-queue',
         permissions: ['users_edit', 'admin']
+      },
+      {
+        label: 'Registration log',
+        to: '/private/staff/registration-log',
+        permissions: ['admin']
+      },
+      {
+        label: 'Invite pool',
+        to: '/private/staff/invite-pool',
+        permissions: ['admin']
+      },
+      {
+        label: 'Invite tree',
+        to: '/private/staff/invite-tree',
+        permissions: ['admin']
+      },
+      {
+        label: 'User flow',
+        to: '/private/staff/user-flow',
+        permissions: ['admin']
       }
     ]
   },
@@ -96,6 +121,16 @@ const sections: SectionProps[] = [
       {
         label: 'Global notices',
         to: '/private/staff/global-notices',
+        permissions: ['news_manage']
+      },
+      {
+        label: 'Vanity House',
+        to: '/private/staff/vanity-house',
+        permissions: ['news_manage']
+      },
+      {
+        label: 'Album of the Month',
+        to: '/private/staff/album-of-month',
         permissions: ['news_manage']
       },
       {
@@ -152,6 +187,21 @@ const sections: SectionProps[] = [
         label: 'Reports queue',
         to: '/private/staff/reports',
         permissions: ['staff', 'admin']
+      },
+      {
+        label: 'Duplicate IPs',
+        to: '/private/staff/duplicate-ips',
+        permissions: ['admin']
+      },
+      {
+        label: 'Do Not Contribute list',
+        to: '/private/staff/dnc',
+        permissions: ['communities_manage']
+      },
+      {
+        label: 'Collage recovery',
+        to: '/private/staff/collage-recovery',
+        permissions: ['collages_moderate']
       }
     ]
   },
@@ -161,16 +211,6 @@ const sections: SectionProps[] = [
       {
         label: 'Ratio policy override',
         to: '/private/staff/tools/ratio-policy',
-        permissions: ['staff', 'admin']
-      },
-      {
-        label: 'Duplicate IPs',
-        to: '/private/staff/duplicate-ips',
-        permissions: ['staff', 'admin']
-      },
-      {
-        label: 'Registration log',
-        to: '/private/staff/registration-log',
         permissions: ['staff', 'admin']
       },
       {
@@ -206,6 +246,41 @@ const sections: SectionProps[] = [
       {
         label: 'Donation log',
         to: '/private/staff/donation-log',
+        permissions: ['admin']
+      }
+    ]
+  },
+  {
+    title: 'Site Information',
+    links: [
+      {
+        label: 'Economic stats',
+        to: '/private/staff/economic-stats',
+        permissions: ['admin']
+      },
+      {
+        label: 'Release stats',
+        to: '/private/staff/release-stats',
+        permissions: ['admin']
+      },
+      {
+        label: 'Ratio watch',
+        to: '/private/staff/ratio-watch',
+        permissions: ['admin']
+      },
+      {
+        label: 'OS & Browser usage',
+        to: '/private/staff/client-stats',
+        permissions: ['admin']
+      }
+    ]
+  },
+  {
+    title: 'Development',
+    links: [
+      {
+        label: 'Site info',
+        to: '/private/staff/site-info',
         permissions: ['admin']
       }
     ]

--- a/src/components/admin/Toolbox.tsx
+++ b/src/components/admin/Toolbox.tsx
@@ -94,6 +94,11 @@ const sections: SectionProps[] = [
         permissions: ['news_manage']
       },
       {
+        label: 'Global notices',
+        to: '/private/staff/global-notices',
+        permissions: ['news_manage']
+      },
+      {
         label: 'Mass PM',
         to: '/private/staff/mass-pm',
         permissions: ['staff', 'admin']
@@ -122,6 +127,11 @@ const sections: SectionProps[] = [
         label: 'Forum manager',
         to: '/private/staff/tools/forums',
         permissions: ['forums_manage']
+      },
+      {
+        label: 'Tag aliases',
+        to: '/private/staff/tag-aliases',
+        permissions: ['staff', 'admin']
       }
     ]
   },
@@ -161,6 +171,11 @@ const sections: SectionProps[] = [
       {
         label: 'Registration log',
         to: '/private/staff/registration-log',
+        permissions: ['staff', 'admin']
+      },
+      {
+        label: 'User warnings',
+        to: '/private/staff/user-warnings',
         permissions: ['staff', 'admin']
       }
     ]

--- a/src/components/contribute/ContributeForm.tsx
+++ b/src/components/contribute/ContributeForm.tsx
@@ -3,7 +3,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   useGetCommunitiesQuery,
-  useCreateContributionMutation
+  useCreateContributionMutation,
+  useGetDncListQuery
 } from '../../store/services/communityApi';
 import { selectCurrentUser } from '../../store/slices/authSlice';
 import { addAlert } from '../../store/slices/alertSlice';
@@ -86,6 +87,11 @@ const ContributeForm = () => {
   const [collaborators, setCollaborators] = useState<Collaborator[]>([
     { artist: '', importance: 'Main artist' }
   ]);
+
+  const { data: dncList } = useGetDncListQuery(
+    community ? parseInt(community, 10) : 0,
+    { skip: !community }
+  );
 
   useEffect(() => {
     if (type === 'Music') {
@@ -187,6 +193,32 @@ const ContributeForm = () => {
             </Link>
           </p>
         </div>
+
+        {dncList && dncList.length > 0 && (
+          <div className="rounded-lg border border-yellow-600/50 bg-yellow-900/20 p-4 space-y-2">
+            <h3 className="text-sm font-semibold text-yellow-400 uppercase tracking-wider">
+              Do Not Contribute List
+            </h3>
+            <p className="text-xs text-yellow-300/80">
+              The following artists, labels, and releases must not be
+              contributed to this community:
+            </p>
+            <ul className="space-y-1">
+              {dncList.map((entry) => (
+                <li key={entry.id} className="flex flex-wrap gap-x-2 text-sm">
+                  <span className="text-yellow-200 font-medium">
+                    {entry.name}
+                  </span>
+                  {entry.comment && (
+                    <span className="text-yellow-300/60 text-xs self-center">
+                      — {entry.comment}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         <div className="grid grid-cols-2 gap-4">
           <div className={fieldWrap}>

--- a/src/components/layout/GlobalNoticeBanner.tsx
+++ b/src/components/layout/GlobalNoticeBanner.tsx
@@ -1,0 +1,49 @@
+import {
+  useGetNotificationsQuery,
+  useMarkNotificationReadMutation
+} from '../../store/services/notificationApi';
+
+const GlobalNoticeBanner = () => {
+  const { data: notifications } = useGetNotificationsQuery();
+  const [markRead] = useMarkNotificationReadMutation();
+
+  const unreadNotices = (notifications ?? []).filter(
+    (n) => n.readAt === null && n.type === 'global_notice'
+  );
+
+  if (unreadNotices.length === 0) return null;
+
+  return (
+    <div className="space-y-px">
+      {unreadNotices.map((n) => (
+        <div
+          key={n.id}
+          className="flex items-center justify-between gap-4 bg-amber-900/70 border-b border-amber-700 px-4 py-2 text-sm text-amber-100"
+        >
+          <span>
+            {n.source?.url ? (
+              <a
+                href={n.source.url}
+                className="underline hover:text-white transition-colors"
+              >
+                {n.source.title}
+              </a>
+            ) : (
+              n.source?.title
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={() => markRead(n.id)}
+            className="shrink-0 text-amber-300 hover:text-white transition-colors text-xs"
+            aria-label="Dismiss"
+          >
+            Dismiss
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default GlobalNoticeBanner;

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -65,6 +65,9 @@ import EmailBlacklistPage from '../../../staff/EmailBlacklistPage';
 import DonationLogPage from '../../../staff/DonationLogPage';
 import DuplicateIpsPage from '../../../staff/DuplicateIpsPage';
 import RegistrationLogPage from '../../../staff/RegistrationLogPage';
+import UserWarningsPage from '../../../staff/UserWarningsPage';
+import TagAliasesPage from '../../../staff/TagAliasesPage';
+import GlobalNoticesPage from '../../../staff/GlobalNoticesPage';
 import SnatchList from '../snatch/SnatchList';
 import BookmarksPage from '../bookmarks/BookmarksPage';
 import FriendsPage from '../friends/FriendsPage';
@@ -306,6 +309,30 @@ const PrivateContent = () => (
       element={
         <StaffGate permissions={['staff', 'admin']}>
           <RegistrationLogPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/user-warnings"
+      element={
+        <StaffGate permissions={['staff', 'admin']}>
+          <UserWarningsPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/tag-aliases"
+      element={
+        <StaffGate permissions={['staff', 'admin']}>
+          <TagAliasesPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/global-notices"
+      element={
+        <StaffGate permissions={['news_manage']}>
+          <GlobalNoticesPage />
         </StaffGate>
       }
     />

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -68,6 +68,19 @@ import RegistrationLogPage from '../../../staff/RegistrationLogPage';
 import UserWarningsPage from '../../../staff/UserWarningsPage';
 import TagAliasesPage from '../../../staff/TagAliasesPage';
 import GlobalNoticesPage from '../../../staff/GlobalNoticesPage';
+import LoginWatchPage from '../../../staff/LoginWatchPage';
+import VanityHousePage from '../../../staff/VanityHousePage';
+import AlbumOfMonthPage from '../../../staff/AlbumOfMonthPage';
+import UserFlowPage from '../../../staff/UserFlowPage';
+import InvitePoolPage from '../../../staff/InvitePoolPage';
+import InviteTreePage from '../../../staff/InviteTreePage';
+import DncPage from '../../../staff/DncPage';
+import CollageRecoveryPage from '../../../staff/CollageRecoveryPage';
+import EconomicStatsPage from '../../../staff/EconomicStatsPage';
+import ReleaseStatsPage from '../../../staff/ReleaseStatsPage';
+import RatioWatchPage from '../../../staff/RatioWatchPage';
+import ClientStatsPage from '../../../staff/ClientStatsPage';
+import SiteInfoPage from '../../../staff/SiteInfoPage';
 import SnatchList from '../snatch/SnatchList';
 import BookmarksPage from '../bookmarks/BookmarksPage';
 import FriendsPage from '../friends/FriendsPage';
@@ -333,6 +346,110 @@ const PrivateContent = () => (
       element={
         <StaffGate permissions={['news_manage']}>
           <GlobalNoticesPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/login-watch"
+      element={
+        <StaffGate permissions={['admin']}>
+          <LoginWatchPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/vanity-house"
+      element={
+        <StaffGate permissions={['news_manage']}>
+          <VanityHousePage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/album-of-month"
+      element={
+        <StaffGate permissions={['news_manage']}>
+          <AlbumOfMonthPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/user-flow"
+      element={
+        <StaffGate permissions={['admin']}>
+          <UserFlowPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/invite-pool"
+      element={
+        <StaffGate permissions={['admin']}>
+          <InvitePoolPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/invite-tree"
+      element={
+        <StaffGate permissions={['admin']}>
+          <InviteTreePage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/dnc"
+      element={
+        <StaffGate permissions={['communities_manage']}>
+          <DncPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/collage-recovery"
+      element={
+        <StaffGate permissions={['collages_moderate']}>
+          <CollageRecoveryPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/economic-stats"
+      element={
+        <StaffGate permissions={['admin']}>
+          <EconomicStatsPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/release-stats"
+      element={
+        <StaffGate permissions={['admin']}>
+          <ReleaseStatsPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/ratio-watch"
+      element={
+        <StaffGate permissions={['admin']}>
+          <RatioWatchPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/client-stats"
+      element={
+        <StaffGate permissions={['admin']}>
+          <ClientStatsPage />
+        </StaffGate>
+      }
+    />
+    <Route
+      path="staff/site-info"
+      element={
+        <StaffGate permissions={['admin']}>
+          <SiteInfoPage />
         </StaffGate>
       }
     />

--- a/src/components/pages/private/layout/PrivateLayout.tsx
+++ b/src/components/pages/private/layout/PrivateLayout.tsx
@@ -9,6 +9,7 @@ import {
 import PrivateHeader from './PrivateHeader';
 import PrivateFooter from './PrivateFooter';
 import NotificationCorner from '../../../layout/NotificationCorner';
+import GlobalNoticeBanner from '../../../layout/GlobalNoticeBanner';
 import Spinner from '../../../layout/Spinner';
 
 interface Props {
@@ -34,6 +35,7 @@ const PrivateLayout = ({ children }: Props) => {
   return (
     <div className="min-h-screen bg-gray-900 text-gray-100 flex flex-col">
       <PrivateHeader user={user} />
+      <GlobalNoticeBanner />
       <main className="flex-1 max-w-7xl w-full mx-auto px-4 py-6">
         {children}
       </main>

--- a/src/components/staff/AlbumOfMonthPage.tsx
+++ b/src/components/staff/AlbumOfMonthPage.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetAlbumOfMonthQuery,
+  useCreateAlbumOfMonthMutation,
+  useDeleteAlbumOfMonthMutation
+} from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const AlbumOfMonthPage = () => {
+  const [groupId, setGroupId] = useState('');
+  const [threadId, setThreadId] = useState('');
+  const [title, setTitle] = useState('');
+  const [started, setStarted] = useState('');
+  const [ended, setEnded] = useState('');
+  const [formError, setFormError] = useState('');
+
+  const { data, isLoading } = useGetAlbumOfMonthQuery();
+  const [createAlbum, { isLoading: isCreating }] =
+    useCreateAlbumOfMonthMutation();
+  const [deleteAlbum] = useDeleteAlbumOfMonthMutation();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError('');
+    const gId = parseInt(groupId, 10);
+    const tId = parseInt(threadId, 10);
+    if (isNaN(gId) || gId <= 0 || isNaN(tId) || tId <= 0) {
+      setFormError('Group ID and Thread ID must be positive integers.');
+      return;
+    }
+    if (!title.trim() || !started || !ended) {
+      setFormError('All fields are required.');
+      return;
+    }
+    try {
+      await createAlbum({
+        groupId: gId,
+        threadId: tId,
+        title: title.trim(),
+        started: new Date(started).toISOString(),
+        ended: new Date(ended).toISOString()
+      }).unwrap();
+      setGroupId('');
+      setThreadId('');
+      setTitle('');
+      setStarted('');
+      setEnded('');
+    } catch {
+      setFormError('Failed to create entry. Check all fields and try again.');
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">
+          Album of the Month
+        </h2>
+      </div>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">
+          Add Entry
+        </h3>
+        <form onSubmit={handleSubmit} className="grid grid-cols-2 gap-3">
+          <input
+            type="number"
+            value={groupId}
+            onChange={(e) => setGroupId(e.target.value)}
+            placeholder="Group ID"
+            className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+          <input
+            type="number"
+            value={threadId}
+            onChange={(e) => setThreadId(e.target.value)}
+            placeholder="Thread ID"
+            className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Title"
+            className="col-span-2 rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+          <div className="flex flex-col gap-1">
+            <label htmlFor="aom-started" className="text-xs text-gray-400">
+              Started
+            </label>
+            <input
+              id="aom-started"
+              type="datetime-local"
+              value={started}
+              onChange={(e) => setStarted(e.target.value)}
+              className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="aom-ended" className="text-xs text-gray-400">
+              Ended
+            </label>
+            <input
+              id="aom-ended"
+              type="datetime-local"
+              value={ended}
+              onChange={(e) => setEnded(e.target.value)}
+              className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+          {formError && (
+            <p className="col-span-2 text-red-400 text-xs">{formError}</p>
+          )}
+          <div className="col-span-2">
+            <button
+              type="submit"
+              disabled={isCreating}
+              className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-4 py-1.5 rounded text-sm"
+            >
+              Add
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">Title</th>
+                <th className="text-left px-4 py-2 font-semibold">Group</th>
+                <th className="text-left px-4 py-2 font-semibold">Thread</th>
+                <th className="text-left px-4 py-2 font-semibold">Started</th>
+                <th className="text-left px-4 py-2 font-semibold">Ended</th>
+                <th className="px-4 py-2 font-semibold"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.length ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No albums on record.
+                  </td>
+                </tr>
+              ) : (
+                data.map((a) => (
+                  <tr
+                    key={a.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2 text-white">{a.title}</td>
+                    <td className="px-4 py-2 text-gray-400 text-xs font-mono">
+                      {a.groupId}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs font-mono">
+                      {a.threadId}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      <Time date={a.started} />
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      <Time date={a.ended} />
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        onClick={() => deleteAlbum(a.id)}
+                        className="text-red-400 hover:text-red-300 text-xs"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AlbumOfMonthPage;

--- a/src/components/staff/ClientStatsPage.tsx
+++ b/src/components/staff/ClientStatsPage.tsx
@@ -1,0 +1,66 @@
+import { Link } from 'react-router-dom';
+import { useGetClientStatsQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+
+const ClientStatsPage = () => {
+  const { data, isLoading } = useGetClientStatsQuery();
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">
+          OS &amp; Browser Usage
+        </h2>
+      </div>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+              <th className="text-left px-4 py-2 font-semibold">User Agent</th>
+              <th className="text-right px-4 py-2 font-semibold">Sessions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-700/50">
+            {!data?.length ? (
+              <tr>
+                <td colSpan={2} className="px-4 py-6 text-center text-gray-500">
+                  No data.
+                </td>
+              </tr>
+            ) : (
+              data.map((row, i) => (
+                <tr key={i} className="hover:bg-gray-700/30 transition-colors">
+                  <td className="px-4 py-2 font-mono text-xs text-gray-300">
+                    {row.userAgent ?? (
+                      <span className="text-gray-500 italic">unknown</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-right text-gray-400 text-xs">
+                    {row.count.toLocaleString()}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ClientStatsPage;

--- a/src/components/staff/CollageRecoveryPage.tsx
+++ b/src/components/staff/CollageRecoveryPage.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetDeletedCollagesQuery } from '../../store/services/adminApi';
+import { useRecoverCollageMutation } from '../../store/services/collageApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const CollageRecoveryPage = () => {
+  const [page, setPage] = useState(1);
+  const [recovering, setRecovering] = useState<number | null>(null);
+
+  const { data, isLoading } = useGetDeletedCollagesQuery(page);
+  const [recoverCollage] = useRecoverCollageMutation();
+
+  const handleRecover = async (id: number) => {
+    setRecovering(id);
+    try {
+      await recoverCollage(id).unwrap();
+    } finally {
+      setRecovering(null);
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Collage Recovery</h2>
+      </div>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">Name</th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  Created By
+                </th>
+                <th className="text-left px-4 py-2 font-semibold">Created</th>
+                <th className="text-left px-4 py-2 font-semibold">Deleted</th>
+                <th className="px-4 py-2 font-semibold"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.data?.length ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No deleted collages.
+                  </td>
+                </tr>
+              ) : (
+                data.data.map((c) => (
+                  <tr
+                    key={c.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2 text-white">{c.name}</td>
+                    <td className="px-4 py-2">
+                      <Link
+                        to={`/private/user/${c.user.id}`}
+                        className="text-indigo-400 hover:text-indigo-300"
+                      >
+                        {c.user.username}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      <Time date={c.createdAt} />
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      {c.deletedAt ? <Time date={c.deletedAt} /> : '—'}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        onClick={() => handleRecover(c.id)}
+                        disabled={recovering === c.id}
+                        className="text-green-400 hover:text-green-300 text-xs disabled:opacity-50"
+                      >
+                        {recovering === c.id ? 'Recovering…' : 'Recover'}
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {data && data.meta.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 text-sm text-gray-400">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Prev
+          </button>
+          <span>
+            {page} / {data.meta.totalPages}
+          </span>
+          <button
+            onClick={() =>
+              setPage((p) => Math.min(data.meta.totalPages, p + 1))
+            }
+            disabled={page === data.meta.totalPages}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CollageRecoveryPage;

--- a/src/components/staff/DncPage.tsx
+++ b/src/components/staff/DncPage.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetDncQuery,
+  useCreateDncEntryMutation,
+  useDeleteDncEntryMutation
+} from '../../store/services/adminApi';
+import { useGetCommunitiesQuery } from '../../store/services/communityApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const DncPage = () => {
+  const [communityId, setCommunityId] = useState<number | null>(null);
+  const [name, setName] = useState('');
+  const [comment, setComment] = useState('');
+  const [formError, setFormError] = useState('');
+
+  const { data: communities } = useGetCommunitiesQuery(1);
+  const { data: dnc, isLoading } = useGetDncQuery(communityId!, {
+    skip: communityId === null
+  });
+  const [createEntry, { isLoading: isCreating }] = useCreateDncEntryMutation();
+  const [deleteEntry] = useDeleteDncEntryMutation();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError('');
+    if (!communityId) return;
+    if (!name.trim()) {
+      setFormError('Name is required.');
+      return;
+    }
+    try {
+      await createEntry({
+        communityId,
+        name: name.trim(),
+        comment: comment.trim()
+      }).unwrap();
+      setName('');
+      setComment('');
+    } catch {
+      setFormError('Failed to add entry.');
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">
+          Do Not Contribute List
+        </h2>
+      </div>
+
+      <div className="flex gap-2 items-center">
+        <label htmlFor="dnc-community" className="text-sm text-gray-400">
+          Community:
+        </label>
+        <select
+          id="dnc-community"
+          value={communityId ?? ''}
+          onChange={(e) =>
+            setCommunityId(e.target.value ? Number(e.target.value) : null)
+          }
+          className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        >
+          <option value="">Select community…</option>
+          {communities?.data?.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {communityId !== null && (
+        <>
+          <div className="bg-gray-800 rounded-lg border border-gray-700 p-4 space-y-3">
+            <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">
+              Add Entry
+            </h3>
+            <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Artist, label, or release title"
+                className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+              <input
+                type="text"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                placeholder="Comment (optional)"
+                className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+              {formError && <p className="text-red-400 text-xs">{formError}</p>}
+              <div>
+                <button
+                  type="submit"
+                  disabled={isCreating}
+                  className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-4 py-1.5 rounded text-sm"
+                >
+                  Add
+                </button>
+              </div>
+            </form>
+          </div>
+
+          <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+            {isLoading ? (
+              <div className="p-6">
+                <Spinner />
+              </div>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                    <th className="text-left px-4 py-2 font-semibold">Name</th>
+                    <th className="text-left px-4 py-2 font-semibold">
+                      Comment
+                    </th>
+                    <th className="text-left px-4 py-2 font-semibold">
+                      Added By
+                    </th>
+                    <th className="text-left px-4 py-2 font-semibold">Date</th>
+                    <th className="px-4 py-2"></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-700/50">
+                  {!dnc?.length ? (
+                    <tr>
+                      <td
+                        colSpan={5}
+                        className="px-4 py-6 text-center text-gray-500"
+                      >
+                        No DNC entries for this community.
+                      </td>
+                    </tr>
+                  ) : (
+                    dnc.map((entry) => (
+                      <tr
+                        key={entry.id}
+                        className="hover:bg-gray-700/30 transition-colors"
+                      >
+                        <td className="px-4 py-2 text-white">{entry.name}</td>
+                        <td
+                          className="px-4 py-2 text-gray-400 text-xs max-w-xs truncate"
+                          title={entry.comment}
+                        >
+                          {entry.comment || '—'}
+                        </td>
+                        <td className="px-4 py-2">
+                          {entry.addedBy ? (
+                            <Link
+                              to={`/private/user/${entry.addedBy.id}`}
+                              className="text-indigo-400 hover:text-indigo-300"
+                            >
+                              {entry.addedBy.username}
+                            </Link>
+                          ) : (
+                            <span className="text-gray-500">—</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-gray-400 text-xs">
+                          <Time date={entry.createdAt} />
+                        </td>
+                        <td className="px-4 py-2 text-right">
+                          <button
+                            onClick={() =>
+                              deleteEntry({
+                                communityId: communityId!,
+                                dncId: entry.id
+                              })
+                            }
+                            className="text-red-400 hover:text-red-300 text-xs"
+                          >
+                            Delete
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default DncPage;

--- a/src/components/staff/EconomicStatsPage.tsx
+++ b/src/components/staff/EconomicStatsPage.tsx
@@ -1,0 +1,146 @@
+import { Link } from 'react-router-dom';
+import { useGetEconomyStatsQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const EconomicStatsPage = () => {
+  const { data, isLoading } = useGetEconomyStatsQuery();
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Economic Stats</h2>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-3">
+          Totals by Reason
+        </h3>
+        <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">Reason</th>
+                <th className="text-right px-4 py-2 font-semibold">
+                  Transactions
+                </th>
+                <th className="text-right px-4 py-2 font-semibold">
+                  Total Amount
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.grouped?.length ? (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No data.
+                  </td>
+                </tr>
+              ) : (
+                data.grouped.map((g) => (
+                  <tr
+                    key={g.reason}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2 text-white font-mono text-xs">
+                      {g.reason}
+                    </td>
+                    <td className="px-4 py-2 text-right text-gray-300">
+                      {g._count}
+                    </td>
+                    <td className="px-4 py-2 text-right text-gray-300 font-mono">
+                      {g._sum.amount != null
+                        ? Number(g._sum.amount).toLocaleString()
+                        : '—'}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-3">
+          Recent Transactions
+        </h3>
+        <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">User</th>
+                <th className="text-left px-4 py-2 font-semibold">Reason</th>
+                <th className="text-right px-4 py-2 font-semibold">Amount</th>
+                <th className="text-left px-4 py-2 font-semibold">Date</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.recent?.length ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No recent transactions.
+                  </td>
+                </tr>
+              ) : (
+                data.recent.map((t) => (
+                  <tr
+                    key={t.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2">
+                      <Link
+                        to={`/private/user/${t.user.id}`}
+                        className="text-indigo-400 hover:text-indigo-300"
+                      >
+                        {t.user.username}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs font-mono">
+                      {t.reason}
+                    </td>
+                    <td
+                      className={`px-4 py-2 text-right text-xs font-mono ${
+                        Number(t.amount) >= 0
+                          ? 'text-green-400'
+                          : 'text-red-400'
+                      }`}
+                    >
+                      {Number(t.amount) >= 0 ? '+' : ''}
+                      {Number(t.amount).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      <Time date={t.createdAt} />
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EconomicStatsPage;

--- a/src/components/staff/GlobalNoticesPage.tsx
+++ b/src/components/staff/GlobalNoticesPage.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetGlobalNoticesQuery,
+  useCreateGlobalNoticeMutation,
+  useDeleteGlobalNoticeMutation
+} from '../../store/services/announcementApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const inputClass =
+  'rounded bg-gray-700 border border-gray-600 text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+const GlobalNoticesPage = () => {
+  const { data: globalNotices, isLoading } = useGetGlobalNoticesQuery();
+  const [createGlobalNotice, { isLoading: creating }] =
+    useCreateGlobalNoticeMutation();
+  const [deleteGlobalNotice] = useDeleteGlobalNoticeMutation();
+
+  const [message, setMessage] = useState('');
+  const [url, setUrl] = useState('');
+  const [expiry, setExpiry] = useState('');
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await createGlobalNotice({
+      message,
+      ...(url ? { url } : {}),
+      ...(expiry ? { expiresAt: new Date(expiry).toISOString() } : {})
+    });
+    setMessage('');
+    setUrl('');
+    setExpiry('');
+  };
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Global Notices</h2>
+        <p className="mt-1 text-sm text-gray-400">
+          Sent as notifications to all active users.
+        </p>
+      </div>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-4">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">Message</th>
+                <th className="text-left px-4 py-2 font-semibold">URL</th>
+                <th className="text-left px-4 py-2 font-semibold">Expires</th>
+                <th className="text-left px-4 py-2 font-semibold">Sent</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!globalNotices?.length ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No notices.
+                  </td>
+                </tr>
+              ) : (
+                globalNotices.map((n) => (
+                  <tr
+                    key={n.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2 text-gray-200">{n.message}</td>
+                    <td className="px-4 py-2 text-gray-400 truncate max-w-xs">
+                      {n.url ?? '—'}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400">
+                      {n.expiresAt ? (
+                        <Time date={n.expiresAt} />
+                      ) : (
+                        <span className="text-gray-600">Never</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400">
+                      <Time date={n.createdAt} />
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        type="button"
+                        onClick={() => deleteGlobalNotice(n.id)}
+                        className="text-red-400 hover:text-red-300 transition-colors text-sm"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+
+        <form
+          onSubmit={handleCreate}
+          className="p-4 border-t border-gray-700 space-y-3"
+        >
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-400">
+            Send Global Notice
+          </h4>
+          <input
+            type="text"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Message (max 500 chars)"
+            maxLength={500}
+            required
+            className={`${inputClass} w-full`}
+          />
+          <input
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="Link URL (optional, must be absolute)"
+            className={`${inputClass} w-full`}
+          />
+          <input
+            type="datetime-local"
+            value={expiry}
+            onChange={(e) => setExpiry(e.target.value)}
+            className={`${inputClass} w-full`}
+            title="Expiry (optional)"
+          />
+          <button
+            type="submit"
+            disabled={creating}
+            className="bg-amber-600 hover:bg-amber-700 disabled:opacity-50 text-white px-4 py-2 rounded text-sm font-medium transition-colors"
+          >
+            {creating ? 'Sending…' : 'Send Notice'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default GlobalNoticesPage;

--- a/src/components/staff/InvitePoolPage.tsx
+++ b/src/components/staff/InvitePoolPage.tsx
@@ -1,0 +1,163 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetInvitesQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const STATUSES = ['PENDING', 'ACCEPTED', 'EXPIRED', 'USED', 'CANCELLED'];
+
+const InvitePoolPage = () => {
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState('');
+
+  const { data, isLoading } = useGetInvitesQuery(
+    status ? { page, status } : { page }
+  );
+
+  const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setStatus(e.target.value);
+    setPage(1);
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Invite Pool</h2>
+      </div>
+
+      <div className="flex gap-2">
+        <select
+          value={status}
+          onChange={handleStatusChange}
+          className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        >
+          <option value="">All statuses</option>
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {s.charAt(0) + s.slice(1).toLowerCase()}
+            </option>
+          ))}
+        </select>
+        {status && (
+          <button
+            type="button"
+            onClick={() => {
+              setStatus('');
+              setPage(1);
+            }}
+            className="text-gray-400 hover:text-white text-sm px-2"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">Inviter</th>
+                <th className="text-left px-4 py-2 font-semibold">Email</th>
+                <th className="text-left px-4 py-2 font-semibold">Status</th>
+                <th className="text-left px-4 py-2 font-semibold">Expires</th>
+                <th className="text-left px-4 py-2 font-semibold">Reason</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.data?.length ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No invites found.
+                  </td>
+                </tr>
+              ) : (
+                data.data.map((inv) => (
+                  <tr
+                    key={inv.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2">
+                      <Link
+                        to={`/private/user/${inv.inviter.id}`}
+                        className="text-indigo-400 hover:text-indigo-300"
+                      >
+                        {inv.inviter.username}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-gray-300 font-mono text-xs">
+                      {inv.email}
+                    </td>
+                    <td className="px-4 py-2 text-xs">
+                      <span
+                        className={
+                          inv.status === 'USED' || inv.status === 'ACCEPTED'
+                            ? 'text-green-400'
+                            : inv.status === 'EXPIRED' ||
+                              inv.status === 'CANCELLED'
+                            ? 'text-red-400'
+                            : 'text-yellow-400'
+                        }
+                      >
+                        {inv.status.charAt(0) +
+                          inv.status.slice(1).toLowerCase()}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      <Time date={inv.expires} />
+                    </td>
+                    <td
+                      className="px-4 py-2 text-gray-400 text-xs max-w-xs truncate"
+                      title={inv.reason}
+                    >
+                      {inv.reason || '—'}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {data && data.meta.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 text-sm text-gray-400">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Prev
+          </button>
+          <span>
+            {page} / {data.meta.totalPages}
+          </span>
+          <button
+            onClick={() =>
+              setPage((p) => Math.min(data.meta.totalPages, p + 1))
+            }
+            disabled={page === data.meta.totalPages}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InvitePoolPage;

--- a/src/components/staff/InvitePoolPage.tsx
+++ b/src/components/staff/InvitePoolPage.tsx
@@ -6,6 +6,12 @@ import Time from '../layout/Time';
 
 const STATUSES = ['PENDING', 'ACCEPTED', 'EXPIRED', 'USED', 'CANCELLED'];
 
+function inviteStatusColor(status: string): string {
+  if (status === 'USED' || status === 'ACCEPTED') return 'text-green-400';
+  if (status === 'EXPIRED' || status === 'CANCELLED') return 'text-red-400';
+  return 'text-yellow-400';
+}
+
 const InvitePoolPage = () => {
   const [page, setPage] = useState(1);
   const [status, setStatus] = useState('');
@@ -102,16 +108,7 @@ const InvitePoolPage = () => {
                       {inv.email}
                     </td>
                     <td className="px-4 py-2 text-xs">
-                      <span
-                        className={
-                          inv.status === 'USED' || inv.status === 'ACCEPTED'
-                            ? 'text-green-400'
-                            : inv.status === 'EXPIRED' ||
-                              inv.status === 'CANCELLED'
-                            ? 'text-red-400'
-                            : 'text-yellow-400'
-                        }
-                      >
+                      <span className={inviteStatusColor(inv.status)}>
                         {inv.status.charAt(0) +
                           inv.status.slice(1).toLowerCase()}
                       </span>

--- a/src/components/staff/InviteTreePage.tsx
+++ b/src/components/staff/InviteTreePage.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetInviteTreeQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+
+const InviteTreePage = () => {
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading } = useGetInviteTreeQuery(page);
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Invite Tree</h2>
+      </div>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">User</th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  Invited By
+                </th>
+                <th className="text-right px-4 py-2 font-semibold">Tree</th>
+                <th className="text-right px-4 py-2 font-semibold">Level</th>
+                <th className="text-right px-4 py-2 font-semibold">Position</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.data?.length ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No invite tree data.
+                  </td>
+                </tr>
+              ) : (
+                data.data.map((row) => (
+                  <tr
+                    key={row.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2">
+                      <Link
+                        to={`/private/user/${row.user.id}`}
+                        className="text-indigo-400 hover:text-indigo-300"
+                      >
+                        {row.user.username}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2">
+                      {row.inviter ? (
+                        <Link
+                          to={`/private/user/${row.inviter.id}`}
+                          className="text-indigo-400 hover:text-indigo-300"
+                        >
+                          {row.inviter.username}
+                        </Link>
+                      ) : (
+                        <span className="text-gray-500">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-right text-gray-400 text-xs font-mono">
+                      {row.treeId}
+                    </td>
+                    <td className="px-4 py-2 text-right text-gray-400 text-xs">
+                      {row.treeLevel}
+                    </td>
+                    <td className="px-4 py-2 text-right text-gray-400 text-xs">
+                      {row.treePosition}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {data && data.meta.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 text-sm text-gray-400">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Prev
+          </button>
+          <span>
+            {page} / {data.meta.totalPages}
+          </span>
+          <button
+            onClick={() =>
+              setPage((p) => Math.min(data.meta.totalPages, p + 1))
+            }
+            disabled={page === data.meta.totalPages}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InviteTreePage;

--- a/src/components/staff/LoginWatchPage.tsx
+++ b/src/components/staff/LoginWatchPage.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetSessionsQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const LoginWatchPage = () => {
+  const [page, setPage] = useState(1);
+  const [userIdInput, setUserIdInput] = useState('');
+  const [userId, setUserId] = useState<number | undefined>();
+
+  const { data, isLoading } = useGetSessionsQuery(
+    userId ? { page, userId } : { page }
+  );
+
+  const handleFilter = (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = parseInt(userIdInput, 10);
+    setUserId(isNaN(parsed) ? undefined : parsed);
+    setPage(1);
+  };
+
+  const clearFilter = () => {
+    setUserIdInput('');
+    setUserId(undefined);
+    setPage(1);
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Login Watch</h2>
+      </div>
+
+      <form onSubmit={handleFilter} className="flex gap-2">
+        <input
+          type="number"
+          value={userIdInput}
+          onChange={(e) => setUserIdInput(e.target.value)}
+          placeholder="Filter by user ID"
+          className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+        <button
+          type="submit"
+          className="bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-1.5 rounded text-sm"
+        >
+          Filter
+        </button>
+        {userId && (
+          <button
+            type="button"
+            onClick={clearFilter}
+            className="text-gray-400 hover:text-white text-sm px-2"
+          >
+            Clear
+          </button>
+        )}
+      </form>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">User</th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  IP Address
+                </th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  User Agent
+                </th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  First Seen
+                </th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  Last Active
+                </th>
+                <th className="text-left px-4 py-2 font-semibold">Revoked</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.data?.length ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No sessions found.
+                  </td>
+                </tr>
+              ) : (
+                data.data.map((s) => (
+                  <tr
+                    key={s.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2">
+                      <Link
+                        to={`/private/user/${s.user.id}`}
+                        className="text-indigo-400 hover:text-indigo-300"
+                      >
+                        {s.user.username}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-gray-300 font-mono text-xs">
+                      {s.ipAddress}
+                    </td>
+                    <td
+                      className="px-4 py-2 text-gray-400 text-xs max-w-xs truncate"
+                      title={s.userAgent ?? undefined}
+                    >
+                      {s.userAgent ? s.userAgent.slice(0, 60) : '—'}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      <Time date={s.createdAt} />
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      <Time date={s.lastActiveAt} />
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      {s.revokedAt ? <Time date={s.revokedAt} /> : '—'}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {data?.meta && data.meta.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 text-sm text-gray-400">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Prev
+          </button>
+          <span>
+            {page} / {data.meta.totalPages}
+          </span>
+          <button
+            onClick={() =>
+              setPage((p) => Math.min(data.meta.totalPages, p + 1))
+            }
+            disabled={page === data.meta.totalPages}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LoginWatchPage;

--- a/src/components/staff/RatioWatchPage.tsx
+++ b/src/components/staff/RatioWatchPage.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetRatioWatchQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const RatioWatchPage = () => {
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading } = useGetRatioWatchQuery(page);
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Ratio Watch</h2>
+      </div>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">User</th>
+                <th className="text-left px-4 py-2 font-semibold">Status</th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  Watch Started
+                </th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  Watch Expires
+                </th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  Leech Disabled
+                </th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  Last Evaluated
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.data?.length ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No users on ratio watch.
+                  </td>
+                </tr>
+              ) : (
+                data.data.map((r) => (
+                  <tr
+                    key={r.userId}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2">
+                      <Link
+                        to={`/private/user/${r.user.id}`}
+                        className="text-indigo-400 hover:text-indigo-300"
+                      >
+                        {r.user.username}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2">
+                      <span
+                        className={`text-xs font-semibold ${
+                          r.status === 'LEECH_DISABLED'
+                            ? 'text-red-400'
+                            : 'text-yellow-400'
+                        }`}
+                      >
+                        {r.status === 'LEECH_DISABLED'
+                          ? 'Leech Disabled'
+                          : 'Watch'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      {r.watchStartedAt ? (
+                        <Time date={r.watchStartedAt} />
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      {r.watchExpiresAt ? (
+                        <Time date={r.watchExpiresAt} />
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      {r.leechDisabledAt ? (
+                        <Time date={r.leechDisabledAt} />
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      <Time date={r.lastEvaluatedAt} />
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {data && data.meta.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 text-sm text-gray-400">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Prev
+          </button>
+          <span>
+            {page} / {data.meta.totalPages}
+          </span>
+          <button
+            onClick={() =>
+              setPage((p) => Math.min(data.meta.totalPages, p + 1))
+            }
+            disabled={page === data.meta.totalPages}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RatioWatchPage;

--- a/src/components/staff/ReleaseStatsPage.tsx
+++ b/src/components/staff/ReleaseStatsPage.tsx
@@ -1,0 +1,111 @@
+import { Link } from 'react-router-dom';
+import { useGetReleaseStatsQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+
+const ReleaseStatsPage = () => {
+  const { data, isLoading } = useGetReleaseStatsQuery();
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-6">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Release Stats</h2>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        {[
+          { label: 'Releases', value: data?.releases },
+          { label: 'Contributions', value: data?.contributions },
+          { label: 'Artists', value: data?.artists }
+        ].map(({ label, value }) => (
+          <div
+            key={label}
+            className="bg-gray-800 border border-gray-700 rounded-lg p-5 text-center"
+          >
+            <div className="text-3xl font-bold text-white">
+              {value?.toLocaleString() ?? '—'}
+            </div>
+            <div className="text-sm text-gray-400 mt-1">{label}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-3">
+            By Type
+          </h3>
+          <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                  <th className="text-left px-4 py-2 font-semibold">Type</th>
+                  <th className="text-right px-4 py-2 font-semibold">Count</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-700/50">
+                {data?.byType.map((row) => (
+                  <tr
+                    key={row.type}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2 text-gray-300">{row.type}</td>
+                    <td className="px-4 py-2 text-right text-gray-400">
+                      {row._count.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-3">
+            By Link Status
+          </h3>
+          <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                  <th className="text-left px-4 py-2 font-semibold">Status</th>
+                  <th className="text-right px-4 py-2 font-semibold">Count</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-700/50">
+                {data?.byLinkStatus.map((row) => (
+                  <tr
+                    key={row.linkStatus}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2 text-gray-300">
+                      {row.linkStatus}
+                    </td>
+                    <td className="px-4 py-2 text-right text-gray-400">
+                      {row._count.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReleaseStatsPage;

--- a/src/components/staff/SiteInfoPage.tsx
+++ b/src/components/staff/SiteInfoPage.tsx
@@ -1,0 +1,62 @@
+import { Link } from 'react-router-dom';
+import {
+  useGetSiteInfoQuery,
+  type SiteInfoData
+} from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+
+const STAT_LABELS: { key: keyof SiteInfoData; label: string }[] = [
+  { key: 'totalUsers', label: 'Total Users' },
+  { key: 'enabledUsers', label: 'Enabled Users' },
+  { key: 'disabledUsers', label: 'Disabled Users' },
+  { key: 'releases', label: 'Releases' },
+  { key: 'artists', label: 'Artists' },
+  { key: 'contributions', label: 'Contributions' },
+  { key: 'communities', label: 'Communities' },
+  { key: 'forumTopics', label: 'Forum Topics' },
+  { key: 'forumPosts', label: 'Forum Posts' },
+  { key: 'collages', label: 'Collages' },
+  { key: 'wikiPages', label: 'Wiki Pages' }
+];
+
+const SiteInfoPage = () => {
+  const { data, isLoading } = useGetSiteInfoQuery();
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Site Info</h2>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        {STAT_LABELS.map(({ key, label }) => (
+          <div
+            key={key}
+            className="bg-gray-800 border border-gray-700 rounded-lg p-4 text-center"
+          >
+            <div className="text-2xl font-bold text-white">
+              {data?.[key] != null ? Number(data[key]).toLocaleString() : '—'}
+            </div>
+            <div className="text-xs text-gray-400 mt-1">{label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SiteInfoPage;

--- a/src/components/staff/TagAliasesPage.tsx
+++ b/src/components/staff/TagAliasesPage.tsx
@@ -1,0 +1,245 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetTagAliasesQuery,
+  useCreateTagAliasMutation,
+  useUpdateTagAliasMutation,
+  useDeleteTagAliasMutation
+} from '../../store/services/tagAliasApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const TagAliasesPage = () => {
+  const [page, setPage] = useState(1);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editBadTag, setEditBadTag] = useState('');
+  const [editGoodTag, setEditGoodTag] = useState('');
+  const [newBadTag, setNewBadTag] = useState('');
+  const [newGoodTag, setNewGoodTag] = useState('');
+  const [error, setError] = useState('');
+
+  const { data, isLoading } = useGetTagAliasesQuery({ page });
+  const [createTagAlias, { isLoading: creating }] = useCreateTagAliasMutation();
+  const [updateTagAlias] = useUpdateTagAliasMutation();
+  const [deleteTagAlias] = useDeleteTagAliasMutation();
+
+  const aliases = data?.data ?? [];
+  const meta = data?.meta;
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const result = await createTagAlias({
+      badTag: newBadTag.trim(),
+      goodTag: newGoodTag.trim()
+    });
+    if ('error' in result) {
+      setError('Failed to create alias. Check that the canonical tag exists.');
+    } else {
+      setNewBadTag('');
+      setNewGoodTag('');
+    }
+  };
+
+  const startEdit = (id: number, badTag: string, goodTagName: string) => {
+    setEditingId(id);
+    setEditBadTag(badTag);
+    setEditGoodTag(goodTagName);
+  };
+
+  const handleSaveEdit = async (id: number) => {
+    await updateTagAlias({
+      id,
+      badTag: editBadTag.trim(),
+      goodTag: editGoodTag.trim()
+    });
+    setEditingId(null);
+  };
+
+  const inputClass =
+    'rounded bg-gray-700 border border-gray-600 text-white px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500';
+
+  return (
+    <div className="space-y-4 max-w-4xl">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">Tag Aliases</h2>
+        <p className="text-sm text-gray-400 mt-1">
+          Maps misspelled or non-canonical tag names to the correct tag. Applied
+          automatically on new submissions.
+        </p>
+      </div>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-700">
+                <th className="text-left px-4 py-2 text-gray-400 font-medium w-1/3">
+                  Bad tag (rename from)
+                </th>
+                <th className="text-left px-4 py-2 text-gray-400 font-medium w-1/3">
+                  Canonical tag (rename to)
+                </th>
+                <th className="text-left px-4 py-2 text-gray-400 font-medium">
+                  Added
+                </th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {aliases.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-4 py-6 text-gray-500 text-center"
+                  >
+                    No aliases defined.
+                  </td>
+                </tr>
+              ) : (
+                aliases.map((a) =>
+                  editingId === a.id ? (
+                    <tr key={a.id} className="bg-gray-700/30">
+                      <td className="px-4 py-2">
+                        <input
+                          className={inputClass}
+                          value={editBadTag}
+                          onChange={(e) => setEditBadTag(e.target.value)}
+                        />
+                      </td>
+                      <td className="px-4 py-2">
+                        <input
+                          className={inputClass}
+                          value={editGoodTag}
+                          onChange={(e) => setEditGoodTag(e.target.value)}
+                        />
+                      </td>
+                      <td className="px-4 py-2 text-gray-400">
+                        <Time date={a.createdAt} />
+                      </td>
+                      <td className="px-4 py-2 text-right space-x-2">
+                        <button
+                          type="button"
+                          onClick={() => handleSaveEdit(a.id)}
+                          className="text-green-400 hover:text-green-300 text-sm transition-colors"
+                        >
+                          Save
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setEditingId(null)}
+                          className="text-gray-400 hover:text-white text-sm transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </td>
+                    </tr>
+                  ) : (
+                    <tr key={a.id} className="hover:bg-gray-700/30">
+                      <td className="px-4 py-2 text-red-300 font-mono">
+                        {a.badTag}
+                      </td>
+                      <td className="px-4 py-2 text-green-300 font-mono">
+                        {a.goodTag.name}
+                      </td>
+                      <td className="px-4 py-2 text-gray-400">
+                        <Time date={a.createdAt} />
+                      </td>
+                      <td className="px-4 py-2 text-right space-x-3">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            startEdit(a.id, a.badTag, a.goodTag.name)
+                          }
+                          className="text-indigo-400 hover:text-indigo-300 text-sm transition-colors"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => deleteTagAlias(a.id)}
+                          className="text-red-400 hover:text-red-300 text-sm transition-colors"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  )
+                )
+              )}
+
+              {/* Create row */}
+              <tr className="bg-gray-700/20">
+                <td className="px-4 py-2">
+                  <input
+                    className={`${inputClass} w-full`}
+                    placeholder="e.g. hip-hop"
+                    value={newBadTag}
+                    onChange={(e) => setNewBadTag(e.target.value)}
+                  />
+                </td>
+                <td className="px-4 py-2">
+                  <input
+                    className={`${inputClass} w-full`}
+                    placeholder="e.g. hip.hop"
+                    value={newGoodTag}
+                    onChange={(e) => setNewGoodTag(e.target.value)}
+                  />
+                </td>
+                <td className="px-4 py-2 text-gray-500 text-xs">
+                  Canonical tag must exist
+                </td>
+                <td className="px-4 py-2 text-right">
+                  <button
+                    type="button"
+                    disabled={creating || !newBadTag || !newGoodTag}
+                    onClick={handleCreate}
+                    className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-3 py-1 rounded text-sm font-medium transition-colors"
+                  >
+                    {creating ? 'Adding…' : 'Add alias'}
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+
+      {meta && meta.totalPages > 1 && (
+        <div className="flex items-center gap-2 text-sm">
+          <button
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40 text-white transition-colors"
+          >
+            Prev
+          </button>
+          <span className="text-gray-400">
+            Page {meta.page} of {meta.totalPages}
+          </span>
+          <button
+            disabled={page >= meta.totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40 text-white transition-colors"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TagAliasesPage;

--- a/src/components/staff/UserFlowPage.tsx
+++ b/src/components/staff/UserFlowPage.tsx
@@ -1,0 +1,109 @@
+import { Link } from 'react-router-dom';
+import { useGetUserFlowQuery } from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const STATUS_LABELS: Record<string, string> = {
+  PENDING: 'Pending',
+  ACCEPTED: 'Accepted',
+  EXPIRED: 'Expired',
+  USED: 'Used',
+  CANCELLED: 'Cancelled'
+};
+
+const UserFlowPage = () => {
+  const { data, isLoading } = useGetUserFlowQuery();
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">User Flow</h2>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-3">
+          Invite Funnel
+        </h3>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          {data?.inviteFunnel.map((item) => (
+            <div
+              key={item.status}
+              className="bg-gray-800 border border-gray-700 rounded-lg p-4 text-center"
+            >
+              <div className="text-2xl font-bold text-white">{item._count}</div>
+              <div className="text-xs text-gray-400 mt-1">
+                {STATUS_LABELS[item.status] ?? item.status}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-3">
+          Site Growth (Last 12 Snapshots)
+        </h3>
+        <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">Date</th>
+                <th className="text-right px-4 py-2 font-semibold">
+                  Total Users
+                </th>
+                <th className="text-right px-4 py-2 font-semibold">
+                  Active This Month
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.snapshots.length ? (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No snapshots available.
+                  </td>
+                </tr>
+              ) : (
+                data.snapshots.map((s) => (
+                  <tr
+                    key={s.bucketAt}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      <Time date={s.bucketAt} />
+                    </td>
+                    <td className="px-4 py-2 text-right text-white">
+                      {s.totalUsers.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-2 text-right text-gray-300">
+                      {s.activeThisMonth.toLocaleString()}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserFlowPage;

--- a/src/components/staff/UserWarningsPage.tsx
+++ b/src/components/staff/UserWarningsPage.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGetAllWarningsQuery } from '../../store/services/userApi';
+import Spinner from '../layout/Spinner';
+import Time from '../layout/Time';
+
+const UserWarningsPage = () => {
+  const [page, setPage] = useState(1);
+  const [userIdInput, setUserIdInput] = useState('');
+  const [userIdFilter, setUserIdFilter] = useState<number | undefined>();
+
+  const { data, isLoading } = useGetAllWarningsQuery({
+    page,
+    userId: userIdFilter
+  });
+
+  const warnings = data?.data ?? [];
+  const meta = data?.meta;
+
+  const handleFilter = (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = parseInt(userIdInput, 10);
+    setUserIdFilter(isNaN(parsed) ? undefined : parsed);
+    setPage(1);
+  };
+
+  const handleClearFilter = () => {
+    setUserIdInput('');
+    setUserIdFilter(undefined);
+    setPage(1);
+  };
+
+  return (
+    <div className="space-y-4 max-w-5xl">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">User Warnings</h2>
+      </div>
+
+      <form onSubmit={handleFilter} className="flex items-center gap-2">
+        <input
+          type="number"
+          min={1}
+          value={userIdInput}
+          onChange={(e) => setUserIdInput(e.target.value)}
+          placeholder="Filter by user ID"
+          className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 w-44"
+        />
+        <button
+          type="submit"
+          className="bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-1.5 rounded text-sm font-medium transition-colors"
+        >
+          Filter
+        </button>
+        {userIdFilter && (
+          <button
+            type="button"
+            onClick={handleClearFilter}
+            className="text-gray-400 hover:text-white text-sm transition-colors"
+          >
+            Clear
+          </button>
+        )}
+      </form>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-700">
+                <th className="text-left px-4 py-2 text-gray-400 font-medium">
+                  User
+                </th>
+                <th className="text-left px-4 py-2 text-gray-400 font-medium">
+                  Reason
+                </th>
+                <th className="text-left px-4 py-2 text-gray-400 font-medium">
+                  Warned by
+                </th>
+                <th className="text-left px-4 py-2 text-gray-400 font-medium">
+                  Issued
+                </th>
+                <th className="text-left px-4 py-2 text-gray-400 font-medium">
+                  Expires
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {warnings.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-6 text-gray-500 text-center"
+                  >
+                    No warnings found.
+                  </td>
+                </tr>
+              ) : (
+                warnings.map((w) => (
+                  <tr key={w.id} className="hover:bg-gray-700/30">
+                    <td className="px-4 py-2">
+                      <Link
+                        to={`/private/user/${w.userId}`}
+                        className="text-indigo-400 hover:text-indigo-300 transition-colors"
+                      >
+                        {w.user?.username ?? `#${w.userId}`}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-gray-200 max-w-xs truncate">
+                      {w.reason}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400">
+                      {w.warnedBy ? (
+                        <Link
+                          to={`/private/user/${w.warnedBy.id}`}
+                          className="text-indigo-400 hover:text-indigo-300 transition-colors"
+                        >
+                          {w.warnedBy.username}
+                        </Link>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-gray-400">
+                      <Time date={w.createdAt} />
+                    </td>
+                    <td className="px-4 py-2 text-gray-400">
+                      {w.expiresAt ? <Time date={w.expiresAt} /> : '—'}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {meta && meta.totalPages > 1 && (
+        <div className="flex items-center gap-2 text-sm">
+          <button
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40 text-white transition-colors"
+          >
+            Prev
+          </button>
+          <span className="text-gray-400">
+            Page {meta.page} of {meta.totalPages}
+          </span>
+          <button
+            disabled={page >= meta.totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40 text-white transition-colors"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserWarningsPage;

--- a/src/components/staff/VanityHousePage.tsx
+++ b/src/components/staff/VanityHousePage.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useGetVanityHouseArtistsQuery,
+  useSetVanityHouseMutation
+} from '../../store/services/adminApi';
+import Spinner from '../layout/Spinner';
+
+const VanityHousePage = () => {
+  const [page, setPage] = useState(1);
+  const [artistIdInput, setArtistIdInput] = useState('');
+  const [error, setError] = useState('');
+
+  const { data, isLoading } = useGetVanityHouseArtistsQuery(page);
+  const [setVanityHouse, { isLoading: isSetting }] =
+    useSetVanityHouseMutation();
+
+  const handleRemove = async (id: number) => {
+    await setVanityHouse({ id, vanityHouse: false });
+  };
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const id = parseInt(artistIdInput, 10);
+    if (isNaN(id) || id <= 0) {
+      setError('Enter a valid artist ID.');
+      return;
+    }
+    try {
+      await setVanityHouse({ id, vanityHouse: true }).unwrap();
+      setArtistIdInput('');
+    } catch {
+      setError('Failed to add artist. Check the ID and try again.');
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <Link
+          to="/private/staff/tools"
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          ← Toolbox
+        </Link>
+        <h2 className="mt-1 text-2xl font-bold text-white">
+          Vanity House Artists
+        </h2>
+      </div>
+
+      <form onSubmit={handleAdd} className="flex gap-2 items-start">
+        <div className="flex flex-col gap-1">
+          <input
+            type="number"
+            value={artistIdInput}
+            onChange={(e) => setArtistIdInput(e.target.value)}
+            placeholder="Artist ID"
+            className="rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 w-36"
+          />
+          {error && <span className="text-red-400 text-xs">{error}</span>}
+        </div>
+        <button
+          type="submit"
+          disabled={isSetting}
+          className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-3 py-1.5 rounded text-sm"
+        >
+          Add Artist
+        </button>
+      </form>
+
+      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        {isLoading ? (
+          <div className="p-6">
+            <Spinner />
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-700/40 text-xs uppercase tracking-wider text-gray-400">
+                <th className="text-left px-4 py-2 font-semibold">ID</th>
+                <th className="text-left px-4 py-2 font-semibold">Artist</th>
+                <th className="text-left px-4 py-2 font-semibold">Releases</th>
+                <th className="px-4 py-2 font-semibold"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700/50">
+              {!data?.data?.length ? (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No vanity house artists.
+                  </td>
+                </tr>
+              ) : (
+                data.data.map((a) => (
+                  <tr
+                    key={a.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-2 text-gray-400 text-xs font-mono">
+                      {a.id}
+                    </td>
+                    <td className="px-4 py-2">
+                      <Link
+                        to={`/private/artist/${a.id}`}
+                        className="text-indigo-400 hover:text-indigo-300"
+                      >
+                        {a.name}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 text-gray-400 text-xs">
+                      {a._count.releases}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        onClick={() => handleRemove(a.id)}
+                        disabled={isSetting}
+                        className="text-red-400 hover:text-red-300 text-xs disabled:opacity-50"
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {data && data.meta.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 text-sm text-gray-400">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Prev
+          </button>
+          <span>
+            {page} / {data.meta.totalPages}
+          </span>
+          <button
+            onClick={() =>
+              setPage((p) => Math.min(data.meta.totalPages, p + 1))
+            }
+            disabled={page === data.meta.totalPages}
+            className="hover:text-white disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VanityHousePage;

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -63,7 +63,10 @@ export const api = createApi({
     'DonorReward',
     'StaffGroup',
     'RulesPage',
-    'Friend'
+    'Friend',
+    'GlobalNotice',
+    'Warning',
+    'TagAlias'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -66,7 +66,20 @@ export const api = createApi({
     'Friend',
     'GlobalNotice',
     'Warning',
-    'TagAlias'
+    'TagAlias',
+    'Session',
+    'Invite',
+    'InviteTree',
+    'RatioWatch',
+    'VanityHouse',
+    'DeletedCollage',
+    'AlbumOfMonth',
+    'Dnc',
+    'EconomyStats',
+    'ReleaseStats',
+    'ClientStats',
+    'UserFlow',
+    'SiteInfo'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/adminApi.ts
+++ b/src/store/services/adminApi.ts
@@ -60,6 +60,135 @@ interface PaginatedResponse<T> {
   };
 }
 
+export interface UserRef {
+  id: number;
+  username: string;
+}
+
+export interface SessionItem {
+  id: string;
+  user: UserRef;
+  ipAddress: string;
+  userAgent: string | null;
+  createdAt: string;
+  lastActiveAt: string;
+  revokedAt: string | null;
+}
+
+export interface InviteItem {
+  id: number;
+  inviter: UserRef;
+  email: string;
+  expires: string;
+  reason: string;
+  status: string;
+}
+
+export interface InviteTreeItem {
+  id: number;
+  userId: number;
+  user: UserRef;
+  inviterId: number;
+  inviter: UserRef | null;
+  treeId: number;
+  treeLevel: number;
+  treePosition: number;
+}
+
+export interface RatioWatchItem {
+  userId: number;
+  user: UserRef;
+  status: string;
+  watchStartedAt: string | null;
+  watchExpiresAt: string | null;
+  leechDisabledAt: string | null;
+  lastEvaluatedAt: string;
+}
+
+export interface VanityHouseArtist {
+  id: number;
+  name: string;
+  vanityHouse: boolean;
+  _count: { releases: number };
+}
+
+export interface FeaturedAlbumItem {
+  id: number;
+  groupId: number;
+  threadId: number;
+  title: string;
+  started: string;
+  ended: string;
+}
+
+export interface DeletedCollageItem {
+  id: number;
+  name: string;
+  user: UserRef;
+  deletedAt: string | null;
+  createdAt: string;
+}
+
+export interface EconomyGroupedItem {
+  reason: string;
+  _sum: { amount: string | null };
+  _count: number;
+}
+
+export interface EconomyTransactionItem {
+  id: number;
+  user: UserRef;
+  amount: string;
+  reason: string;
+  createdAt: string;
+}
+
+export interface ReleaseStatsItem {
+  releases: number;
+  contributions: number;
+  artists: number;
+  byType: { type: string; _count: number }[];
+  byLinkStatus: { linkStatus: string; _count: number }[];
+}
+
+export interface ClientStatsItem {
+  userAgent: string | null;
+  count: number;
+}
+
+export interface UserFlowData {
+  inviteFunnel: { status: string; _count: number }[];
+  snapshots: {
+    bucketAt: string;
+    totalUsers: number;
+    activeThisMonth: number;
+  }[];
+}
+
+export interface SiteInfoData {
+  totalUsers: number;
+  enabledUsers: number;
+  disabledUsers: number;
+  releases: number;
+  artists: number;
+  contributions: number;
+  communities: number;
+  forumTopics: number;
+  forumPosts: number;
+  collages: number;
+  wikiPages: number;
+}
+
+export interface DncEntry {
+  id: number;
+  name: string;
+  comment: string;
+  communityId: number;
+  userId: number;
+  createdAt: string;
+  addedBy: UserRef | null;
+}
+
 export const adminApi = api.injectEndpoints({
   endpoints: (build) => ({
     // IP Bans
@@ -141,6 +270,163 @@ export const adminApi = api.injectEndpoints({
       number | void
     >({
       query: (page = 1) => `/users/registration-log?page=${page}`
+    }),
+
+    // Login Watch
+    getSessions: build.query<
+      PaginatedResponse<SessionItem>,
+      { page?: number; userId?: number } | void
+    >({
+      query: (args) => {
+        const params = new URLSearchParams();
+        if (args?.page) params.set('page', String(args.page));
+        if (args?.userId) params.set('userId', String(args.userId));
+        return `/users/sessions?${params.toString()}`;
+      },
+      providesTags: ['Session']
+    }),
+
+    // Invite Pool
+    getInvites: build.query<
+      PaginatedResponse<InviteItem>,
+      { page?: number; status?: string } | void
+    >({
+      query: (args) => {
+        const params = new URLSearchParams();
+        if (args?.page) params.set('page', String(args.page));
+        if (args?.status) params.set('status', args.status);
+        return `/users/invites?${params.toString()}`;
+      },
+      providesTags: ['Invite']
+    }),
+
+    // Invite Tree
+    getInviteTree: build.query<
+      PaginatedResponse<InviteTreeItem>,
+      number | void
+    >({
+      query: (page = 1) => `/users/invite-tree?page=${page}`,
+      providesTags: ['InviteTree']
+    }),
+
+    // Ratio Watch
+    getRatioWatch: build.query<
+      PaginatedResponse<RatioWatchItem>,
+      number | void
+    >({
+      query: (page = 1) => `/users/ratio-watch?page=${page}`,
+      providesTags: ['RatioWatch']
+    }),
+
+    // Vanity House
+    getVanityHouseArtists: build.query<
+      PaginatedResponse<VanityHouseArtist>,
+      number | void
+    >({
+      query: (page = 1) => `/artists/vanity-house?page=${page}`,
+      providesTags: ['VanityHouse']
+    }),
+    setVanityHouse: build.mutation<
+      VanityHouseArtist,
+      { id: number; vanityHouse: boolean }
+    >({
+      query: ({ id, vanityHouse }) => ({
+        url: `/artists/${id}/vanity-house`,
+        method: 'PUT',
+        body: { vanityHouse }
+      }),
+      invalidatesTags: ['VanityHouse']
+    }),
+
+    // Album of the Month
+    getAlbumOfMonth: build.query<FeaturedAlbumItem[], void>({
+      query: () => '/announcements/album-of-month',
+      providesTags: ['AlbumOfMonth']
+    }),
+    createAlbumOfMonth: build.mutation<
+      FeaturedAlbumItem,
+      {
+        groupId: number;
+        threadId: number;
+        title: string;
+        started: string;
+        ended: string;
+      }
+    >({
+      query: (body) => ({
+        url: '/announcements/album-of-month',
+        method: 'POST',
+        body
+      }),
+      invalidatesTags: ['AlbumOfMonth']
+    }),
+    deleteAlbumOfMonth: build.mutation<void, number>({
+      query: (albumId) => ({
+        url: `/announcements/album-of-month/${albumId}`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: ['AlbumOfMonth']
+    }),
+
+    // Deleted Collages
+    getDeletedCollages: build.query<
+      PaginatedResponse<DeletedCollageItem>,
+      number | void
+    >({
+      query: (page = 1) => `/collages/deleted?page=${page}`,
+      providesTags: ['DeletedCollage']
+    }),
+
+    // DNC
+    getDnc: build.query<DncEntry[], number>({
+      query: (communityId) => `/communities/${communityId}/dnc`,
+      providesTags: ['Dnc']
+    }),
+    createDncEntry: build.mutation<
+      DncEntry,
+      { communityId: number; name: string; comment: string }
+    >({
+      query: ({ communityId, ...body }) => ({
+        url: `/communities/${communityId}/dnc`,
+        method: 'POST',
+        body
+      }),
+      invalidatesTags: ['Dnc']
+    }),
+    deleteDncEntry: build.mutation<
+      void,
+      { communityId: number; dncId: number }
+    >({
+      query: ({ communityId, dncId }) => ({
+        url: `/communities/${communityId}/dnc/${dncId}`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: ['Dnc']
+    }),
+
+    // Stats
+    getEconomyStats: build.query<
+      { grouped: EconomyGroupedItem[]; recent: EconomyTransactionItem[] },
+      void
+    >({
+      query: () => '/stats/economy',
+      providesTags: ['EconomyStats']
+    }),
+    getReleaseStats: build.query<ReleaseStatsItem, void>({
+      query: () => '/stats/releases',
+      providesTags: ['ReleaseStats']
+    }),
+    getClientStats: build.query<ClientStatsItem[], void>({
+      query: () => '/stats/clients',
+      providesTags: ['ClientStats']
+    }),
+    getUserFlow: build.query<UserFlowData, void>({
+      query: () => '/stats/user-flow',
+      providesTags: ['UserFlow']
+    }),
+    getSiteInfo: build.query<SiteInfoData, void>({
+      query: () => '/stats/site-info',
+      providesTags: ['SiteInfo']
     })
   })
 });
@@ -156,5 +442,23 @@ export const {
   useCreateDonationMutation,
   useDeleteDonationMutation,
   useGetDuplicateIpsQuery,
-  useGetRegistrationLogQuery
+  useGetRegistrationLogQuery,
+  useGetSessionsQuery,
+  useGetInvitesQuery,
+  useGetInviteTreeQuery,
+  useGetRatioWatchQuery,
+  useGetVanityHouseArtistsQuery,
+  useSetVanityHouseMutation,
+  useGetAlbumOfMonthQuery,
+  useCreateAlbumOfMonthMutation,
+  useDeleteAlbumOfMonthMutation,
+  useGetDeletedCollagesQuery,
+  useGetDncQuery,
+  useCreateDncEntryMutation,
+  useDeleteDncEntryMutation,
+  useGetEconomyStatsQuery,
+  useGetReleaseStatsQuery,
+  useGetClientStatsQuery,
+  useGetUserFlowQuery,
+  useGetSiteInfoQuery
 } = adminApi;

--- a/src/store/services/announcementApi.ts
+++ b/src/store/services/announcementApi.ts
@@ -13,6 +13,13 @@ type CreateBlogPostArgs = NonNullable<
 >['content']['application/json'];
 type CreateBlogPostResponse =
   paths['/announcements/blog']['post']['responses'][201]['content']['application/json'];
+type GlobalNoticesResponse =
+  paths['/announcements/global-notices']['get']['responses'][200]['content']['application/json'];
+type CreateGlobalNoticeArgs = NonNullable<
+  paths['/announcements/global-notice']['post']['requestBody']
+>['content']['application/json'];
+type CreateGlobalNoticeResponse =
+  paths['/announcements/global-notice']['post']['responses'][201]['content']['application/json'];
 
 export const announcementApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -42,6 +49,28 @@ export const announcementApi = api.injectEndpoints({
     deleteBlogPost: build.mutation<void, number>({
       query: (id) => ({ url: `/announcements/blog/${id}`, method: 'DELETE' }),
       invalidatesTags: ['Announcement']
+    }),
+    getGlobalNotices: build.query<GlobalNoticesResponse, void>({
+      query: () => '/announcements/global-notices',
+      providesTags: ['GlobalNotice']
+    }),
+    createGlobalNotice: build.mutation<
+      CreateGlobalNoticeResponse,
+      CreateGlobalNoticeArgs
+    >({
+      query: (data) => ({
+        url: '/announcements/global-notice',
+        method: 'POST',
+        body: data
+      }),
+      invalidatesTags: ['GlobalNotice']
+    }),
+    deleteGlobalNotice: build.mutation<void, number>({
+      query: (id) => ({
+        url: `/announcements/global-notice/${id}`,
+        method: 'DELETE'
+      }),
+      invalidatesTags: ['GlobalNotice']
     })
   })
 });
@@ -51,5 +80,8 @@ export const {
   useCreateAnnouncementMutation,
   useDeleteAnnouncementMutation,
   useCreateBlogPostMutation,
-  useDeleteBlogPostMutation
+  useDeleteBlogPostMutation,
+  useGetGlobalNoticesQuery,
+  useCreateGlobalNoticeMutation,
+  useDeleteGlobalNoticeMutation
 } = announcementApi;

--- a/src/store/services/communityApi.ts
+++ b/src/store/services/communityApi.ts
@@ -1,5 +1,6 @@
 import { api } from '../api';
 import type { components, paths } from '../../types/api';
+import type { DncEntry } from './adminApi';
 
 export interface VoteAggregate {
   releaseId: number;
@@ -312,6 +313,12 @@ export const communityApi = api.injectEndpoints({
       invalidatesTags: (_, __, { releaseId }) => [
         { type: 'Release', id: releaseId }
       ]
+    }),
+
+    // DNC (Do Not Contribute) — readable by all authenticated users
+    getDncList: build.query<DncEntry[], number>({
+      query: (communityId) => `/communities/${communityId}/dnc`,
+      providesTags: ['Dnc']
     })
   })
 });
@@ -339,5 +346,6 @@ export const {
   useVoteOnReleaseTagMutation,
   useRemoveTagFromReleaseMutation,
   useGetReleaseHistoryQuery,
-  useRevertReleaseHistoryMutation
+  useRevertReleaseHistoryMutation,
+  useGetDncListQuery
 } = communityApi;

--- a/src/store/services/tagAliasApi.ts
+++ b/src/store/services/tagAliasApi.ts
@@ -1,0 +1,50 @@
+import { api } from '../api';
+import type { paths } from '../../types/api';
+
+type TagAliasListResponse =
+  paths['/tag-aliases']['get']['responses'][200]['content']['application/json'];
+type CreateTagAliasArgs = NonNullable<
+  paths['/tag-aliases']['post']['requestBody']
+>['content']['application/json'];
+type CreateTagAliasResponse =
+  paths['/tag-aliases']['post']['responses'][201]['content']['application/json'];
+type UpdateTagAliasArgs = NonNullable<
+  paths['/tag-aliases/{id}']['put']['requestBody']
+>['content']['application/json'];
+type UpdateTagAliasResponse =
+  paths['/tag-aliases/{id}']['put']['responses'][200]['content']['application/json'];
+
+export const tagAliasApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getTagAliases: build.query<TagAliasListResponse, { page?: number }>({
+      query: ({ page = 1 } = {}) => `/tag-aliases?page=${page}`,
+      providesTags: ['TagAlias']
+    }),
+    createTagAlias: build.mutation<CreateTagAliasResponse, CreateTagAliasArgs>({
+      query: (body) => ({ url: '/tag-aliases', method: 'POST', body }),
+      invalidatesTags: ['TagAlias']
+    }),
+    updateTagAlias: build.mutation<
+      UpdateTagAliasResponse,
+      { id: number } & UpdateTagAliasArgs
+    >({
+      query: ({ id, ...body }) => ({
+        url: `/tag-aliases/${id}`,
+        method: 'PUT',
+        body
+      }),
+      invalidatesTags: ['TagAlias']
+    }),
+    deleteTagAlias: build.mutation<void, number>({
+      query: (id) => ({ url: `/tag-aliases/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['TagAlias']
+    })
+  })
+});
+
+export const {
+  useGetTagAliasesQuery,
+  useCreateTagAliasMutation,
+  useUpdateTagAliasMutation,
+  useDeleteTagAliasMutation
+} = tagAliasApi;

--- a/src/store/services/userApi.ts
+++ b/src/store/services/userApi.ts
@@ -269,6 +269,17 @@ export const userApi = api.injectEndpoints({
       }),
       invalidatesTags: (_, __, { id }) => [{ type: 'User', id }, 'Profile']
     }),
+    getAllWarnings: build.query<
+      paths['/users/warnings']['get']['responses'][200]['content']['application/json'],
+      { page?: number; userId?: number }
+    >({
+      query: ({ page = 1, userId } = {}) => {
+        const params = new URLSearchParams({ page: String(page) });
+        if (userId) params.set('userId', String(userId));
+        return `/users/warnings?${params}`;
+      },
+      providesTags: ['Warning']
+    }),
     getSnatchListByUserId: build.query<
       Array<{
         id: number;
@@ -399,5 +410,6 @@ export const {
   useCreateStaffGroupMutation,
   useUpdateStaffGroupMutation,
   useDeleteStaffGroupMutation,
-  useSetStaffBioMutation
+  useSetStaffBioMutation,
+  useGetAllWarningsQuery
 } = userApi;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -583,6 +583,47 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/users/warnings': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: string;
+          userId?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated staff warning log */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['UserWarningItem'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/users/{id}/recovery': {
     parameters: {
       query?: never;
@@ -1359,6 +1400,139 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/announcements/global-notices': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description All global notices */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['GlobalNotice'][];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/announcements/global-notice': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            message: string;
+            /** Format: uri */
+            url?: string;
+            /** Format: date-time */
+            expiresAt?: string;
+          };
+        };
+      };
+      responses: {
+        /** @description Global notice created */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['GlobalNotice'];
+          };
+        };
+        /** @description Validation error */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ValidationError'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/announcements/global-notice/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Notice deleted */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/stats': {
     parameters: {
       query?: never;
@@ -1864,7 +2038,9 @@ export interface paths {
               | 'requests'
               | 'communities'
               | 'contributions'
-              | 'release';
+              | 'release'
+              | 'news'
+              | 'global_notices';
             pageId: number;
             /** @enum {string} */
             action: 'subscribe' | 'unsubscribe';
@@ -1904,7 +2080,9 @@ export interface paths {
             | 'requests'
             | 'communities'
             | 'contributions'
-            | 'release';
+            | 'release'
+            | 'news'
+            | 'global_notices';
           pageId: number;
         };
         header?: never;
@@ -7961,6 +8139,171 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/tag-aliases': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated tag alias list */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['TagAliasItem'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            badTag: string;
+            goodTag: string;
+          };
+        };
+      };
+      responses: {
+        /** @description Tag alias created */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['TagAliasItem'];
+          };
+        };
+        /** @description Validation error */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ValidationError'];
+          };
+        };
+        /** @description Canonical tag not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/tag-aliases/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            badTag: string;
+            goodTag: string;
+          };
+        };
+      };
+      responses: {
+        /** @description Tag alias updated */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['TagAliasItem'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    post?: never;
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Tag alias deleted */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -8268,6 +8611,21 @@ export interface components {
       /** Format: date-time */
       usedAt: string | null;
     };
+    UserWarningItem: {
+      id: number;
+      userId: number;
+      user: {
+        id: number;
+        username: string;
+      };
+      reason: string;
+      expiresAt: string | null;
+      createdAt: string;
+      warnedBy: {
+        id: number;
+        username: string;
+      } | null;
+    };
     DonorRewards: {
       rewards: {
         iconMouseOverText: string;
@@ -8417,6 +8775,17 @@ export interface components {
       name: string;
       cssUrl: string;
       createdAt: string;
+    };
+    GlobalNotice: {
+      id: number;
+      message: string;
+      url: string | null;
+      expiresAt: string | null;
+      createdAt: string;
+      createdBy: {
+        id: number;
+        username: string;
+      };
     };
     Forum: {
       id: number;
@@ -8997,6 +9366,19 @@ export interface components {
         username: string;
         avatar: string | null;
       };
+    };
+    TagAliasItem: {
+      id: number;
+      badTag: string;
+      goodTag: {
+        id: number;
+        name: string;
+      };
+      createdBy: {
+        id: number;
+        username: string;
+      };
+      createdAt: string;
     };
   };
   responses: never;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -8304,6 +8304,625 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/users/sessions': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: string;
+          userId?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated session list */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['SessionItem'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/users/invites': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: string;
+          status?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated invite list */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['InviteItem'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/users/invite-tree': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated invite tree */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['InviteTreeItem'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/users/ratio-watch': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated ratio watch list */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['RatioWatchItem'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/artists/vanity-house': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated vanity house artists */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['VanityHouseArtist'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/artists/{id}/vanity-house': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            vanityHouse: boolean;
+          };
+        };
+      };
+      responses: {
+        /** @description Artist updated */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['VanityHouseArtist'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/announcements/album-of-month': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Featured album list */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['FeaturedAlbumItem'][];
+          };
+        };
+      };
+    };
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            groupId: number;
+            threadId: number;
+            title: string;
+            /** Format: date-time */
+            started: string;
+            /** Format: date-time */
+            ended: string;
+          };
+        };
+      };
+      responses: {
+        /** @description Created */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['FeaturedAlbumItem'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/announcements/album-of-month/{albumId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          albumId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Deleted */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/collages/deleted': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Paginated deleted collages */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: components['schemas']['DeletedCollageItem'][];
+              meta: components['schemas']['PaginationMeta'];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/stats/economy': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Economy stats */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              grouped: components['schemas']['EconomyGroupedItem'][];
+              recent: components['schemas']['EconomyTransactionItem'][];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/stats/releases': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Release and contribution counts */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              releases: number;
+              contributions: number;
+              artists: number;
+              byType: {
+                type: string;
+                _count: number;
+              }[];
+              byLinkStatus: {
+                linkStatus: string;
+                _count: number;
+              }[];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/stats/clients': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Top user agent strings */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              userAgent: string | null;
+              count: number;
+            }[];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/stats/user-flow': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Invite funnel and snapshot trend */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              inviteFunnel: {
+                status: string;
+                _count: number;
+              }[];
+              snapshots: {
+                bucketAt: string;
+                totalUsers: number;
+                activeThisMonth: number;
+              }[];
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/stats/site-info': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Aggregate DB counts */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              totalUsers: number;
+              enabledUsers: number;
+              disabledUsers: number;
+              releases: number;
+              artists: number;
+              contributions: number;
+              communities: number;
+              forumTopics: number;
+              forumPosts: number;
+              collages: number;
+              wikiPages: number;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -9378,6 +9997,100 @@ export interface components {
         id: number;
         username: string;
       };
+      createdAt: string;
+    };
+    SessionItem: {
+      id: string;
+      user: {
+        id: number;
+        username: string;
+      };
+      ipAddress: string;
+      userAgent: string | null;
+      createdAt: string;
+      lastActiveAt: string;
+      revokedAt: string | null;
+    };
+    InviteItem: {
+      id: number;
+      inviter: {
+        id: number;
+        username: string;
+      };
+      email: string;
+      expires: string;
+      reason: string;
+      status: string;
+    };
+    InviteTreeItem: {
+      id: number;
+      userId: number;
+      user: {
+        id: number;
+        username: string;
+      };
+      inviterId: number;
+      inviter: {
+        id: number;
+        username: string;
+      } | null;
+      treeId: number;
+      treeLevel: number;
+      treePosition: number;
+    };
+    RatioWatchItem: {
+      userId: number;
+      user: {
+        id: number;
+        username: string;
+      };
+      status: string;
+      watchStartedAt: string | null;
+      watchExpiresAt: string | null;
+      leechDisabledAt: string | null;
+      lastEvaluatedAt: string;
+    };
+    VanityHouseArtist: {
+      id: number;
+      name: string;
+      vanityHouse: boolean;
+      _count: {
+        releases: number;
+      };
+    };
+    FeaturedAlbumItem: {
+      id: number;
+      groupId: number;
+      threadId: number;
+      title: string;
+      started: string;
+      ended: string;
+    };
+    DeletedCollageItem: {
+      id: number;
+      name: string;
+      user: {
+        id: number;
+        username: string;
+      };
+      deletedAt: string | null;
+      createdAt: string;
+    };
+    EconomyGroupedItem: {
+      reason: string;
+      _sum: {
+        amount: string | null;
+      };
+      _count: number;
+    };
+    EconomyTransactionItem: {
+      id: number;
+      user: {
+        id: number;
+        username: string;
+      };
+      amount: string;
+      reason: string;
       createdAt: string;
     };
   };


### PR DESCRIPTION
## Summary
- Phase 2 of the staff toolbox frontend: adds 13 new staff pages (Login Watch, Invite Pool, Invite Tree, User Flow, Vanity House, Album of the Month, DNC list, Collage Recovery, Economic/Release/Client stats, Ratio Watch, Site Info) and a new "Site Information" toolbox section
- Surfaces an amber Do Not Contribute warning panel on the contribute form when the selected community has active DNC entries, via a new authenticated `getDncList` query
- Wires up RTK Query tagTypes and admin endpoints to back the new pages, regenerates OpenAPI types, and registers permission-gated routes in `PrivateContent`

## Test plan
- [ ] Visit `/private/staff/tools` and confirm the new Site Information section and reorganized links render
- [ ] Click each of the 13 new toolbox links and confirm the page loads behind its `StaffGate` permission
- [ ] Hit a non-staff account and confirm the new routes are blocked
- [ ] On `/contribute`, select a community with at least one DNC entry and confirm the amber warning panel renders with entries + comments
- [ ] Select a community with no DNC entries and confirm the panel is hidden
- [ ] Run `npm run lint` and `npm run typecheck` (or `tsc --noEmit`) clean on changed files
- [ ] Run the test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)