### PR TITLE
Consume topicSession endpoint in ForumTopicPage

### DIFF
--- a/src/__tests__/forum/ForumTopicPage.integration.test.tsx
+++ b/src/__tests__/forum/ForumTopicPage.integration.test.tsx
@@ -21,18 +21,21 @@ type PollState = {
   votes: Array<{ userId: number; vote: number }>;
 };
 
+// Builds a fetch mock that serves the single session endpoint and handles all
+// topic-session mutations. canModerate controls the server-computed affordances.
 const makeForumFetch = ({
   topic,
   poll,
   subscriptions,
-  markReadStatus = 200
+  markReadStatus = 200,
+  canModerate = false
 }: {
   topic?: TopicState;
   poll?: PollState;
   subscriptions?: Array<{ topicId: number }>;
   markReadStatus?: number;
+  canModerate?: boolean;
 }) => {
-  const forum = { id: 9, name: 'Jazz Forum' };
   const posts = {
     data: [
       {
@@ -45,52 +48,70 @@ const makeForumFetch = ({
         body: 'Second post',
         author: { id: 8, username: 'bob' }
       }
-    ]
+    ],
+    meta: { total: 2, page: 1, limit: 25, totalPages: 1 }
   };
-  const topicState = topic ?? {
+  const topicState: TopicState = topic ?? {
     id: 44,
     title: 'Blue Note thread',
     isLocked: false,
     isSticky: false
   };
-  const pollState = poll ?? {
+  const pollState: PollState = poll ?? {
     id: 6,
     question: 'Best format?',
     answers: JSON.stringify(['CD', 'Vinyl']),
     closed: false,
     votes: []
   };
-  const subscriptionState = subscriptions ?? [{ topicId: 44 }];
+  const subscriptionState: Array<{ topicId: number }> = subscriptions ?? [
+    { topicId: 44 }
+  ];
+
+  const buildSession = () => ({
+    forum: {
+      id: 9,
+      name: 'Jazz Forum',
+      forumCategoryId: 1,
+      forumCategory: null
+    },
+    topic: {
+      ...topicState,
+      authorId: 5,
+      author: { id: 5, username: 'author', avatar: null },
+      notes: []
+    },
+    posts,
+    poll: pollState,
+    subscription: {
+      isSubscribed: subscriptionState.some((s) => s.topicId === topicState.id)
+    },
+    affordances: {
+      canReply: !topicState.isLocked || canModerate,
+      canModerate,
+      canVoteInPoll: !pollState.closed,
+      canSubscribe: true,
+      canCatchUp: true
+    },
+    readState: { lastVisiblePostId: 102 }
+  });
 
   return jest.fn(async (request: Request) => {
     const url = new URL(request.url, 'http://localhost');
 
-    if (url.pathname === '/api/forums/9') {
-      return makeResponse({ body: forum });
+    if (url.pathname === '/api/forums/9/topics/44/session') {
+      return makeResponse({ body: buildSession() });
     }
 
-    if (url.pathname === '/api/forums/9/topics/44') {
-      if (request.method === 'PUT') {
-        const body = JSON.parse(
-          (await request.text()) || '{}'
-        ) as Partial<TopicState>;
-        Object.assign(topicState, body);
-        return makeResponse({ body: topicState });
-      }
-
+    if (
+      url.pathname === '/api/forums/9/topics/44' &&
+      request.method === 'PUT'
+    ) {
+      const body = JSON.parse(
+        (await request.text()) || '{}'
+      ) as Partial<TopicState>;
+      Object.assign(topicState, body);
       return makeResponse({ body: topicState });
-    }
-
-    if (url.pathname === '/api/forums/9/topics/44/posts') {
-      return makeResponse({ body: posts });
-    }
-
-    if (url.pathname === '/api/forums/polls/44') {
-      return makeResponse({ body: pollState });
-    }
-
-    if (url.pathname === '/api/subscriptions') {
-      return makeResponse({ body: subscriptionState });
     }
 
     if (url.pathname === '/api/subscriptions/subscribe') {
@@ -98,7 +119,6 @@ const makeForumFetch = ({
         topicId: number;
         action: 'subscribe' | 'unsubscribe';
       };
-
       if (body.action === 'unsubscribe') {
         const index = subscriptionState.findIndex(
           (s) => s.topicId === body.topicId
@@ -107,7 +127,6 @@ const makeForumFetch = ({
       } else if (!subscriptionState.some((s) => s.topicId === body.topicId)) {
         subscriptionState.push({ topicId: body.topicId });
       }
-
       return makeResponse({ status: 204 });
     }
 
@@ -189,7 +208,9 @@ describe('ForumTopicPage RTK Query integration', () => {
         userRank: { permissions: { forums_moderate: true } }
       } as never)
     );
-    (global.fetch as jest.Mock).mockImplementation(makeForumFetch({}));
+    (global.fetch as jest.Mock).mockImplementation(
+      makeForumFetch({ canModerate: true })
+    );
 
     renderWithProviders(<ForumTopicPage />, { store });
 
@@ -297,7 +318,8 @@ describe('ForumTopicPage RTK Query integration', () => {
           closed: false,
           votes: []
         },
-        subscriptions: []
+        subscriptions: [],
+        canModerate: false
       })
     );
 

--- a/src/__tests__/forum/ForumTopicPage.test.tsx
+++ b/src/__tests__/forum/ForumTopicPage.test.tsx
@@ -10,11 +10,7 @@ type MockForumPostProps = {
   onQuote?: (text: string) => void;
 };
 
-const mockUseGetForumByIdQuery = jest.fn();
-const mockUseGetTopicByIdQuery = jest.fn();
-const mockUseGetPostsByTopicQuery = jest.fn();
-const mockUseGetPollByTopicQuery = jest.fn();
-const mockUseGetSubscriptionsQuery = jest.fn();
+const mockUseGetTopicSessionQuery = jest.fn();
 const mockMarkRead = jest.fn();
 const mockVotePoll = jest.fn();
 const mockSubscribe = jest.fn();
@@ -23,14 +19,8 @@ const mockTrashTopic = jest.fn();
 const mockCatchupForum = jest.fn();
 
 jest.mock('../../store/services/forumApi', () => ({
-  useGetForumByIdQuery: (...args: unknown[]) =>
-    mockUseGetForumByIdQuery(...args),
-  useGetTopicByIdQuery: (...args: unknown[]) =>
-    mockUseGetTopicByIdQuery(...args),
-  useGetPostsByTopicQuery: (...args: unknown[]) =>
-    mockUseGetPostsByTopicQuery(...args),
-  useGetPollByTopicQuery: (...args: unknown[]) =>
-    mockUseGetPollByTopicQuery(...args),
+  useGetTopicSessionQuery: (...args: unknown[]) =>
+    mockUseGetTopicSessionQuery(...args),
   useMarkTopicReadMutation: () => [mockMarkRead],
   useVotePollMutation: () => [mockVotePoll, { isLoading: false }],
   useUpdateTopicMutation: () => [mockUpdateTopic, { isLoading: false }],
@@ -39,7 +29,6 @@ jest.mock('../../store/services/forumApi', () => ({
 }));
 
 jest.mock('../../store/services/subscriptionApi', () => ({
-  useGetSubscriptionsQuery: () => mockUseGetSubscriptionsQuery(),
   useSubscribeMutation: () => [mockSubscribe, { isLoading: false }]
 }));
 
@@ -73,49 +62,55 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ forumId: '9', forumTopicId: '44' })
 }));
 
+// Default session covers the common happy-path shape. Individual tests override
+// only what they need.
+const defaultSession = {
+  forum: {
+    id: 9,
+    name: 'Jazz Forum',
+    forumCategoryId: 1,
+    forumCategory: null
+  },
+  topic: {
+    id: 44,
+    title: 'Blue Note thread',
+    isLocked: false,
+    isSticky: false,
+    authorId: 5,
+    author: { id: 5, username: 'alice', avatar: null },
+    notes: []
+  },
+  posts: {
+    data: [
+      { id: 101, body: 'First post', author: { id: 7, username: 'alice' } },
+      { id: 102, body: 'Second post', author: { id: 8, username: 'bob' } }
+    ],
+    meta: { total: 2, page: 1, limit: 25, totalPages: 1 }
+  },
+  poll: {
+    id: 6,
+    question: 'Best format?',
+    answers: JSON.stringify(['CD', 'Vinyl']),
+    closed: false,
+    votes: [] as Array<{ userId: number; vote: number }>
+  },
+  subscription: { isSubscribed: true },
+  affordances: {
+    canReply: true,
+    canModerate: true,
+    canVoteInPoll: true,
+    canSubscribe: true,
+    canCatchUp: true
+  },
+  readState: { lastVisiblePostId: 102 }
+};
+
 describe('ForumTopicPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseGetForumByIdQuery.mockReturnValue({
-      data: { id: 9, name: 'Jazz Forum' }
-    });
-    mockUseGetTopicByIdQuery.mockReturnValue({
-      data: {
-        id: 44,
-        title: 'Blue Note thread',
-        isLocked: false,
-        isSticky: false
-      },
+    mockUseGetTopicSessionQuery.mockReturnValue({
+      data: defaultSession,
       isLoading: false
-    });
-    mockUseGetPostsByTopicQuery.mockReturnValue({
-      data: {
-        data: [
-          {
-            id: 101,
-            body: 'First post',
-            author: { id: 7, username: 'alice' }
-          },
-          {
-            id: 102,
-            body: 'Second post',
-            author: { id: 8, username: 'bob' }
-          }
-        ]
-      },
-      isLoading: false
-    });
-    mockUseGetPollByTopicQuery.mockReturnValue({
-      data: {
-        id: 6,
-        question: 'Best format?',
-        answers: JSON.stringify(['CD', 'Vinyl']),
-        closed: false,
-        votes: []
-      }
-    });
-    mockUseGetSubscriptionsQuery.mockReturnValue({
-      data: [{ topicId: 44 }]
     });
   });
 
@@ -180,17 +175,21 @@ describe('ForumTopicPage', () => {
         userRank: { permissions: { forums_moderate: true } }
       } as never)
     );
-    mockUseGetPollByTopicQuery.mockReturnValue({
+    mockUseGetTopicSessionQuery.mockReturnValue({
       data: {
-        id: 6,
-        question: 'Best format?',
-        answers: JSON.stringify(['CD', 'Vinyl']),
-        closed: true,
-        votes: [
-          { userId: 9, vote: 0 },
-          { userId: 10, vote: 1 }
-        ]
-      }
+        ...defaultSession,
+        poll: {
+          id: 6,
+          question: 'Best format?',
+          answers: JSON.stringify(['CD', 'Vinyl']),
+          closed: true,
+          votes: [
+            { userId: 9, vote: 0 },
+            { userId: 10, vote: 1 }
+          ]
+        }
+      },
+      isLoading: false
     });
 
     renderWithProviders(<ForumTopicPage />, { store });
@@ -202,10 +201,10 @@ describe('ForumTopicPage', () => {
     // Quote a post then clear it via onQuoteConsumed
     await user.click(screen.getByRole('button', { name: /quote post 101/i }));
     await user.click(screen.getByRole('button', { name: /clear quote/i }));
-    // No assertion needed — just exercising the callback path
+    // No assertion needed — exercising the callback path
   });
 
-  it('shows subscribe (not unsubscribe) when not subscribed, topic not found when data missing, and singular vote count', async () => {
+  it('shows subscribe (not unsubscribe) when not subscribed, and singular vote count', async () => {
     const user = userEvent.setup();
     const store = createTestStore();
     store.dispatch(
@@ -215,17 +214,27 @@ describe('ForumTopicPage', () => {
         userRank: { permissions: {} }
       } as never)
     );
-    // Not subscribed
-    mockUseGetSubscriptionsQuery.mockReturnValue({ data: [] });
-    // Poll: open with 1 vote by another user → shows voting form with '1 vote'
-    mockUseGetPollByTopicQuery.mockReturnValue({
+    // Poll open, 1 vote by another user → shows voting form with '1 vote'
+    mockUseGetTopicSessionQuery.mockReturnValue({
       data: {
-        id: 6,
-        question: 'Format?',
-        answers: JSON.stringify(['CD', 'Vinyl']),
-        closed: false,
-        votes: [{ userId: 99, vote: 0 }]
-      }
+        ...defaultSession,
+        poll: {
+          id: 6,
+          question: 'Format?',
+          answers: JSON.stringify(['CD', 'Vinyl']),
+          closed: false,
+          votes: [{ userId: 99, vote: 0 }]
+        },
+        subscription: { isSubscribed: false },
+        affordances: {
+          canReply: true,
+          canModerate: false,
+          canVoteInPoll: true,
+          canSubscribe: true,
+          canCatchUp: true
+        }
+      },
+      isLoading: false
     });
 
     renderWithProviders(<ForumTopicPage />, { store });
@@ -251,19 +260,18 @@ describe('ForumTopicPage', () => {
         userRank: { permissions: {} }
       } as never)
     );
-    mockUseGetPollByTopicQuery.mockReturnValue({ data: undefined });
+    mockUseGetTopicSessionQuery.mockReturnValue({
+      data: { ...defaultSession, poll: null },
+      isLoading: false
+    });
 
     renderWithProviders(<ForumTopicPage />, { store });
 
     expect(screen.queryByText('Best format?')).not.toBeInTheDocument();
   });
 
-  it('shows topic not found when topic data is absent', () => {
-    mockUseGetTopicByIdQuery.mockReturnValue({
-      data: undefined,
-      isLoading: false
-    });
-    mockUseGetPostsByTopicQuery.mockReturnValue({
+  it('shows topic not found when session data is absent', () => {
+    mockUseGetTopicSessionQuery.mockReturnValue({
       data: undefined,
       isLoading: false
     });
@@ -280,14 +288,18 @@ describe('ForumTopicPage', () => {
         userRank: { permissions: {} }
       } as never)
     );
-    mockUseGetPollByTopicQuery.mockReturnValue({
+    mockUseGetTopicSessionQuery.mockReturnValue({
       data: {
-        id: 6,
-        question: 'Format?',
-        answers: JSON.stringify(['CD', 'Vinyl']),
-        closed: true,
-        votes: []
-      }
+        ...defaultSession,
+        poll: {
+          id: 6,
+          question: 'Format?',
+          answers: JSON.stringify(['CD', 'Vinyl']),
+          closed: true,
+          votes: []
+        }
+      },
+      isLoading: false
     });
 
     renderWithProviders(<ForumTopicPage />, { store });
@@ -305,18 +317,24 @@ describe('ForumTopicPage', () => {
         userRank: { permissions: {} }
       } as never)
     );
-    mockUseGetTopicByIdQuery.mockReturnValue({
-      data: { id: 44, title: 'Locked topic', isLocked: true, isSticky: false },
-      isLoading: false
-    });
-    mockUseGetPollByTopicQuery.mockReturnValue({
+    mockUseGetTopicSessionQuery.mockReturnValue({
       data: {
-        id: 6,
-        question: 'Broken poll',
-        answers: '{bad json',
-        closed: false,
-        votes: []
-      }
+        ...defaultSession,
+        topic: { ...defaultSession.topic, isLocked: true },
+        poll: {
+          id: 6,
+          question: 'Broken poll',
+          answers: '{bad json',
+          closed: false,
+          votes: []
+        },
+        affordances: {
+          ...defaultSession.affordances,
+          canReply: false,
+          canModerate: false
+        }
+      },
+      isLoading: false
     });
 
     renderWithProviders(<ForumTopicPage />, { store });

--- a/src/components/forum/ForumTopicPage.tsx
+++ b/src/components/forum/ForumTopicPage.tsx
@@ -2,22 +2,15 @@ import { useEffect, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import {
-  useGetTopicByIdQuery,
-  useGetPostsByTopicQuery,
-  useGetForumByIdQuery,
+  useGetTopicSessionQuery,
   useMarkTopicReadMutation,
-  useGetPollByTopicQuery,
   useVotePollMutation,
   useUpdateTopicMutation,
   useTrashTopicMutation,
   useCatchupForumMutation
 } from '../../store/services/forumApi';
-import {
-  useGetSubscriptionsQuery,
-  useSubscribeMutation
-} from '../../store/services/subscriptionApi';
+import { useSubscribeMutation } from '../../store/services/subscriptionApi';
 import { selectCurrentUser } from '../../store/slices/authSlice';
-import { hasAnyPermission } from '../../utils/permissions';
 import Spinner from '../layout/Spinner';
 import PostBox from '../layout/PostBox';
 import ForumTopicPost from './ForumTopicPost';
@@ -31,51 +24,38 @@ const ForumTopicPage = () => {
   }>();
   const fId = parseInt(forumId ?? '0');
   const tId = parseInt(forumTopicId ?? '0');
+  const navigate = useNavigate();
   const currentUser = useSelector(selectCurrentUser);
 
-  const { data: forum } = useGetForumByIdQuery(fId);
-  const { data: topic, isLoading: topicLoading } = useGetTopicByIdQuery({
+  const { data: session, isLoading } = useGetTopicSessionQuery({
     forumId: fId,
     topicId: tId
   });
-  const { data: posts, isLoading: postsLoading } = useGetPostsByTopicQuery({
-    forumId: fId,
-    topicId: tId
-  });
-  const { data: poll } = useGetPollByTopicQuery(tId);
-  const { data: subscriptions } = useGetSubscriptionsQuery();
+
   const [markRead] = useMarkTopicReadMutation();
   const [votePoll, { isLoading: voting }] = useVotePollMutation();
   const [subscribe, { isLoading: subscribing }] = useSubscribeMutation();
   const [updateTopic, { isLoading: updatingTopic }] = useUpdateTopicMutation();
   const [trashTopic, { isLoading: trashing }] = useTrashTopicMutation();
-  const navigate = useNavigate();
+  const [catchupForum] = useCatchupForumMutation();
 
   const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
   const [quoteText, setQuoteText] = useState('');
 
-  const [catchupForum] = useCatchupForumMutation();
-
-  const isSubscribed = subscriptions?.some((s) => s.topicId === tId) ?? false;
-  const canModerate = hasAnyPermission(currentUser, [
-    'forums_moderate',
-    'forums_manage',
-    'staff',
-    'admin'
-  ]);
-
+  // Mark the last visible post as read whenever the posts list refreshes.
   useEffect(() => {
-    if (posts?.data?.length) {
-      markRead({
-        forumTopicId: tId,
-        forumPostId: posts.data[posts.data.length - 1].id
-      });
+    const lastPostId = session?.readState.lastVisiblePostId;
+    if (lastPostId != null) {
+      markRead({ forumTopicId: tId, forumPostId: lastPostId });
     }
-  }, [posts, tId, markRead]);
+  }, [session?.readState.lastVisiblePostId, tId, markRead]);
 
-  if (topicLoading || postsLoading) return <Spinner />;
-  if (!topic) return <div className="p-4 text-red-400">Topic not found.</div>;
+  if (isLoading) return <Spinner />;
+  if (!session) return <div className="p-4 text-red-400">Topic not found.</div>;
 
+  const { forum, topic, posts, poll, subscription, affordances } = session;
+
+  // Poll answer parsing
   let answers: string[] = [];
   let pollParseError = false;
   if (poll) {
@@ -88,7 +68,6 @@ const ForumTopicPage = () => {
 
   const myVote = poll?.votes.find((v) => v.userId === currentUser?.id);
   const totalVotes = poll?.votes.length ?? 0;
-
   const voteCounts = answers.map(
     (_, i) => poll?.votes.filter((v) => v.vote === i).length ?? 0
   );
@@ -113,6 +92,10 @@ const ForumTopicPage = () => {
     }
   };
 
+  // Show results when poll is closed or user has already voted (canVoteInPoll=false + poll exists)
+  const showPollResults =
+    !!poll && (!poll.closed ? !affordances.canVoteInPoll : true);
+
   return (
     <div>
       <nav className="text-sm text-gray-500 mb-4">
@@ -120,8 +103,8 @@ const ForumTopicPage = () => {
           Forums
         </Link>
         {' › '}
-        <Link to={`/private/forums/${forumId}`} className="hover:text-gray-300">
-          {forum?.name ?? 'Forum'}
+        <Link to={`/private/forums/${fId}`} className="hover:text-gray-300">
+          {forum.name}
         </Link>
         {' › '}
         <strong className="text-gray-200">{topic.title}</strong>
@@ -143,7 +126,7 @@ const ForumTopicPage = () => {
             )}
           </span>
           <div className="flex items-center gap-3">
-            {canModerate && (
+            {affordances.canModerate && (
               <>
                 <button
                   type="button"
@@ -188,13 +171,15 @@ const ForumTopicPage = () => {
               onClick={() =>
                 subscribe({
                   topicId: tId,
-                  action: isSubscribed ? 'unsubscribe' : 'subscribe'
+                  action: subscription.isSubscribed
+                    ? 'unsubscribe'
+                    : 'subscribe'
                 })
               }
               disabled={subscribing}
               className="text-xs text-gray-400 hover:text-gray-200"
             >
-              {isSubscribed ? 'Unsubscribe' : 'Subscribe'}
+              {subscription.isSubscribed ? 'Unsubscribe' : 'Subscribe'}
             </button>
             <button
               type="button"
@@ -216,7 +201,7 @@ const ForumTopicPage = () => {
       {poll && !pollParseError && answers.length > 0 && (
         <div className="rounded border border-gray-700 bg-gray-900 mb-4 p-4">
           <strong className="text-sm text-gray-200">{poll.question}</strong>
-          {myVote !== undefined || poll.closed ? (
+          {showPollResults ? (
             <table className="w-full text-sm mt-3">
               <tbody>
                 {answers.map((answer, i) => {
@@ -280,20 +265,20 @@ const ForumTopicPage = () => {
         </div>
       )}
 
-      {posts?.data?.map((post) => (
+      {posts.data.map((post) => (
         <ErrorBoundary key={post.id} FallbackComponent={FallbackComponent}>
           <ForumTopicPost
             post={post}
             forumId={fId}
             topicId={tId}
             currentUserId={currentUser?.id}
-            canModerate={canModerate}
+            canModerate={affordances.canModerate}
             onQuote={(text) => setQuoteText((prev) => prev + text)}
           />
         </ErrorBoundary>
       ))}
 
-      {(!topic.isLocked || canModerate) && (
+      {affordances.canReply && (
         <PostBox
           forumId={forumId!}
           topicId={forumTopicId!}

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -80,7 +80,8 @@ export const api = createApi({
     'ClientStats',
     'UserFlow',
     'SiteInfo',
-    'DevSeedRun'
+    'DevSeedRun',
+    'TopicSession'
   ] as const,
   endpoints: () => ({})
 });

--- a/src/store/services/forumApi.ts
+++ b/src/store/services/forumApi.ts
@@ -89,7 +89,11 @@ type MarkReadArgs = NonNullable<
 type MarkReadResponse =
   paths['/forums/last-read']['post']['responses'][200]['content']['application/json'];
 
-export type { CreateTopicArgs };
+type TopicSessionResponse =
+  paths['/forums/{forumId}/topics/{topicId}/session']['get']['responses'][200]['content']['application/json'];
+type TopicSessionArgs = { forumId: number; topicId: number; page?: number };
+
+export type { CreateTopicArgs, TopicSessionResponse };
 
 export const forumApi = api.injectEndpoints({
   endpoints: (build) => ({
@@ -171,6 +175,13 @@ export const forumApi = api.injectEndpoints({
         { type: 'ForumTopic', id: topicId }
       ]
     }),
+    getTopicSession: build.query<TopicSessionResponse, TopicSessionArgs>({
+      query: ({ forumId, topicId, page = 1 }) =>
+        `/forums/${forumId}/topics/${topicId}/session?page=${page}`,
+      providesTags: (_, __, { topicId }) => [
+        { type: 'TopicSession', id: topicId }
+      ]
+    }),
     createTopic: build.mutation<CreateTopicResponse, CreateTopicArgs>({
       query: ({ forumId, ...data }) => ({
         url: `/forums/${forumId}/topics`,
@@ -189,7 +200,8 @@ export const forumApi = api.injectEndpoints({
         body: data
       }),
       invalidatesTags: (_, __, { topicId }) => [
-        { type: 'ForumTopic', id: topicId }
+        { type: 'ForumTopic', id: topicId },
+        { type: 'TopicSession', id: topicId }
       ]
     }),
     deleteTopic: build.mutation<void, TopicArgs>({
@@ -197,9 +209,10 @@ export const forumApi = api.injectEndpoints({
         url: `/forums/${forumId}/topics/${topicId}`,
         method: 'DELETE'
       }),
-      invalidatesTags: (_, __, { forumId }) => [
+      invalidatesTags: (_, __, { forumId, topicId }) => [
         { type: 'Forum', id: forumId },
-        'ForumTopic'
+        'ForumTopic',
+        { type: 'TopicSession', id: topicId }
       ]
     }),
     trashTopic: build.mutation<TrashTopicResponse, TopicArgs>({
@@ -207,9 +220,10 @@ export const forumApi = api.injectEndpoints({
         url: `/forums/${forumId}/topics/${topicId}/trash`,
         method: 'POST'
       }),
-      invalidatesTags: (_, __, { forumId }) => [
+      invalidatesTags: (_, __, { forumId, topicId }) => [
         { type: 'Forum', id: forumId },
-        'ForumTopic'
+        'ForumTopic',
+        { type: 'TopicSession', id: topicId }
       ]
     }),
 
@@ -230,7 +244,8 @@ export const forumApi = api.injectEndpoints({
       }),
       invalidatesTags: (_, __, { topicId, forumId }) => [
         { type: 'ForumPost', id: topicId },
-        { type: 'Forum', id: forumId }
+        { type: 'Forum', id: forumId },
+        { type: 'TopicSession', id: topicId }
       ]
     }),
     updatePost: build.mutation<UpdatePostResponse, UpdatePostArgs>({
@@ -263,7 +278,8 @@ export const forumApi = api.injectEndpoints({
         body: data
       }),
       invalidatesTags: (_, __, { topicId }) => [
-        { type: 'ForumTopic', id: topicId }
+        { type: 'ForumTopic', id: topicId },
+        { type: 'TopicSession', id: topicId }
       ]
     }),
 
@@ -274,7 +290,8 @@ export const forumApi = api.injectEndpoints({
         body: data
       }),
       invalidatesTags: (_, __, { forumTopicId }) => [
-        { type: 'ForumTopic', id: forumTopicId }
+        { type: 'ForumTopic', id: forumTopicId },
+        { type: 'TopicSession', id: forumTopicId }
       ]
     }),
 
@@ -305,6 +322,7 @@ export const {
   useDeleteForumMutation,
   useGetTopicsByForumQuery,
   useGetTopicByIdQuery,
+  useGetTopicSessionQuery,
   useCreateTopicMutation,
   useUpdateTopicMutation,
   useDeleteTopicMutation,

--- a/src/store/services/subscriptionApi.ts
+++ b/src/store/services/subscriptionApi.ts
@@ -26,7 +26,14 @@ export const subscriptionApi = api.injectEndpoints({
         method: 'POST',
         body: data
       }),
-      invalidatesTags: ['Subscription']
+      invalidatesTags: (_, __, args) => [
+        'Subscription',
+        // Invalidate the topic session so the page's subscription.isSubscribed
+        // field reflects the new state without a separate subscriptions fetch.
+        ...('topicId' in args && args.topicId != null
+          ? [{ type: 'TopicSession' as const, id: args.topicId }]
+          : [])
+      ]
     }),
     subscribeComments: build.mutation<void, SubscribeCommentsArgs>({
       query: (data) => ({

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -2550,6 +2550,64 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/forums/{forumId}/topics/{topicId}/session': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: string;
+        };
+        header?: never;
+        path: {
+          forumId: string;
+          topicId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Topic session view model (forum + topic + posts + poll + subscription + affordances) */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ForumTopicSession'];
+          };
+        };
+        /** @description Insufficient class */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Forum or topic not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/forums/{forumId}/topics/{topicId}': {
     parameters: {
       query?: never;
@@ -11456,6 +11514,36 @@ export interface components {
     PaginatedForumTopics: {
       data: components['schemas']['ForumTopic'][];
       meta: components['schemas']['PaginationMeta'];
+    };
+    ForumTopicSession: {
+      forum: {
+        id: number;
+        name: string;
+        forumCategoryId: number;
+        forumCategory?: {
+          id: number;
+          name: string;
+        } | null;
+      };
+      topic: components['schemas']['ForumTopic'];
+      posts: {
+        data: components['schemas']['ForumPost'][];
+        meta: components['schemas']['PaginationMeta'];
+      };
+      poll?: components['schemas']['ForumPoll'] & unknown;
+      subscription: {
+        isSubscribed: boolean;
+      };
+      affordances: {
+        canReply: boolean;
+        canModerate: boolean;
+        canVoteInPoll: boolean;
+        canSubscribe: boolean;
+        canCatchUp: boolean;
+      };
+      readState: {
+        lastVisiblePostId: number | null;
+      };
     };
     CommunityStaffMember: {
       id: number;


### PR DESCRIPTION
## Summary

Refactors `ForumTopicPage` from orchestrating five separate queries into consuming one `useGetTopicSessionQuery` that returns everything the page needs. Pairs with stellar-api #49.

## Changes

### `src/store/api.ts`
Adds `'TopicSession'` to the RTK Query tag registry.

### `src/store/services/forumApi.ts`
- Adds `getTopicSession` query: `GET /forums/:forumId/topics/:topicId/session`
- All topic/post/poll mutations now invalidate the `TopicSession` tag so the page re-fetches after any action:
  - `updateTopic`, `deleteTopic`, `trashTopic`, `createPost`, `votePoll`, `markTopicRead`

### `src/store/services/subscriptionApi.ts`
The `subscribe` mutation conditionally invalidates `{ type: 'TopicSession', id: topicId }` when `topicId` is present, so the subscribe/unsubscribe button reflects the new state without a separate fetch.

### `src/components/forum/ForumTopicPage.tsx`
Replaces five separate queries (`useGetForumByIdQuery`, `useGetTopicByIdQuery`, `useGetPostsByTopicQuery`, `useGetPollByTopicQuery`, `useGetSubscriptionsQuery`) with one `useGetTopicSessionQuery`. The page renders from:
- `session.forum` — breadcrumb
- `session.topic` — title, locked/sticky badges
- `session.posts` — paginated post list
- `session.poll` — poll widget (open/closed/voted state)
- `session.subscription` — subscribe button state
- `session.affordances` — reply box, moderation controls, vote eligibility
- `session.readState.lastVisiblePostId` — mark-read side effect

Moderation gating (`canModerate`) and reply eligibility (`canReply`) now come from server-provided affordances rather than local permission checks.

### `src/types/api.ts`
Regenerated to include the `ForumTopicSession` schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)