### PR TITLE
Add rank permissions manager UI

### DIFF
--- a/src/__tests__/admin/Toolbox.test.tsx
+++ b/src/__tests__/admin/Toolbox.test.tsx
@@ -43,7 +43,12 @@ const staffUser = {
     level: 500,
     name: 'Staff',
     color: '#fff',
-    permissions: { staff: true }
+    permissions: {
+      staff: true,
+      staff_inbox_manage: true,
+      reports_manage: true,
+      messages_mass_pm: true
+    }
   }
 };
 

--- a/src/__tests__/admin/UserRankFormPage.test.tsx
+++ b/src/__tests__/admin/UserRankFormPage.test.tsx
@@ -19,6 +19,18 @@ jest.mock('../../store/services/userApi', () => ({
   useGetStaffGroupsQuery: () => ({ data: [] })
 }));
 
+jest.mock('../../store/services/forumApi', () => ({
+  useGetForumCategoriesQuery: () => ({
+    data: [
+      {
+        id: 1,
+        name: 'Music',
+        forums: [{ id: 7, name: 'Jazz', minClassRead: 200 }]
+      }
+    ]
+  })
+}));
+
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useDispatch: () => mockDispatch
@@ -56,12 +68,13 @@ describe('UserRankFormPage — create mode', () => {
     renderWithProviders(<UserRankFormPage />);
     expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/^level$/i)).toBeInTheDocument();
