### PR TITLE
Update CommentsSection: rename page prop to context, regenerate API types

### DIFF
--- a/src/__tests__/communities/ArtistPage.test.tsx
+++ b/src/__tests__/communities/ArtistPage.test.tsx
@@ -29,8 +29,8 @@ jest.mock('../../store/services/subscriptionApi', () => ({
 
 jest.mock('../../components/layout/CommentsSection', () => ({
   __esModule: true,
-  default: ({ page, pageId }: { page: string; pageId: number }) => (
-    <div data-testid="artist-comments">{`${page}:${pageId}`}</div>
+  default: ({ context, pageId }: { context: string; pageId: number }) => (
+    <div data-testid="artist-comments">{`${context}:${pageId}`}</div>
   )
 }));
 

--- a/src/__tests__/layout/CommentsSection.test.tsx
+++ b/src/__tests__/layout/CommentsSection.test.tsx
@@ -193,7 +193,9 @@ describe('CommentsSection', () => {
 
   it('calls createComment with contributionId on submit for contributions page', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection context="contributions" pageId={11} />);
+    renderWithProviders(
+      <CommentsSection context="contributions" pageId={11} />
+    );
     await user.type(screen.getByPlaceholderText(/add a comment/i), 'Thanks');
     await user.click(screen.getByRole('button', { name: /post comment/i }));
     await waitFor(() => {

--- a/src/__tests__/layout/CommentsSection.test.tsx
+++ b/src/__tests__/layout/CommentsSection.test.tsx
@@ -92,31 +92,31 @@ describe('CommentsSection', () => {
   it('shows loading state', () => {
     mockIsLoading = true;
     mockCommentsData = undefined;
-    renderWithProviders(<CommentsSection page="release" pageId={1} />);
+    renderWithProviders(<CommentsSection context="release" pageId={1} />);
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 
   it('shows empty state when no comments', () => {
     mockCommentsData = [];
-    renderWithProviders(<CommentsSection page="release" pageId={1} />);
+    renderWithProviders(<CommentsSection context="release" pageId={1} />);
     expect(screen.getByText(/no comments yet/i)).toBeInTheDocument();
   });
 
   it('renders comment authors and bodies', () => {
-    renderWithProviders(<CommentsSection page="release" pageId={1} />);
+    renderWithProviders(<CommentsSection context="release" pageId={1} />);
     expect(screen.getByText('alice')).toBeInTheDocument();
     expect(screen.getByText('bob')).toBeInTheDocument();
   });
 
   it('shows delete button for own comment (bob)', () => {
-    renderWithProviders(<CommentsSection page="release" pageId={1} />);
+    renderWithProviders(<CommentsSection context="release" pageId={1} />);
     expect(
       screen.getByRole('button', { name: /delete comment/i })
     ).toBeInTheDocument();
   });
 
   it("shows report link for other users' comments (alice)", () => {
-    renderWithProviders(<CommentsSection page="release" pageId={1} />);
+    renderWithProviders(<CommentsSection context="release" pageId={1} />);
     expect(
       screen.getByRole('link', { name: /report comment/i })
     ).toBeInTheDocument();
@@ -124,14 +124,14 @@ describe('CommentsSection', () => {
 
   it('calls deleteComment when delete button is clicked', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="release" pageId={1} />);
+    renderWithProviders(<CommentsSection context="release" pageId={1} />);
     await user.click(screen.getByRole('button', { name: /delete comment/i }));
     expect(mockDeleteComment).toHaveBeenCalledWith(2);
   });
 
   it('calls createComment with releaseId on submit', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="release" pageId={5} />);
+    renderWithProviders(<CommentsSection context="release" pageId={5} />);
     await user.type(
       screen.getByPlaceholderText(/add a comment/i),
       'Nice release'
@@ -148,7 +148,7 @@ describe('CommentsSection', () => {
 
   it('calls createComment with communityId on submit for communities page', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="communities" pageId={7} />);
+    renderWithProviders(<CommentsSection context="communities" pageId={7} />);
     await user.type(
       screen.getByPlaceholderText(/add a comment/i),
       'Great community'
@@ -165,7 +165,7 @@ describe('CommentsSection', () => {
 
   it('calls createComment with artistId on submit for artist page', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="artist" pageId={3} />);
+    renderWithProviders(<CommentsSection context="artist" pageId={3} />);
     await user.type(screen.getByPlaceholderText(/add a comment/i), 'Fan');
     await user.click(screen.getByRole('button', { name: /post comment/i }));
     await waitFor(() => {
@@ -179,7 +179,7 @@ describe('CommentsSection', () => {
 
   it('calls createComment with collageId on submit for collages page', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="collages" pageId={9} />);
+    renderWithProviders(<CommentsSection context="collages" pageId={9} />);
     await user.type(screen.getByPlaceholderText(/add a comment/i), 'Nice');
     await user.click(screen.getByRole('button', { name: /post comment/i }));
     await waitFor(() => {
@@ -193,7 +193,7 @@ describe('CommentsSection', () => {
 
   it('calls createComment with contributionId on submit for contributions page', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="contributions" pageId={11} />);
+    renderWithProviders(<CommentsSection context="contributions" pageId={11} />);
     await user.type(screen.getByPlaceholderText(/add a comment/i), 'Thanks');
     await user.click(screen.getByRole('button', { name: /post comment/i }));
     await waitFor(() => {
@@ -207,7 +207,7 @@ describe('CommentsSection', () => {
 
   it('calls createComment with requestId on submit for requests page', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="requests" pageId={13} />);
+    renderWithProviders(<CommentsSection context="requests" pageId={13} />);
     await user.type(screen.getByPlaceholderText(/add a comment/i), 'Support');
     await user.click(screen.getByRole('button', { name: /post comment/i }));
     await waitFor(() => {
@@ -221,7 +221,7 @@ describe('CommentsSection', () => {
 
   it('clears comment body after successful submission', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="release" pageId={5} />);
+    renderWithProviders(<CommentsSection context="release" pageId={5} />);
     const textarea = screen.getByPlaceholderText(/add a comment/i);
     await user.type(textarea, 'Hello world');
     await user.click(screen.getByRole('button', { name: /post comment/i }));
@@ -232,21 +232,21 @@ describe('CommentsSection', () => {
 
   it('hides form when user is not logged in', () => {
     mockCurrentUser = null;
-    renderWithProviders(<CommentsSection page="release" pageId={1} />);
+    renderWithProviders(<CommentsSection context="release" pageId={1} />);
     expect(
       screen.queryByPlaceholderText(/add a comment/i)
     ).not.toBeInTheDocument();
   });
 
   it('shows subscribe checkbox on subscribable pages (artist)', () => {
-    renderWithProviders(<CommentsSection page="artist" pageId={3} />);
+    renderWithProviders(<CommentsSection context="artist" pageId={3} />);
     expect(
       screen.getByRole('checkbox', { name: /subscribe to comments/i })
     ).toBeInTheDocument();
   });
 
   it('shows subscribe checkbox on release page', () => {
-    renderWithProviders(<CommentsSection page="release" pageId={5} />);
+    renderWithProviders(<CommentsSection context="release" pageId={5} />);
     expect(
       screen.getByRole('checkbox', { name: /subscribe to comments/i })
     ).toBeInTheDocument();
@@ -254,7 +254,7 @@ describe('CommentsSection', () => {
 
   it('calls subscribeComments when checkbox is checked on submit', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="artist" pageId={3} />);
+    renderWithProviders(<CommentsSection context="artist" pageId={3} />);
     await user.click(
       screen.getByRole('checkbox', { name: /subscribe to comments/i })
     );
@@ -271,7 +271,7 @@ describe('CommentsSection', () => {
 
   it('does not call subscribeComments when checkbox is unchecked', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="artist" pageId={3} />);
+    renderWithProviders(<CommentsSection context="artist" pageId={3} />);
     await user.type(screen.getByPlaceholderText(/add a comment/i), 'Great');
     await user.click(screen.getByRole('button', { name: /post comment/i }));
     await waitFor(() => {
@@ -282,7 +282,7 @@ describe('CommentsSection', () => {
 
   it('resets subscribe checkbox to unchecked after submit', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="communities" pageId={7} />);
+    renderWithProviders(<CommentsSection context="communities" pageId={7} />);
     const checkbox = screen.getByRole('checkbox', {
       name: /subscribe to comments/i
     });
@@ -300,7 +300,7 @@ describe('CommentsSection', () => {
       unwrap: () => Promise.reject(new Error('nope'))
     });
     const user = userEvent.setup();
-    renderWithProviders(<CommentsSection page="artist" pageId={3} />);
+    renderWithProviders(<CommentsSection context="artist" pageId={3} />);
     const checkbox = screen.getByRole('checkbox', {
       name: /subscribe to comments/i
     });

--- a/src/__tests__/requests/RequestDetailPage.test.tsx
+++ b/src/__tests__/requests/RequestDetailPage.test.tsx
@@ -154,7 +154,7 @@ describe('RequestDetailPage', () => {
       expect(mockDeleteRequest).toHaveBeenCalledWith(12);
       expect(mockNavigate).toHaveBeenCalledWith('/private/requests');
       expect(mockCommentsSection).toHaveBeenCalledWith({
-        page: 'requests',
+        context: 'requests',
         pageId: 12
       });
       expect(screen.getAllByText('100.00 MiB').length).toBeGreaterThan(0);

--- a/src/components/collages/CollageDetail.tsx
+++ b/src/components/collages/CollageDetail.tsx
@@ -406,7 +406,7 @@ const CollageDetail = () => {
           )}
 
           {/* Comments */}
-          <CommentsSection page="collages" pageId={collageId} />
+          <CommentsSection context="collages" pageId={collageId} />
         </div>
       </div>
     </div>

--- a/src/components/communities/ArtistPage.tsx
+++ b/src/components/communities/ArtistPage.tsx
@@ -256,7 +256,7 @@ const ArtistPage = () => {
           </table>
         )}
       </div>
-      <CommentsSection page="artist" pageId={artistId} />
+      <CommentsSection context="artist" pageId={artistId} />
     </div>
   );
 };

--- a/src/components/communities/ReleasePage.tsx
+++ b/src/components/communities/ReleasePage.tsx
@@ -448,7 +448,7 @@ const ReleasePage = () => {
           </div>
 
           <CommentsSection
-            page="release"
+            context="release"
             pageId={rId}
             alreadySubscribed={isSubscribedToComments}
           />

--- a/src/components/layout/CommentsSection.tsx
+++ b/src/components/layout/CommentsSection.tsx
@@ -34,7 +34,10 @@ const CommentsSection = ({
   alreadySubscribed = false
 }: Props) => {
   const currentUser = useSelector(selectCurrentUser);
-  const { data: comments, isLoading } = useGetCommentsQuery({ context, pageId });
+  const { data: comments, isLoading } = useGetCommentsQuery({
+    context,
+    pageId
+  });
   const [createComment, { isLoading: posting }] = useCreateCommentMutation();
   const [deleteComment] = useDeleteCommentMutation();
 
@@ -42,28 +45,53 @@ const CommentsSection = ({
   const [subscribe, setSubscribe] = useState(false);
   const [subscribeComments, { isLoading: subscribing }] =
     useSubscribeCommentsMutation();
-  const canSubscribe = SUBSCRIBABLE_PAGES.includes(context) && !alreadySubscribed;
+  const canSubscribe =
+    SUBSCRIBABLE_PAGES.includes(context) && !alreadySubscribed;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!body.trim()) return;
     try {
       if (context === 'communities') {
-        await createComment({ page: context, body, communityId: pageId }).unwrap();
+        await createComment({
+          page: context,
+          body,
+          communityId: pageId
+        }).unwrap();
       } else if (context === 'artist') {
         await createComment({ page: context, body, artistId: pageId }).unwrap();
       } else if (context === 'release') {
-        await createComment({ page: context, body, releaseId: pageId }).unwrap();
+        await createComment({
+          page: context,
+          body,
+          releaseId: pageId
+        }).unwrap();
       } else if (context === 'collages') {
-        await createComment({ page: context, body, collageId: pageId }).unwrap();
+        await createComment({
+          page: context,
+          body,
+          collageId: pageId
+        }).unwrap();
       } else if (context === 'contributions') {
-        await createComment({ page: context, body, contributionId: pageId }).unwrap();
+        await createComment({
+          page: context,
+          body,
+          contributionId: pageId
+        }).unwrap();
       } else {
-        await createComment({ page: context, body, requestId: pageId }).unwrap();
+        await createComment({
+          page: context,
+          body,
+          requestId: pageId
+        }).unwrap();
       }
 
       if (subscribe && canSubscribe) {
-        await subscribeComments({ page: context, pageId, action: 'subscribe' }).unwrap();
+        await subscribeComments({
+          page: context,
+          pageId,
+          action: 'subscribe'
+        }).unwrap();
       }
 
       setBody('');

--- a/src/components/layout/CommentsSection.tsx
+++ b/src/components/layout/CommentsSection.tsx
@@ -23,18 +23,18 @@ const SUBSCRIBABLE_PAGES: CommentPage[] = [
 ];
 
 interface Props {
-  page: CommentPage;
+  context: CommentPage;
   pageId: number;
   alreadySubscribed?: boolean;
 }
 
 const CommentsSection = ({
-  page,
+  context,
   pageId,
   alreadySubscribed = false
 }: Props) => {
   const currentUser = useSelector(selectCurrentUser);
-  const { data: comments, isLoading } = useGetCommentsQuery({ page, pageId });
+  const { data: comments, isLoading } = useGetCommentsQuery({ context, pageId });
   const [createComment, { isLoading: posting }] = useCreateCommentMutation();
   const [deleteComment] = useDeleteCommentMutation();
 
@@ -42,28 +42,28 @@ const CommentsSection = ({
   const [subscribe, setSubscribe] = useState(false);
   const [subscribeComments, { isLoading: subscribing }] =
     useSubscribeCommentsMutation();
-  const canSubscribe = SUBSCRIBABLE_PAGES.includes(page) && !alreadySubscribed;
+  const canSubscribe = SUBSCRIBABLE_PAGES.includes(context) && !alreadySubscribed;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!body.trim()) return;
     try {
-      if (page === 'communities') {
-        await createComment({ page, body, communityId: pageId }).unwrap();
-      } else if (page === 'artist') {
-        await createComment({ page, body, artistId: pageId }).unwrap();
-      } else if (page === 'release') {
-        await createComment({ page, body, releaseId: pageId }).unwrap();
-      } else if (page === 'collages') {
-        await createComment({ page, body, collageId: pageId }).unwrap();
-      } else if (page === 'contributions') {
-        await createComment({ page, body, contributionId: pageId }).unwrap();
+      if (context === 'communities') {
+        await createComment({ page: context, body, communityId: pageId }).unwrap();
+      } else if (context === 'artist') {
+        await createComment({ page: context, body, artistId: pageId }).unwrap();
+      } else if (context === 'release') {
+        await createComment({ page: context, body, releaseId: pageId }).unwrap();
+      } else if (context === 'collages') {
+        await createComment({ page: context, body, collageId: pageId }).unwrap();
+      } else if (context === 'contributions') {
+        await createComment({ page: context, body, contributionId: pageId }).unwrap();
       } else {
-        await createComment({ page, body, requestId: pageId }).unwrap();
+        await createComment({ page: context, body, requestId: pageId }).unwrap();
       }
 
       if (subscribe && canSubscribe) {
-        await subscribeComments({ page, pageId, action: 'subscribe' }).unwrap();
+        await subscribeComments({ page: context, pageId, action: 'subscribe' }).unwrap();
       }
 
       setBody('');

--- a/src/components/requests/RequestDetailPage.tsx
+++ b/src/components/requests/RequestDetailPage.tsx
@@ -395,7 +395,7 @@ const RequestDetailPage = () => {
         )}
       </div>
 
-      <CommentsSection page="requests" pageId={requestId} />
+      <CommentsSection context="requests" pageId={requestId} />
     </div>
   );
 };

--- a/src/store/services/commentApi.ts
+++ b/src/store/services/commentApi.ts
@@ -3,7 +3,7 @@ import type { paths } from '../../types/api';
 
 export type CommentPage = NonNullable<
   paths['/comments']['get']['parameters']['query']
->['page'] extends infer T
+>['context'] extends infer T
   ? Exclude<T, undefined>
   : never;
 type CommentQueryParams = NonNullable<

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -4585,7 +4585,9 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          page?:
+          page?: number;
+          limit?: number;
+          context?:
             | 'artist'
             | 'collages'
             | 'contributions'


### PR DESCRIPTION
## What

Companion to stellar-api#47.

The comment GET query parameter `page` (CommentPage enum context filter — e.g. `communities`, `artist`) was renamed to `context` in the backend schema to free up `page` for numeric offset pagination. This cascades to the frontend:

### Changes

- **`CommentsSection`**: prop `page` → `context`; passes `context` to `useGetCommentsQuery`
- **`commentApi.ts`**: `CommentPage` type now reads `['context']` from generated OpenAPI path types
- **4 callers**: `ArtistPage`, `ReleasePage`, `CollageDetail`, `RequestDetailPage` — all updated to `context=` prop
- **Tests**: `CommentsSection.test.tsx`, `ArtistPage.test.tsx`, `RequestDetailPage.test.tsx` updated
- **`src/types/api.ts`**: regenerated from updated OpenAPI spec; `/comments` GET query now has `context`, `page` (number), `limit` (number)

🤖 Generated with [Claude Code](https://claude.com/claude-code)