+    expect(screen.getByText(/secondary class/i)).toBeInTheDocument();
   });
 
   it('shows permission checkboxes', () => {
     renderWithProviders(<UserRankFormPage />);
-    expect(screen.getByText(/forums read/i)).toBeInTheDocument();
-    expect(screen.getByText(/admin/i)).toBeInTheDocument();
+    expect(screen.getByText(/read forums/i)).toBeInTheDocument();
+    expect(screen.getByText(/administrator/i)).toBeInTheDocument();
   });
 
   it('calls createUserRank with form data and navigates on success', async () => {
@@ -70,10 +83,18 @@ describe('UserRankFormPage — create mode', () => {
     await user.type(screen.getByLabelText(/^name$/i), 'Veteran');
     await user.clear(screen.getByLabelText(/^level$/i));
     await user.type(screen.getByLabelText(/^level$/i), '300');
+    await user.click(
+      screen.getByRole('checkbox', { name: /secondary class/i })
+    );
+    await user.click(screen.getByRole('checkbox', { name: /jazz/i }));
     await user.click(screen.getByRole('button', { name: /^create$/i }));
     await waitFor(() => {
       expect(mockCreateUserRank).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'Veteran' })
+        expect.objectContaining({
+          name: 'Veteran',
+          secondary: true,
+          permittedForumIds: [7]
+        })
       );
       expect(mockNavigate).toHaveBeenCalledWith(
         '/private/staff/tools/user-ranks'
@@ -108,7 +129,9 @@ describe('UserRankFormPage — edit mode', () => {
         id: 3,
         level: 500,
         name: 'Staff',
-        permissions: { staff: true, forums_moderate: true }
+        permissions: { staff: true, forums_moderate: true },
+        secondary: true,
+        permittedForumIds: [7]
       },
       isLoading: false
     });
@@ -130,6 +153,13 @@ describe('UserRankFormPage — edit mode', () => {
         'Staff'
       );
     });
+    expect(
+      (
+        screen.getByRole('checkbox', {
+          name: /secondary class/i
+        }) as HTMLInputElement
+      ).checked
+    ).toBe(true);
   });
 
   it('shows spinner when isLoading is true in edit mode', () => {

--- a/src/__tests__/layout/PrivateHeader.test.tsx
+++ b/src/__tests__/layout/PrivateHeader.test.tsx
@@ -61,8 +61,20 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('../../utils/permissions', () => ({
-  isStaffUser: (user: { permissions?: { staff?: boolean } }) =>
-    !!user.permissions?.staff
+  isStaffUser: (user: {
+    permissions?: { staff?: boolean };
+    userRank?: { permissions?: { staff?: boolean } };
+  }) => !!(user.permissions?.staff ?? user.userRank?.permissions?.staff),
+  canSeeModBar: (user: {
+    permissions?: { staff?: boolean; admin?: boolean };
+    userRank?: { permissions?: { staff?: boolean; admin?: boolean } };
+  }) =>
+    !!(
+      user.permissions?.staff ??
+      user.permissions?.admin ??
+      user.userRank?.permissions?.staff ??
+      user.userRank?.permissions?.admin
+    )
 }));
 
 jest.mock('../../store/services/messagesApi', () => ({
@@ -79,7 +91,7 @@ const mockUser = {
   username: 'testuser',
   avatar: null,
   inviteCount: 2,
-  userRank: { level: 100, name: 'Member', color: '#fff' },
+  userRank: { level: 100, name: 'Member', color: '#fff', permissions: {} },
   contributed: '2000000000',
   consumed: '500000000',
   ratio: 4.0,
@@ -148,7 +160,10 @@ describe('PrivateHeader', () => {
   });
 
   it('shows Staff Queue link for staff users', () => {
-    const staffUser = { ...mockUser, permissions: { staff: true } };
+    const staffUser = {
+      ...mockUser,
+      userRank: { ...mockUser.userRank, permissions: { staff: true } }
+    };
     renderWithProviders(<PrivateHeader user={staffUser as never} />);
     expect(
       screen.getByRole('link', { name: /staff queue/i })
@@ -156,7 +171,10 @@ describe('PrivateHeader', () => {
   });
 
   it('shows ModBar for staff users', () => {
-    const staffUser = { ...mockUser, permissions: { staff: true } };
+    const staffUser = {
+      ...mockUser,
+      userRank: { ...mockUser.userRank, permissions: { staff: true } }
+    };
     renderWithProviders(<PrivateHeader user={staffUser as never} />);
     expect(screen.getByText('ModBar')).toBeInTheDocument();
   });
@@ -181,7 +199,10 @@ describe('PrivateHeader', () => {
   });
 
   it('shows staff inbox badge when there are pending tickets', () => {
-    const staffUser = { ...mockUser, permissions: { staff: true } };
+    const staffUser = {
+      ...mockUser,
+      userRank: { ...mockUser.userRank, permissions: { staff: true } }
+    };
     mockUseGetQueueCountQuery.mockReturnValue({ data: { count: 7 } });
     renderWithProviders(<PrivateHeader user={staffUser as never} />);
     expect(screen.getByText('7')).toBeInTheDocument();

--- a/src/__tests__/profile/UserProfile.test.tsx
+++ b/src/__tests__/profile/UserProfile.test.tsx
@@ -66,6 +66,10 @@ let mockSetUserRankLoading = false;
 let mockGrantDonorLoading = false;
 
 let mockUserRanks: Array<{ id: number; name: string }> = [];
+let mockUserRankAssignment = {
+  userRankId: 10,
+  secondaryRankIds: [] as number[]
+};
 let mockDonorRanks: Array<{ id: number; name: string }> = [];
 let mockNotes: Array<{
   id: number;
@@ -104,6 +108,7 @@ jest.mock('../../store/services/userApi', () => ({
   useDeleteUserNoteMutation: () => [mockDeleteUserNote],
   useDisableUserMutation: () => [mockDisableUser, { isLoading: false }],
   useEnableUserMutation: () => [mockEnableUser, { isLoading: false }],
+  useGetUserRankAssignmentQuery: () => ({ data: mockUserRankAssignment }),
   useSetUserRankMutation: () => [
     mockSetUserRank,
     { isLoading: mockSetUserRankLoading }
@@ -225,6 +230,7 @@ describe('UserProfile', () => {
     mockCurrentUser = { id: 99, username: 'bob' };
     mockHasAnyPermission = false;
     mockUserRanks = [];
+    mockUserRankAssignment = { userRankId: 10, secondaryRankIds: [] };
     mockDonorRanks = [];
     mockNotes = [];
     mockWarnings = [];
@@ -515,7 +521,11 @@ describe('UserProfile', () => {
   describe('StaffActionsPanel interactions', () => {
     beforeEach(() => {
       mockHasAnyPermission = true;
-      mockUserRanks = [{ id: 10, name: 'Senior' }];
+      mockUserRanks = [
+        { id: 10, name: 'Senior', level: 100, secondary: false } as never,
+        { id: 11, name: 'Forum Staff', level: 500, secondary: true } as never
+      ];
+      mockUserRankAssignment = { userRankId: 10, secondaryRankIds: [] };
       mockDonorRanks = [{ id: 20, name: 'Gold' }];
     });
 
@@ -588,7 +598,7 @@ describe('UserProfile', () => {
       mockSetUserRank.mockReturnValue({ unwrap: () => Promise.reject({}) });
       const user = userEvent.setup();
       renderWithProviders(<UserProfile />);
-      await user.selectOptions(screen.getByDisplayValue('Select rank…'), '10');
+      await user.selectOptions(screen.getAllByRole('combobox')[0], '10');
       await user.click(screen.getByRole('button', { name: /^save$/i }));
       await waitFor(() => {
         expect(mockSetUserRank).toHaveBeenCalled();
@@ -683,12 +693,27 @@ describe('UserProfile', () => {
     it('selects a rank and clicks Save', async () => {
       const user = userEvent.setup();
       renderWithProviders(<UserProfile />);
-      await user.selectOptions(screen.getByDisplayValue('Select rank…'), '10');
+      await user.selectOptions(screen.getAllByRole('combobox')[0], '10');
       await user.click(screen.getByRole('button', { name: /^save$/i }));
       await waitFor(() => {
         expect(mockSetUserRank).toHaveBeenCalledWith({
           id: 42,
-          userRankId: 10
+          userRankId: 10,
+          secondaryRankIds: []
+        });
+      });
+    });
+
+    it('saves selected secondary classes', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<UserProfile />);
+      await user.click(screen.getByRole('checkbox', { name: /forum staff/i }));
+      await user.click(screen.getByRole('button', { name: /^save$/i }));
+      await waitFor(() => {
+        expect(mockSetUserRank).toHaveBeenCalledWith({
+          id: 42,
+          userRankId: 10,
+          secondaryRankIds: [11]
         });
       });
     });
@@ -696,7 +721,7 @@ describe('UserProfile', () => {
     it('selecting placeholder rank resets selectedRankId to empty string', async () => {
       const user = userEvent.setup();
       renderWithProviders(<UserProfile />);
-      const rankSelect = screen.getByDisplayValue('Select rank…');
+      const rankSelect = screen.getAllByRole('combobox')[0];
       await user.selectOptions(rankSelect, '10');
       await user.selectOptions(rankSelect, '');
       expect((rankSelect as HTMLSelectElement).value).toBe('');

--- a/src/__tests__/utils/permissions.test.ts
+++ b/src/__tests__/utils/permissions.test.ts
@@ -1,4 +1,5 @@
 import {
+  canSeeModBar,
   hasPermission,
   hasAnyPermission,
   isStaffUser
@@ -12,8 +13,10 @@ const makeUser = (permissions: Record<string, boolean>) =>
   }) as never;
 
 describe('permissions helpers', () => {
-  it('treats staff as satisfying admin checks', () => {
-    expect(hasPermission(makeUser({ staff: true }), 'admin')).toBe(true);
+  it('treats admin as satisfying other permission checks', () => {
+    expect(hasPermission(makeUser({ admin: true }), 'reports_manage')).toBe(
+      true
+    );
   });
 
   it('returns true when any permission matches', () => {
@@ -25,5 +28,11 @@ describe('permissions helpers', () => {
   it('recognizes non-staff elevated users for staff-only UI gates', () => {
     expect(isStaffUser(makeUser({ forums_moderate: true }))).toBe(true);
     expect(isStaffUser(makeUser({}))).toBe(false);
+  });
+
+  it('limits the modbar to explicit staff/admin users', () => {
+    expect(canSeeModBar(makeUser({ staff: true }))).toBe(true);
+    expect(canSeeModBar(makeUser({ admin: true }))).toBe(true);
+    expect(canSeeModBar(makeUser({ forums_moderate: true }))).toBe(false);
   });
 });

--- a/src/components/admin/ModBar.tsx
+++ b/src/components/admin/ModBar.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useAppSelector } from '../../store/hooks';
 import { selectCurrentUser } from '../../store/slices/authSlice';
-import { isStaffUser } from '../../utils/permissions';
+import { canSeeModBar } from '../../utils/permissions';
 import { useGetReportCountsQuery } from '../../store/services/reportsApi';
 import {
   useDismissInstallChecklistItemMutation,
@@ -32,7 +32,7 @@ const ModBar = () => {
   const { data: installStatus } = useGetInstallStatusQuery();
   const [dismissChecklistItem] = useDismissInstallChecklistItemMutation();
 
-  if (!isStaffUser(user)) return null;
+  if (!canSeeModBar(user)) return null;
 
   const openReports = reportCounts?.open ?? 0;
   const setupChecklist = installStatus?.setupChecklist ?? [];

--- a/src/components/admin/Toolbox.tsx
+++ b/src/components/admin/Toolbox.tsx
@@ -46,12 +46,12 @@ const sections: SectionProps[] = [
       {
         label: 'User ranks',
         to: '/private/staff/tools/user-ranks',
-        permissions: ['admin']
+        permissions: ['rank_permissions_manage']
       },
       {
         label: 'Staff groups',
         to: '/private/staff/tools/staff-groups',
-        permissions: ['admin']
+        permissions: ['staff_groups_manage']
       },
       {
         label: 'Site settings',
@@ -61,7 +61,7 @@ const sections: SectionProps[] = [
       {
         label: 'Login Watch',
         to: '/private/staff/login-watch',
-        permissions: ['admin']
+        permissions: ['login_watch_view']
       }
     ]
   },
@@ -76,22 +76,22 @@ const sections: SectionProps[] = [
       {
         label: 'Recovery queue',
         to: '/private/staff/tools/recovery-queue',
-        permissions: ['users_edit', 'admin']
+        permissions: ['recovery_manage']
       },
       {
         label: 'Registration log',
         to: '/private/staff/registration-log',
-        permissions: ['admin']
+        permissions: ['registration_log_view']
       },
       {
         label: 'Invite pool',
         to: '/private/staff/invite-pool',
-        permissions: ['admin']
+        permissions: ['invites_manage']
       },
       {
         label: 'Invite tree',
         to: '/private/staff/invite-tree',
-        permissions: ['admin']
+        permissions: ['invites_manage']
       },
       {
         label: 'User flow',
@@ -141,7 +141,7 @@ const sections: SectionProps[] = [
       {
         label: 'Site History',
         to: '/private/staff/site-history',
-        permissions: ['staff', 'admin']
+        permissions: ['site_history_manage']
       }
     ]
   },
@@ -166,7 +166,7 @@ const sections: SectionProps[] = [
       {
         label: 'Tag aliases',
         to: '/private/staff/tag-aliases',
-        permissions: ['staff', 'admin']
+        permissions: ['tags_manage']
       }
     ]
   },
@@ -176,27 +176,27 @@ const sections: SectionProps[] = [
       {
         label: 'Ticket queue',
         to: '/private/staff/tickets',
-        permissions: ['staff', 'admin']
+        permissions: ['staff_inbox_manage']
       },
       {
         label: 'Canned responses',
         to: '/private/staff/inbox/responses',
-        permissions: ['staff', 'admin']
+        permissions: ['staff_inbox_manage']
       },
       {
         label: 'Reports queue',
         to: '/private/staff/reports',
-        permissions: ['staff', 'admin']
+        permissions: ['reports_manage']
       },
       {
         label: 'Duplicate IPs',
         to: '/private/staff/duplicate-ips',
-        permissions: ['admin']
+        permissions: ['duplicate_ips_view']
       },
       {
         label: 'Do Not Contribute list',
         to: '/private/staff/dnc',
-        permissions: ['communities_manage']
+        permissions: ['dnc_manage']
       },
       {
         label: 'Collage recovery',
@@ -211,12 +211,12 @@ const sections: SectionProps[] = [
       {
         label: 'Ratio policy override',
         to: '/private/staff/tools/ratio-policy',
-        permissions: ['staff', 'admin']
+        permissions: ['ratio_policy_manage']
       },
       {
         label: 'User warnings',
         to: '/private/staff/user-warnings',
-        permissions: ['staff', 'admin']
+        permissions: ['users_warn']
       }
     ]
   },
@@ -226,12 +226,12 @@ const sections: SectionProps[] = [
       {
         label: 'IP address bans',
         to: '/private/staff/ip-bans',
-        permissions: ['admin']
+        permissions: ['ip_bans_manage']
       },
       {
         label: 'Email blacklist',
         to: '/private/staff/email-blacklist',
-        permissions: ['admin']
+        permissions: ['email_blacklist_manage']
       }
     ]
   },
@@ -241,12 +241,12 @@ const sections: SectionProps[] = [
       {
         label: 'Donor ranks',
         to: '/private/staff/donor-ranks',
-        permissions: ['admin']
+        permissions: ['donor_ranks_manage']
       },
       {
         label: 'Donation log',
         to: '/private/staff/donation-log',
-        permissions: ['admin']
+        permissions: ['donation_log_view']
       }
     ]
   },

--- a/src/components/admin/UserRankFormPage.tsx
+++ b/src/components/admin/UserRankFormPage.tsx
@@ -237,6 +237,7 @@ const UserRankFormPage = () => {
                         category.forums.map((forum) => (
                           <label
                             key={forum.id}
+                            aria-label={forum.name}
                             className="flex items-start gap-3 cursor-pointer rounded border border-gray-800 px-3 py-2 hover:border-gray-700"
                           >
                             <input

--- a/src/components/admin/UserRankFormPage.tsx
+++ b/src/components/admin/UserRankFormPage.tsx
@@ -8,46 +8,27 @@ import {
   useUpdateUserRankMutation,
   useGetStaffGroupsQuery
 } from '../../store/services/userApi';
+import { useGetForumCategoriesQuery } from '../../store/services/forumApi';
 import { addAlert } from '../../store/slices/alertSlice';
 import Spinner from '../layout/Spinner';
-
-const PERM_GROUPS: { title: string; perms: string[] }[] = [
-  {
-    title: 'Forums',
-    perms: ['forums_read', 'forums_post', 'forums_moderate', 'forums_manage']
-  },
-  {
-    title: 'Communities',
-    perms: ['communities_manage']
-  },
-  {
-    title: 'Collages',
-    perms: ['collages_manage', 'collages_moderate']
-  },
-  {
-    title: 'Users',
-    perms: ['users_edit', 'users_warn', 'users_disable', 'invites_manage']
-  },
-  {
-    title: 'Search',
-    perms: ['advanced_search', 'users_search']
-  },
-  {
-    title: 'System',
-    perms: ['news_manage', 'rules_manage', 'staff', 'admin']
-  }
-];
+import { PERMISSION_GROUPS } from '../../utils/permissionCatalog';
 
 interface FormValues {
   level: number;
   name: string;
   permissions: Record<string, boolean>;
+  secondary: boolean;
+  permittedForumIds: number[];
   personalCollageLimit: number;
   displayStaff: boolean;
   staffGroupId: number | '';
 }
 
-const formatPerm = (perm: string) => perm.replace(/_/g, ' ');
+type ForumCategory = {
+  id: number;
+  name: string;
+  forums?: Array<{ id: number; name: string; minClassRead?: number | null }>;
+};
 
 const UserRankFormPage = () => {
   const { id } = useParams<{ id?: string }>();
@@ -58,22 +39,27 @@ const UserRankFormPage = () => {
     skip: !isEditing
   });
   const { data: staffGroups } = useGetStaffGroupsQuery();
+  const { data: forumCategories } = useGetForumCategoriesQuery({ all: true });
   const [createUserRank] = useCreateUserRankMutation();
   const [updateUserRank] = useUpdateUserRankMutation();
   const dispatch = useDispatch();
 
-  const { register, handleSubmit, reset, watch } = useForm<FormValues>({
-    defaultValues: {
-      level: 0,
-      name: '',
-      permissions: {},
-      personalCollageLimit: 0,
-      displayStaff: false,
-      staffGroupId: ''
-    }
-  });
+  const { register, handleSubmit, reset, watch, setValue } =
+    useForm<FormValues>({
+      defaultValues: {
+        level: 0,
+        name: '',
+        permissions: {},
+        secondary: false,
+        permittedForumIds: [],
+        personalCollageLimit: 0,
+        displayStaff: false,
+        staffGroupId: ''
+      }
+    });
 
   const displayStaff = watch('displayStaff');
+  const selectedForumIds = watch('permittedForumIds');
 
   useEffect(() => {
     if (existing) {
@@ -81,12 +67,21 @@ const UserRankFormPage = () => {
         level: existing.level,
         name: existing.name,
         permissions: existing.permissions ?? {},
+        secondary: existing.secondary ?? false,
+        permittedForumIds: existing.permittedForumIds ?? [],
         personalCollageLimit: existing.personalCollageLimit ?? 0,
         displayStaff: existing.displayStaff ?? false,
         staffGroupId: existing.staffGroupId ?? ''
       });
     }
   }, [existing, reset]);
+
+  const togglePermittedForum = (forumId: number) => {
+    const next = selectedForumIds.includes(forumId)
+      ? selectedForumIds.filter((id) => id !== forumId)
+      : [...selectedForumIds, forumId].sort((a, b) => a - b);
+    setValue('permittedForumIds', next, { shouldDirty: true });
+  };
 
   const onSubmit = async (data: FormValues) => {
     const payload = {
@@ -113,7 +108,7 @@ const UserRankFormPage = () => {
   if (isEditing && isLoading) return <Spinner />;
 
   return (
-    <div className="max-w-3xl space-y-6">
+    <div className="mx-auto max-w-6xl px-4 py-6 space-y-6">
       <div className="flex items-center gap-4">
         <div>
           <div className="flex gap-3 text-sm mb-2">
@@ -146,7 +141,7 @@ const UserRankFormPage = () => {
             </h3>
           </div>
           <div className="p-4 space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
               <div>
                 <label
                   htmlFor="perm-name"
@@ -194,6 +189,81 @@ const UserRankFormPage = () => {
                 />
                 <p className="text-xs text-gray-500 mt-1">0 = unlimited</p>
               </div>
+              <div className="rounded border border-gray-700 bg-gray-900/50 px-3 py-3">
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    {...register('secondary')}
+                    className="mt-0.5 rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-gray-800"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-sm text-gray-200">
+                      Secondary class
+                    </span>
+                    <span className="block text-xs text-gray-500">
+                      Assignable as an additional class without replacing the
+                      user&apos;s primary rank.
+                    </span>
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+          <div className="bg-gray-700/60 px-4 py-2 border-b border-gray-700">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-300">
+              Permitted Forums
+            </h3>
+          </div>
+          <div className="p-4 space-y-4">
+            <p className="text-sm text-gray-400">
+              Grant access to specific forums even when the effective class
+              level would normally be too low.
+            </p>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {(forumCategories as ForumCategory[] | undefined)?.map(
+                (category) => (
+                  <div
+                    key={category.id}
+                    className="rounded border border-gray-700 bg-gray-900/40 p-3"
+                  >
+                    <h4 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-400">
+                      {category.name}
+                    </h4>
+                    <div className="space-y-2">
+                      {category.forums?.length ? (
+                        category.forums.map((forum) => (
+                          <label
+                            key={forum.id}
+                            className="flex items-start gap-3 cursor-pointer rounded border border-gray-800 px-3 py-2 hover:border-gray-700"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={selectedForumIds.includes(forum.id)}
+                              onChange={() => togglePermittedForum(forum.id)}
+                              className="mt-0.5 rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-gray-800"
+                            />
+                            <span className="min-w-0">
+                              <span className="block text-sm text-gray-200">
+                                {forum.name}
+                              </span>
+                              <span className="block text-xs text-gray-500">
+                                Read level {forum.minClassRead ?? 0}
+                              </span>
+                            </span>
+                          </label>
+                        ))
+                      ) : (
+                        <p className="text-xs text-gray-500">
+                          No forums in this category.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                )
+              )}
             </div>
           </div>
         </div>
@@ -205,25 +275,30 @@ const UserRankFormPage = () => {
               Rank Permissions
             </h3>
           </div>
-          <div className="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            {PERM_GROUPS.map(({ title, perms }) => (
+          <div className="p-4 grid grid-cols-1 gap-6 lg:grid-cols-3">
+            {PERMISSION_GROUPS.map(({ title, permissions }) => (
               <div key={title}>
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2 pb-1 border-b border-gray-700">
                   {title}
                 </h4>
-                <div className="space-y-1.5">
-                  {perms.map((perm) => (
+                <div className="space-y-2">
+                  {permissions.map(({ key, label, description }) => (
                     <label
-                      key={perm}
-                      className="flex items-center gap-2 cursor-pointer group"
+                      key={key}
+                      className="flex items-start gap-3 cursor-pointer group rounded border border-gray-700/70 px-3 py-2 hover:border-gray-600"
                     >
                       <input
                         type="checkbox"
-                        {...register(`permissions.${perm}`)}
-                        className="rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-gray-800"
+                        {...register(`permissions.${key}`)}
+                        className="mt-0.5 rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-gray-800"
                       />
-                      <span className="text-xs text-gray-400 group-hover:text-gray-200 transition-colors capitalize">
-                        {formatPerm(perm)}
+                      <span className="min-w-0">
+                        <span className="block text-sm text-gray-200 group-hover:text-white transition-colors">
+                          {label}
+                        </span>
+                        <span className="block text-xs text-gray-500">
+                          {description}
+                        </span>
                       </span>
                     </label>
                   ))}

--- a/src/components/admin/UserRankManager.tsx
+++ b/src/components/admin/UserRankManager.tsx
@@ -1,7 +1,8 @@
 import { Link } from 'react-router-dom';
 import {
   useGetUserRanksQuery,
-  useDeleteUserRankMutation
+  useDeleteUserRankMutation,
+  type UserRankRecord
 } from '../../store/services/userApi';
 import Spinner from '../layout/Spinner';
 
@@ -48,7 +49,14 @@ const UserRankManager = () => {
               <tr className="bg-gray-700/60 text-gray-300 text-xs uppercase tracking-wider">
                 <th className="text-left px-4 py-3 font-semibold">Name</th>
                 <th className="text-left px-4 py-3 font-semibold">Level</th>
+                <th className="text-left px-4 py-3 font-semibold">Type</th>
                 <th className="text-left px-4 py-3 font-semibold">Users</th>
+                <th className="text-left px-4 py-3 font-semibold">
+                  Permissions
+                </th>
+                <th className="text-left px-4 py-3 font-semibold">
+                  Forum Overrides
+                </th>
                 <th className="text-left px-4 py-3 font-semibold">
                   Collage Limit
                 </th>
@@ -59,55 +67,64 @@ const UserRankManager = () => {
               {!userRanks?.length ? (
                 <tr>
                   <td
-                    colSpan={5}
+                    colSpan={8}
                     className="px-4 py-6 text-center text-gray-500"
                   >
                     No user ranks defined yet.
                   </td>
                 </tr>
               ) : (
-                userRanks.map(
-                  (rank: {
-                    id: number;
-                    name: string;
-                    level: number;
-                    personalCollageLimit?: number;
-                    userCount?: number;
-                  }) => (
-                    <tr
-                      key={rank.id}
-                      className="hover:bg-gray-700/30 transition-colors"
-                    >
-                      <td className="px-4 py-3 text-gray-200 font-medium">
-                        {rank.name}
-                      </td>
-                      <td className="px-4 py-3 text-gray-400">{rank.level}</td>
-                      <td className="px-4 py-3 text-gray-400">
-                        {rank.userCount ?? 0}
-                      </td>
-                      <td className="px-4 py-3 text-gray-400">
-                        {rank.personalCollageLimit === 0
-                          ? '∞'
-                          : rank.personalCollageLimit ?? '∞'}
-                      </td>
-                      <td className="px-4 py-3 flex gap-2">
-                        <Link
-                          to={`/private/staff/tools/user-ranks/${rank.id}/edit`}
-                          className="text-indigo-400 hover:text-indigo-300 transition-colors"
-                        >
-                          Edit
-                        </Link>
-                        <button
-                          type="button"
-                          onClick={() => handleDelete(rank.id)}
-                          className="text-red-400 hover:text-red-300 transition-colors"
-                        >
-                          Delete
-                        </button>
-                      </td>
-                    </tr>
-                  )
-                )
+                userRanks.map((rank: UserRankRecord) => (
+                  <tr
+                    key={rank.id}
+                    className="hover:bg-gray-700/30 transition-colors"
+                  >
+                    <td className="px-4 py-3 text-gray-200 font-medium">
+                      {rank.name}
+                    </td>
+                    <td className="px-4 py-3 text-gray-400">{rank.level}</td>
+                    <td className="px-4 py-3 text-gray-400">
+                      {rank.secondary ? 'Secondary' : 'Primary'}
+                    </td>
+                    <td className="px-4 py-3 text-gray-400">
+                      {rank.userCount ?? 0}
+                    </td>
+                    <td className="px-4 py-3 text-gray-400">
+                      {
+                        Object.values(
+                          (
+                            rank as {
+                              permissions?: Record<string, boolean> | null;
+                            }
+                          ).permissions ?? {}
+                        ).filter(Boolean).length
+                      }
+                    </td>
+                    <td className="px-4 py-3 text-gray-400">
+                      {rank.permittedForumIds?.length ?? 0}
+                    </td>
+                    <td className="px-4 py-3 text-gray-400">
+                      {rank.personalCollageLimit === 0
+                        ? '∞'
+                        : rank.personalCollageLimit ?? '∞'}
+                    </td>
+                    <td className="px-4 py-3 flex gap-2">
+                      <Link
+                        to={`/private/staff/tools/user-ranks/${rank.id}/edit`}
+                        className="text-indigo-400 hover:text-indigo-300 transition-colors"
+                      >
+                        Edit
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(rank.id)}
+                        className="text-red-400 hover:text-red-300 transition-colors"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))
               )}
             </tbody>
           </table>

--- a/src/components/collages/CollageBrowse.tsx
+++ b/src/components/collages/CollageBrowse.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { useListCollagesQuery } from '../../store/services/collageApi';
 import type { CollageOrderBy } from '../../types';
 import Spinner from '../layout/Spinner';
+import { selectCurrentUser } from '../../store/slices/authSlice';
+import { hasPermission } from '../../utils/permissions';
 
 const CATEGORIES = [
   { id: undefined, label: 'All' },
@@ -23,6 +26,7 @@ const ORDER_OPTIONS: { value: CollageOrderBy; label: string }[] = [
 ];
 
 const CollageBrowse = () => {
+  const currentUser = useSelector(selectCurrentUser);
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [searchInput, setSearchInput] = useState('');
@@ -49,17 +53,20 @@ const CollageBrowse = () => {
 
   const collages = data?.data ?? [];
   const meta = data?.meta;
+  const canCreateCollage = hasPermission(currentUser, 'collages_create');
 
   return (
     <div className="thin">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-xl font-semibold">Collages</h2>
-        <Link
-          to="/private/collages/new"
-          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
-        >
-          New Collage
-        </Link>
+        {canCreateCollage && (
+          <Link
+            to="/private/collages/new"
+            className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+          >
+            New Collage
+          </Link>
+        )}
       </div>
 
       <form onSubmit={handleSearch} className="flex gap-2 mb-4">

--- a/src/components/pages/private/layout/PrivateContent.tsx
+++ b/src/components/pages/private/layout/PrivateContent.tsx
@@ -149,7 +149,7 @@ const PrivateContent = () => (
     <Route
       path="staff/tools/staff-groups"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['staff_groups_manage']}>
           <StaffGroupsPage />
         </StaffGate>
       }
@@ -165,7 +165,7 @@ const PrivateContent = () => (
     <Route
       path="staff/tools/user-ranks/new"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['rank_permissions_manage']}>
           <UserRankFormPage />
         </StaffGate>
       }
@@ -173,7 +173,7 @@ const PrivateContent = () => (
     <Route
       path="staff/tools/user-ranks/:id/edit"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['rank_permissions_manage']}>
           <UserRankFormPage />
         </StaffGate>
       }
@@ -181,7 +181,7 @@ const PrivateContent = () => (
     <Route
       path="staff/tools/user-ranks"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['rank_permissions_manage']}>
           <UserRankManager />
         </StaffGate>
       }
@@ -229,7 +229,7 @@ const PrivateContent = () => (
     <Route
       path="staff/tools/ratio-policy"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['ratio_policy_manage']}>
           <RatioPolicyPanel />
         </StaffGate>
       }
@@ -239,14 +239,32 @@ const PrivateContent = () => (
       element={
         <StaffGate
           permissions={[
-            'staff',
-            'admin',
+            'rank_permissions_manage',
+            'staff_groups_manage',
             'forums_manage',
             'forums_moderate',
             'communities_manage',
+            'contributions_manage',
+            'dnc_manage',
+            'collages_moderate',
             'news_manage',
             'rules_manage',
-            'users_edit'
+            'reports_manage',
+            'staff_inbox_manage',
+            'users_edit',
+            'users_warn',
+            'recovery_manage',
+            'invites_manage',
+            'ratio_policy_manage',
+            'site_history_manage',
+            'ip_bans_manage',
+            'email_blacklist_manage',
+            'donor_ranks_manage',
+            'donation_log_view',
+            'login_watch_view',
+            'duplicate_ips_view',
+            'registration_log_view',
+            'tags_manage'
           ]}
         >
           <Toolbox />
@@ -256,7 +274,7 @@ const PrivateContent = () => (
     <Route
       path="staff/site-history"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['site_history_manage']}>
           <SiteHistoryPage />
         </StaffGate>
       }
@@ -264,7 +282,7 @@ const PrivateContent = () => (
     <Route
       path="staff/mass-pm"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['messages_mass_pm']}>
           <MassPmPage />
         </StaffGate>
       }
@@ -272,7 +290,7 @@ const PrivateContent = () => (
     <Route
       path="staff/donor-ranks"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['donor_ranks_manage']}>
           <DonorRanksPage />
         </StaffGate>
       }
@@ -280,7 +298,7 @@ const PrivateContent = () => (
     <Route
       path="staff/tools/recovery-queue"
       element={
-        <StaffGate permissions={['users_edit']}>
+        <StaffGate permissions={['recovery_manage']}>
           <RecoveryQueuePage />
         </StaffGate>
       }
@@ -288,7 +306,7 @@ const PrivateContent = () => (
     <Route
       path="staff/ip-bans"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['ip_bans_manage']}>
           <IpBansPage />
         </StaffGate>
       }
@@ -296,7 +314,7 @@ const PrivateContent = () => (
     <Route
       path="staff/email-blacklist"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['email_blacklist_manage']}>
           <EmailBlacklistPage />
         </StaffGate>
       }
@@ -304,7 +322,7 @@ const PrivateContent = () => (
     <Route
       path="staff/donation-log"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['donation_log_view']}>
           <DonationLogPage />
         </StaffGate>
       }
@@ -312,7 +330,7 @@ const PrivateContent = () => (
     <Route
       path="staff/duplicate-ips"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['duplicate_ips_view']}>
           <DuplicateIpsPage />
         </StaffGate>
       }
@@ -320,7 +338,7 @@ const PrivateContent = () => (
     <Route
       path="staff/registration-log"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['registration_log_view']}>
           <RegistrationLogPage />
         </StaffGate>
       }
@@ -328,7 +346,7 @@ const PrivateContent = () => (
     <Route
       path="staff/user-warnings"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['users_warn']}>
           <UserWarningsPage />
         </StaffGate>
       }
@@ -336,7 +354,7 @@ const PrivateContent = () => (
     <Route
       path="staff/tag-aliases"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['tags_manage']}>
           <TagAliasesPage />
         </StaffGate>
       }
@@ -352,7 +370,7 @@ const PrivateContent = () => (
     <Route
       path="staff/login-watch"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['login_watch_view']}>
           <LoginWatchPage />
         </StaffGate>
       }
@@ -384,7 +402,7 @@ const PrivateContent = () => (
     <Route
       path="staff/invite-pool"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['invites_manage']}>
           <InvitePoolPage />
         </StaffGate>
       }
@@ -392,7 +410,7 @@ const PrivateContent = () => (
     <Route
       path="staff/invite-tree"
       element={
-        <StaffGate permissions={['admin']}>
+        <StaffGate permissions={['invites_manage']}>
           <InviteTreePage />
         </StaffGate>
       }
@@ -400,7 +418,7 @@ const PrivateContent = () => (
     <Route
       path="staff/dnc"
       element={
-        <StaffGate permissions={['communities_manage']}>
+        <StaffGate permissions={['dnc_manage']}>
           <DncPage />
         </StaffGate>
       }
@@ -476,11 +494,25 @@ const PrivateContent = () => (
     <Route path="contribute/list" element={wrap(ContributionsPage)} />
     <Route path="contribute" element={wrap(ContributeForm)} />
 
-    <Route path="requests/new" element={wrap(CreateRequestForm)} />
+    <Route
+      path="requests/new"
+      element={
+        <StaffGate permissions={['requests_create']}>
+          <CreateRequestForm />
+        </StaffGate>
+      }
+    />
     <Route path="requests/:id" element={wrap(RequestDetailPage)} />
     <Route path="requests" element={wrap(RequestsPage)} />
 
-    <Route path="collages/new" element={wrap(CollageCreate)} />
+    <Route
+      path="collages/new"
+      element={
+        <StaffGate permissions={['collages_create']}>
+          <CollageCreate />
+        </StaffGate>
+      }
+    />
     <Route path="collages/:id/edit" element={wrap(CollageEdit)} />
     <Route path="collages/:id" element={wrap(CollageDetail)} />
     <Route path="collages" element={wrap(CollageBrowse)} />
@@ -497,7 +529,7 @@ const PrivateContent = () => (
     <Route
       path="staff/tickets/:id"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['staff_inbox_manage']}>
           <TicketView />
         </StaffGate>
       }
@@ -505,7 +537,7 @@ const PrivateContent = () => (
     <Route
       path="staff/tickets"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['staff_inbox_manage']}>
           <TicketQueuePage />
         </StaffGate>
       }
@@ -513,7 +545,7 @@ const PrivateContent = () => (
     <Route
       path="staff/inbox/responses"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['staff_inbox_manage']}>
           <CannedResponsesPage />
         </StaffGate>
       }
@@ -522,7 +554,7 @@ const PrivateContent = () => (
     <Route
       path="staff/reports"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['reports_manage']}>
           <ReportsQueuePage />
         </StaffGate>
       }
@@ -530,7 +562,7 @@ const PrivateContent = () => (
     <Route
       path="staff/reports/:id"
       element={
-        <StaffGate permissions={['staff', 'admin']}>
+        <StaffGate permissions={['reports_manage']}>
           <ReportDetailPage />
         </StaffGate>
       }

--- a/src/components/pages/private/layout/PrivateHeader.tsx
+++ b/src/components/pages/private/layout/PrivateHeader.tsx
@@ -4,7 +4,7 @@ import Alert from '../../../layout/Alert';
 import ModBar from '../../../admin/ModBar';
 import QuickSearch from '../../../layout/QuickSearch';
 import type { AuthUser } from '../../../../types';
-import { isStaffUser } from '../../../../utils/permissions';
+import { canSeeModBar, isStaffUser } from '../../../../utils/permissions';
 import { formatBytes } from '../../../../utils';
 import { useGetUnreadCountQuery } from '../../../../store/services/messagesApi';
 import {
@@ -30,6 +30,7 @@ const navLinks = [
 
 const PrivateHeader = ({ user }: Props) => {
   const isStaff = isStaffUser(user);
+  const showModBar = canSeeModBar(user);
   const { data: inboxData } = useGetUnreadCountQuery();
   const { data: ticketData } = useGetQueueCountQuery();
   const { data: myTicketData } = useGetMyTicketCountQuery();
@@ -158,7 +159,7 @@ const PrivateHeader = ({ user }: Props) => {
       </nav>
 
       <QuickSearch />
-      {isStaff && <ModBar />}
+      {showModBar && <ModBar />}
       <Alert />
     </header>
   );

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -575,6 +575,7 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
                     {secondaryRanks.map((rank) => (
                       <label
                         key={rank.id}
+                        aria-label={rank.name}
                         className="flex items-start gap-3 rounded border border-gray-800 px-3 py-2 cursor-pointer hover:border-gray-700"
                       >
                         <input

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -15,6 +15,7 @@ import {
   useDeleteUserNoteMutation,
   useDisableUserMutation,
   useEnableUserMutation,
+  useGetUserRankAssignmentQuery,
   useSetUserRankMutation,
   useGetUserIpHistoryQuery,
   useGetUserEmailHistoryQuery,
@@ -229,10 +230,14 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
   const [showSnatchList, setShowSnatchList] = useState(false);
   const [newNote, setNewNote] = useState('');
   const [selectedRankId, setSelectedRankId] = useState<number | ''>('');
+  const [selectedSecondaryRankIds, setSelectedSecondaryRankIds] = useState<
+    number[]
+  >([]);
   const [donorRankId, setDonorRankId] = useState<number | ''>('');
   const [donorExpiry, setDonorExpiry] = useState('');
 
   const { data: userRanks } = useGetUserRanksQuery();
+  const { data: rankAssignment } = useGetUserRankAssignmentQuery(profileId);
   const { data: donorRanks } = useGetDonorRanksQuery();
   const { data: ipHistory } = useGetUserIpHistoryQuery(profileId, {
     skip: !showIpHistory
@@ -251,6 +256,20 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
   const { data: profile } = useGetProfileByUserIdQuery(String(profileId));
   const isDisabled = profile?.disabled;
   const staffPmOverview = profile?.staffPmOverview;
+  const primaryRanks =
+    userRanks
+      ?.filter((rank) => !rank.secondary)
+      .sort((a, b) => a.level - b.level) ?? [];
+  const secondaryRanks =
+    userRanks
+      ?.filter((rank) => rank.secondary)
+      .sort((a, b) => a.level - b.level) ?? [];
+
+  useEffect(() => {
+    if (!rankAssignment) return;
+    setSelectedRankId(rankAssignment.userRankId);
+    setSelectedSecondaryRankIds(rankAssignment.secondaryRankIds);
+  }, [rankAssignment]);
 
   const [disableUser, { isLoading: isDisabling }] = useDisableUserMutation();
   const [enableUser, { isLoading: isEnabling }] = useEnableUserMutation();
@@ -297,7 +316,8 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
     try {
       await setUserRank({
         id: profileId,
-        userRankId: Number(selectedRankId)
+        userRankId: Number(selectedRankId),
+        secondaryRankIds: selectedSecondaryRankIds
       }).unwrap();
       dispatch(addAlert('Rank updated.', 'success'));
     } catch (err) {
@@ -305,6 +325,14 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
         addAlert(getApiErrorMessage(err) ?? 'Failed to set rank.', 'danger')
       );
     }
+  };
+
+  const handleToggleSecondaryRank = (rankId: number) => {
+    setSelectedSecondaryRankIds((current) =>
+      current.includes(rankId)
+        ? current.filter((id) => id !== rankId)
+        : [...current, rankId].sort((a, b) => a - b)
+    );
   };
 
   const handleDeleteNote = async (noteId: number) => {
@@ -512,30 +540,62 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
 
           <div className={sectionClass}>
             <div className={headClass}>Change Rank</div>
-            <div className={`${bodyClass} flex gap-2`}>
-              <select
-                value={selectedRankId}
-                onChange={(e) =>
-                  setSelectedRankId(
-                    e.target.value ? Number(e.target.value) : ''
-                  )
-                }
-                className="flex-1 rounded bg-gray-700 border border-gray-600 text-white px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500"
-              >
-                <option value="">Select rank…</option>
-                {userRanks?.map((rank) => (
-                  <option key={rank.id} value={rank.id}>
-                    {rank.name}
-                  </option>
-                ))}
-              </select>
-              <button
-                onClick={handleSetRank}
-                disabled={!selectedRankId || isSettingRank}
-                className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-xs rounded transition-colors"
-              >
-                {isSettingRank ? 'Saving…' : 'Save'}
-              </button>
+            <div className={`${bodyClass} space-y-3`}>
+              <div className="flex gap-2">
+                <select
+                  value={selectedRankId}
+                  onChange={(e) =>
+                    setSelectedRankId(
+                      e.target.value ? Number(e.target.value) : ''
+                    )
+                  }
+                  className="flex-1 rounded bg-gray-700 border border-gray-600 text-white px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                >
+                  <option value="">Select rank…</option>
+                  {primaryRanks.map((rank) => (
+                    <option key={rank.id} value={rank.id}>
+                      {rank.name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={handleSetRank}
+                  disabled={!selectedRankId || isSettingRank}
+                  className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-xs rounded transition-colors"
+                >
+                  {isSettingRank ? 'Saving…' : 'Save'}
+                </button>
+              </div>
+              {secondaryRanks.length > 0 ? (
+                <div className="rounded border border-gray-800 bg-gray-950/60 p-3 space-y-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-500">
+                    Secondary Classes
+                  </div>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {secondaryRanks.map((rank) => (
+                      <label
+                        key={rank.id}
+                        className="flex items-start gap-3 rounded border border-gray-800 px-3 py-2 cursor-pointer hover:border-gray-700"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedSecondaryRankIds.includes(rank.id)}
+                          onChange={() => handleToggleSecondaryRank(rank.id)}
+                          className="mt-0.5 rounded border-gray-600 bg-gray-700 text-indigo-500 focus:ring-indigo-500"
+                        />
+                        <span className="min-w-0">
+                          <span className="block text-sm text-gray-200">
+                            {rank.name}
+                          </span>
+                          <span className="block text-xs text-gray-500">
+                            Level {rank.level}
+                          </span>
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
             </div>
           </div>
 

--- a/src/components/requests/RequestsPage.tsx
+++ b/src/components/requests/RequestsPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../store/services/requestApi';
 import type { RequestStatus } from '../../types';
 import Spinner from '../layout/Spinner';
+import { hasPermission } from '../../utils/permissions';
 
 const STATUS_LABELS: Record<RequestStatus, string> = {
   open: 'Open',
@@ -132,17 +133,20 @@ const RequestsPage = () => {
 
   const requests = data?.data ?? [];
   const meta = data?.meta;
+  const canCreateRequest = hasPermission(user, 'requests_create');
 
   return (
     <div className="thin">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-xl font-semibold">Requests</h2>
-        <Link
-          to="/private/requests/new"
-          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
-        >
-          New Request
-        </Link>
+        {canCreateRequest && (
+          <Link
+            to="/private/requests/new"
+            className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+          >
+            New Request
+          </Link>
+        )}
       </div>
 
       {/* Search form */}

--- a/src/store/services/forumApi.ts
+++ b/src/store/services/forumApi.ts
@@ -91,8 +91,14 @@ export type { CreateTopicArgs };
 
 export const forumApi = api.injectEndpoints({
   endpoints: (build) => ({
-    getForumCategories: build.query<ForumCategoriesResponse, void>({
-      query: () => '/forums/categories',
+    getForumCategories: build.query<
+      ForumCategoriesResponse,
+      { all?: boolean } | void
+    >({
+      query: (args) => {
+        const all = args && 'all' in args ? args.all : false;
+        return all ? '/forums/categories?all=true' : '/forums/categories';
+      },
       providesTags: ['ForumCategory']
     }),
     createForumCategory: build.mutation<

--- a/src/store/services/userApi.ts
+++ b/src/store/services/userApi.ts
@@ -15,21 +15,43 @@ type CreateUserArgs = NonNullable<
 >['content']['application/json'];
 type CreateUserResponse =
   paths['/users']['post']['responses'][201]['content']['application/json'];
-type UserRanksResponse =
-  paths['/tools/user-ranks']['get']['responses'][200]['content']['application/json'];
-type UserRankResponse =
-  paths['/tools/user-ranks/{id}']['get']['responses'][200]['content']['application/json'];
 type CreateUserRankArgs = NonNullable<
   paths['/tools/user-ranks']['post']['requestBody']
 >['content']['application/json'];
-type CreateUserRankResponse =
-  paths['/tools/user-ranks']['post']['responses'][201]['content']['application/json'];
 type UpdateUserRankBody = NonNullable<
   paths['/tools/user-ranks/{id}']['put']['requestBody']
 >['content']['application/json'];
 type UpdateUserRankArgs = { id: number } & UpdateUserRankBody;
-type UpdateUserRankResponse =
-  paths['/tools/user-ranks/{id}']['put']['responses'][200]['content']['application/json'];
+type StaffGroupsResponse =
+  paths['/tools/staff-groups']['get']['responses'][200]['content']['application/json'];
+
+export interface UserRankRecord {
+  id: number;
+  name: string;
+  level: number;
+  permissions: Record<string, boolean> | null;
+  secondary?: boolean;
+  permittedForumIds?: number[];
+  color?: string | null;
+  badge?: string | null;
+  personalCollageLimit?: number | null;
+  displayStaff?: boolean;
+  staffGroupId?: number | null;
+  primaryUserCount?: number;
+  secondaryUserCount?: number;
+  userCount?: number;
+}
+
+export interface UserRankAssignment {
+  userRankId: number;
+  secondaryRankIds: number[];
+}
+
+type SetUserRankArgs = {
+  id: number;
+  userRankId: number;
+  secondaryRankIds?: number[];
+};
 
 export const userApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -54,15 +76,21 @@ export const userApi = api.injectEndpoints({
     }),
 
     // UserRanks (UserRank)
-    getUserRanks: build.query<UserRanksResponse, void>({
+    getUserRanks: build.query<UserRankRecord[], void>({
       query: () => '/tools/user-ranks',
       providesTags: ['UserRank']
     }),
-    getUserRankById: build.query<UserRankResponse, number | string>({
+    getUserRankById: build.query<UserRankRecord, number | string>({
       query: (id) => `/tools/user-ranks/${id}`,
       providesTags: (_, __, id) => [{ type: 'UserRank', id: Number(id) }]
     }),
-    createUserRank: build.mutation<CreateUserRankResponse, CreateUserRankArgs>({
+    createUserRank: build.mutation<
+      UserRankRecord,
+      CreateUserRankArgs & {
+        secondary?: boolean;
+        permittedForumIds?: number[];
+      }
+    >({
       query: (data) => ({
         url: '/tools/user-ranks',
         method: 'POST',
@@ -70,7 +98,13 @@ export const userApi = api.injectEndpoints({
       }),
       invalidatesTags: ['UserRank']
     }),
-    updateUserRank: build.mutation<UpdateUserRankResponse, UpdateUserRankArgs>({
+    updateUserRank: build.mutation<
+      UserRankRecord,
+      UpdateUserRankArgs & {
+        secondary?: boolean;
+        permittedForumIds?: number[];
+      }
+    >({
       query: ({ id, ...data }) => ({
         url: `/tools/user-ranks/${id}`,
         method: 'PUT',
@@ -151,14 +185,15 @@ export const userApi = api.injectEndpoints({
         'Profile'
       ]
     }),
-    setUserRank: build.mutation<
-      { msg: string },
-      { id: number; userRankId: number }
-    >({
-      query: ({ id, userRankId }) => ({
+    getUserRankAssignment: build.query<UserRankAssignment, number>({
+      query: (id) => `/users/${id}/rank`,
+      providesTags: (_, __, id) => [{ type: 'User', id }]
+    }),
+    setUserRank: build.mutation<{ msg: string }, SetUserRankArgs>({
+      query: ({ id, userRankId, secondaryRankIds = [] }) => ({
         url: `/users/${id}/rank`,
         method: 'PUT',
-        body: { userRankId }
+        body: { userRankId, secondaryRankIds }
       }),
       invalidatesTags: (_, __, { id }) => [{ type: 'User', id }, 'Profile']
     }),
@@ -320,10 +355,7 @@ export const userApi = api.injectEndpoints({
     }),
 
     // Staff groups (admin-only CRUD, lives here alongside rank mutations)
-    getStaffGroups: build.query<
-      paths['/tools/staff-groups']['get']['responses'][200]['content']['application/json'],
-      void
-    >({
+    getStaffGroups: build.query<StaffGroupsResponse, void>({
       query: () => '/tools/staff-groups',
       providesTags: ['StaffGroup']
     }),
@@ -391,6 +423,7 @@ export const {
   useDeleteUserNoteMutation,
   useDisableUserMutation,
   useEnableUserMutation,
+  useGetUserRankAssignmentQuery,
   useSetUserRankMutation,
   useGetUserIpHistoryQuery,
   useGetUserEmailHistoryQuery,

--- a/src/utils/permissionCatalog.ts
+++ b/src/utils/permissionCatalog.ts
@@ -1,0 +1,280 @@
+export const PERMISSION_GROUPS = [
+  {
+    title: 'Discovery',
+    permissions: [
+      {
+        key: 'advanced_search',
+        label: 'Advanced search',
+        description: 'Access advanced search and broader discovery tools.'
+      },
+      {
+        key: 'users_search',
+        label: 'Search users',
+        description: 'Access elevated user search tooling.'
+      }
+    ]
+  },
+  {
+    title: 'Forums',
+    permissions: [
+      {
+        key: 'forums_read',
+        label: 'Read forums',
+        description: 'Browse forum categories and topics.'
+      },
+      {
+        key: 'forums_post',
+        label: 'Post in forums',
+        description: 'Create and reply to forum topics.'
+      },
+      {
+        key: 'forums_moderate',
+        label: 'Moderate forums',
+        description: 'Edit, lock, move, and otherwise moderate forum content.'
+      },
+      {
+        key: 'forums_manage',
+        label: 'Manage forums',
+        description: 'Manage forum categories, forums, and forum settings.'
+      }
+    ]
+  },
+  {
+    title: 'Communities',
+    permissions: [
+      {
+        key: 'communities_manage',
+        label: 'Manage communities',
+        description: 'Create and manage communities and related metadata.'
+      },
+      {
+        key: 'contributions_manage',
+        label: 'Manage contributions',
+        description:
+          'Moderate releases, contributions, and related community content.'
+      },
+      {
+        key: 'dnc_manage',
+        label: 'Manage DNC',
+        description: 'Manage the Do Not Contribute list.'
+      }
+    ]
+  },
+  {
+    title: 'Collages',
+    permissions: [
+      {
+        key: 'collages_create',
+        label: 'Create collages',
+        description: 'Create new collages, including personal collages.'
+      },
+      {
+        key: 'collages_manage',
+        label: 'Manage collages',
+        description: 'Edit owned collages and manage collage entries.'
+      },
+      {
+        key: 'collages_moderate',
+        label: 'Moderate collages',
+        description: 'Recover, delete, and fully moderate collages.'
+      }
+    ]
+  },
+  {
+    title: 'Requests',
+    permissions: [
+      {
+        key: 'requests_create',
+        label: 'Create requests',
+        description: 'Submit new requests.'
+      },
+      {
+        key: 'requests_moderate',
+        label: 'Moderate requests',
+        description:
+          'Edit, fill, unfill, and delete requests outside ownership.'
+      }
+    ]
+  },
+  {
+    title: 'Wiki',
+    permissions: [
+      {
+        key: 'wiki_edit',
+        label: 'Edit wiki',
+        description: 'Create and edit wiki pages.'
+      },
+      {
+        key: 'wiki_manage',
+        label: 'Manage wiki',
+        description: 'Manage restricted wiki operations and revision tools.'
+      }
+    ]
+  },
+  {
+    title: 'Content',
+    permissions: [
+      {
+        key: 'news_manage',
+        label: 'Manage news',
+        description: 'Manage announcements, blog posts, and featured albums.'
+      },
+      {
+        key: 'rules_manage',
+        label: 'Manage rules',
+        description: 'Manage rules pages.'
+      },
+      {
+        key: 'tags_manage',
+        label: 'Manage tags',
+        description: 'Manage tag aliases and related tag tooling.'
+      },
+      {
+        key: 'reports_manage',
+        label: 'Manage reports',
+        description: 'Work reports queues and report resolution flows.'
+      },
+      {
+        key: 'staff_inbox_manage',
+        label: 'Manage staff inbox',
+        description: 'Work staff inbox queues, tickets, and canned responses.'
+      }
+    ]
+  },
+  {
+    title: 'Users',
+    permissions: [
+      {
+        key: 'users_edit',
+        label: 'Edit users',
+        description: 'Create users and manage user account state.'
+      },
+      {
+        key: 'users_warn',
+        label: 'Warn users',
+        description: 'Issue and remove user warnings.'
+      },
+      {
+        key: 'users_disable',
+        label: 'Disable users',
+        description: 'Enable or disable user accounts.'
+      },
+      {
+        key: 'users_view_ips',
+        label: 'View IP history',
+        description: 'View per-user IP history.'
+      },
+      {
+        key: 'users_view_email',
+        label: 'View email history',
+        description: 'View per-user email history.'
+      },
+      {
+        key: 'recovery_manage',
+        label: 'Manage recovery',
+        description:
+          'Manage account recovery requests and trigger recovery emails.'
+      },
+      {
+        key: 'invites_manage',
+        label: 'Manage invites',
+        description: 'Access invite pool and invite tree tools.'
+      },
+      {
+        key: 'ratio_policy_manage',
+        label: 'Manage ratio policy',
+        description: 'Manage ratio policy tools and ratio watch.'
+      }
+    ]
+  },
+  {
+    title: 'Operations',
+    permissions: [
+      {
+        key: 'site_history_manage',
+        label: 'Manage site history',
+        description: 'Manage site history entries.'
+      },
+      {
+        key: 'ip_bans_manage',
+        label: 'Manage IP bans',
+        description: 'Manage IP ban ranges.'
+      },
+      {
+        key: 'email_blacklist_manage',
+        label: 'Manage email blacklist',
+        description: 'Manage blacklisted email domains and addresses.'
+      },
+      {
+        key: 'donor_ranks_manage',
+        label: 'Manage donor ranks',
+        description: 'Manage donor ranks and donor assignments.'
+      },
+      {
+        key: 'donation_log_view',
+        label: 'View donation log',
+        description: 'Access donation log and related finance read tools.'
+      },
+      {
+        key: 'messages_mass_pm',
+        label: 'Send mass PMs',
+        description: 'Send site-wide mass private messages.'
+      }
+    ]
+  },
+  {
+    title: 'Staff Tools',
+    permissions: [
+      {
+        key: 'login_watch_view',
+        label: 'View login watch',
+        description: 'Access login watch session tools.'
+      },
+      {
+        key: 'duplicate_ips_view',
+        label: 'View duplicate IPs',
+        description: 'Access duplicate IP reports.'
+      },
+      {
+        key: 'registration_log_view',
+        label: 'View registration log',
+        description: 'Access registration logs.'
+      },
+      {
+        key: 'staff',
+        label: 'General staff',
+        description:
+          'Access general staff-only surfaces not broken out further.'
+      }
+    ]
+  },
+  {
+    title: 'Administration',
+    permissions: [
+      {
+        key: 'rank_permissions_manage',
+        label: 'Manage rank permissions',
+        description: 'Create, edit, and delete user ranks and permission sets.'
+      },
+      {
+        key: 'staff_groups_manage',
+        label: 'Manage staff groups',
+        description: 'Create, edit, and delete staff groups.'
+      },
+      {
+        key: 'admin',
+        label: 'Administrator',
+        description: 'Global administrative override.'
+      }
+    ]
+  }
+] as const;
+
+type PermissionEntry =
+  (typeof PERMISSION_GROUPS)[number]['permissions'][number];
+
+export const VALID_PERMISSIONS = PERMISSION_GROUPS.flatMap((group) =>
+  group.permissions.map((permission) => permission.key)
+) as [PermissionEntry['key'], ...PermissionEntry['key'][]];
+
+export type Permission = (typeof VALID_PERMISSIONS)[number];

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,28 +1,8 @@
 import type { AuthUser } from '../types';
+import { type Permission, VALID_PERMISSIONS } from './permissionCatalog';
 
-export const VALID_PERMISSIONS = [
-  'forums_read',
-  'forums_post',
-  'forums_moderate',
-  'forums_manage',
-  'communities_manage',
-  'collages_manage',
-  'collages_moderate',
-  'news_manage',
-  'invites_manage',
-  'users_edit',
-  'users_warn',
-  'users_disable',
-  'wiki_edit',
-  'wiki_manage',
-  'rules_manage',
-  'advanced_search',
-  'users_search',
-  'staff',
-  'admin'
-] as const;
-
-export type Permission = (typeof VALID_PERMISSIONS)[number];
+export { VALID_PERMISSIONS };
+export type { Permission };
 
 const getPermissions = (
   user: AuthUser | null | undefined
@@ -33,7 +13,7 @@ export const hasPermission = (
   permission: Permission
 ): boolean => {
   const permissions = getPermissions(user);
-  if (permission === 'admin') return !!(permissions.admin || permissions.staff);
+  if (permissions.admin) return true;
   return !!permissions[permission];
 };
 
@@ -42,13 +22,19 @@ export const hasAnyPermission = (
   permissions: Permission[]
 ): boolean => permissions.some((permission) => hasPermission(user, permission));
 
+export const canSeeModBar = (user: AuthUser | null | undefined): boolean =>
+  hasAnyPermission(user, ['staff', 'admin']);
+
 export const isStaffUser = (user: AuthUser | null | undefined): boolean =>
   hasAnyPermission(user, [
     'staff',
-    'admin',
     'forums_manage',
     'forums_moderate',
     'communities_manage',
+    'contributions_manage',
+    'reports_manage',
+    'staff_inbox_manage',
     'news_manage',
-    'users_edit'
+    'users_edit',
+    'rank_permissions_manage'
   ]);


### PR DESCRIPTION
## Summary
- add the rank permissions manager UI and permission catalog grouping
- add secondary class assignment and permitted forum override editing flows
- align staff toolbox, gated routes, modbar visibility, and create actions with explicit permissions
- widen the user rank editor to match the standard page width

## Verification
- npm run typecheck
- npm run lint
- npm test -- --runInBand src/__tests__/admin/UserRankFormPage.test.tsx src/__tests__/admin/UserRankManager.test.tsx src/__tests__/profile/UserProfile.test.tsx
- npm test -- --runInBand src/__tests__/utils/permissions.test.ts src/__tests__/admin/ModBar.test.tsx src/__tests__/layout/PrivateHeader.test.tsx