### PR TITLE
Fix user journey bugs (walkthrough pass 1 & 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,10 +104,15 @@ The 14 valid backend permissions: `forums_read`, `forums_post`, `forums_moderate
 
 ## Commit workflow
 
-1. `npx tsc --noEmit` — must be clean
-2. `npx prettier --write <changed files>`
-3. Commit with descriptive message following existing log style
-4. Push to current branch
+Run every step before committing. All must pass clean on new/changed files.
+
+1. `npm run format` — format **all** of `src/` (not just changed files — confirms nothing else drifted)
+2. `npm run lint` — must be clean on new/changed files; pre-existing errors in untouched files are acceptable
+3. `npx tsc --noEmit` — must be clean
+4. `npm run test --no-coverage` — full suite must pass
+5. Commit with descriptive message following existing log style
+
+> Order matters: format before lint (Prettier violations are ESLint errors), and lint before type-check.
 
 ## Audit history
 

--- a/src/__tests__/admin/ForumControlPanel.test.tsx
+++ b/src/__tests__/admin/ForumControlPanel.test.tsx
@@ -7,11 +7,15 @@ import ForumControlPanel from '../../components/admin/ForumControlPanel';
 const mockGetForumCategoriesQuery = jest.fn();
 const mockGetForumsQuery = jest.fn();
 const mockCreateForum = jest.fn();
+const mockUpdateForum = jest.fn();
+const mockDeleteForum = jest.fn();
 
 jest.mock('../../store/services/forumApi', () => ({
   useGetForumCategoriesQuery: () => mockGetForumCategoriesQuery(),
   useGetForumsQuery: () => mockGetForumsQuery(),
-  useCreateForumMutation: () => [mockCreateForum, { isLoading: false }]
+  useCreateForumMutation: () => [mockCreateForum, { isLoading: false }],
+  useUpdateForumMutation: () => [mockUpdateForum, { isLoading: false }],
+  useDeleteForumMutation: () => [mockDeleteForum]
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/src/__tests__/forum/ForumTopicPost.test.tsx
+++ b/src/__tests__/forum/ForumTopicPost.test.tsx
@@ -345,6 +345,24 @@ describe('ForumTopicPost', () => {
     expect(screen.getByText('2024-03-03T00:00:00Z')).toBeInTheDocument();
   });
 
+  it('does not show Last edited when editedAt equals createdAt (unedited post)', () => {
+    // Seed data sometimes sets lastEdit with editedAt === createdAt on unedited posts.
+    const postWithSameTimestamp = {
+      ...mockPost,
+      lastEdit: {
+        id: 1,
+        forumPostId: 7,
+        editorId: 10,
+        editedAt: mockPost.createdAt, // same as createdAt — post was never actually edited
+        editor: { id: 10, username: 'alice' }
+      }
+    };
+    renderWithProviders(
+      <ForumTopicPost post={postWithSameTimestamp} forumId={1} topicId={5} />
+    );
+    expect(screen.queryByText(/last edited by/i)).not.toBeInTheDocument();
+  });
+
   it('does not show edit history control to non-moderators', () => {
     renderWithProviders(
       <ForumTopicPost post={mockEditedPost} forumId={1} topicId={5} />

--- a/src/__tests__/profile/Settings.test.tsx
+++ b/src/__tests__/profile/Settings.test.tsx
@@ -490,7 +490,10 @@ describe('Settings', () => {
   it('pre-selects the radio button matching the saved paranoia level', async () => {
     const profile = makeProfile();
     profile.userSettings.paranoia = 2;
-    mockUseGetMyProfileQuery.mockReturnValue({ data: profile, isLoading: false });
+    mockUseGetMyProfileQuery.mockReturnValue({
+      data: profile,
+      isLoading: false
+    });
 
     const user = userEvent.setup();
     renderWithProviders(<Settings />);

--- a/src/__tests__/profile/Settings.test.tsx
+++ b/src/__tests__/profile/Settings.test.tsx
@@ -486,4 +486,19 @@ describe('Settings', () => {
     await user.click(screen.getByRole('button', { name: /security/i }));
     expect(document.querySelector('.animate-spin')).toBeInTheDocument();
   });
+
+  it('pre-selects the radio button matching the saved paranoia level', async () => {
+    const profile = makeProfile();
+    profile.userSettings.paranoia = 2;
+    mockUseGetMyProfileQuery.mockReturnValue({ data: profile, isLoading: false });
+
+    const user = userEvent.setup();
+    renderWithProviders(<Settings />);
+    await user.click(screen.getByRole('button', { name: /privacy/i }));
+
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    const checked = radios.find((r) => r.checked);
+    expect(checked).toBeDefined();
+    expect(checked?.value).toBe('2');
+  });
 });

--- a/src/__tests__/profile/UserProfile.integration.test.tsx
+++ b/src/__tests__/profile/UserProfile.integration.test.tsx
@@ -305,7 +305,7 @@ describe('UserProfile RTK Query integration', () => {
     });
     renderAs(STAFF_USER);
 
-    expect(await screen.findByText('Staff PMs')).toBeInTheDocument();
+    expect(await screen.findByText('Support Tickets')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument(); // total
     expect(screen.getByText('2')).toBeInTheDocument(); // unresolved
     expect(

--- a/src/__tests__/profile/UserProfile.test.tsx
+++ b/src/__tests__/profile/UserProfile.test.tsx
@@ -342,13 +342,14 @@ describe('UserProfile', () => {
     expect(screen.getByText('Elite')).toBeInTheDocument();
   });
 
-  it('renders formatCount fallback for unparseable BigInt string in stats', () => {
+  it('renders 0 B for unparseable byte stat string', () => {
     mockProfileData = {
       ...mockProfile,
       stats: { ...mockProfile.stats, contributed: 'not-a-valid-bigint' }
     } as never;
     renderWithProviders(<UserProfile />);
-    expect(screen.getByText('not-a-valid-bigint')).toBeInTheDocument();
+    // Falls through to formatBytes(NaN) which returns '0 B'
+    expect(screen.getAllByText('0 B').length).toBeGreaterThan(0);
   });
 
   it('renders Hidden when stats value is null', () => {
@@ -657,6 +658,7 @@ describe('UserProfile', () => {
     });
 
     it('dispatches danger alert when revoke donor fails', async () => {
+      mockProfileData = { ...mockProfile, isDonor: true } as never;
       mockRevokeDonor.mockReturnValue({ unwrap: () => Promise.reject({}) });
       const user = userEvent.setup();
       renderWithProviders(<UserProfile />);
@@ -728,6 +730,7 @@ describe('UserProfile', () => {
     });
 
     it('clicks Revoke donor status', async () => {
+      mockProfileData = { ...mockProfile, isDonor: true } as never;
       const user = userEvent.setup();
       renderWithProviders(<UserProfile />);
       await user.click(
@@ -897,7 +900,7 @@ describe('UserProfile', () => {
         staffPmOverview: { total: 0, unresolved: 0, recentConversations: [] }
       } as never;
       renderWithProviders(<UserProfile />);
-      expect(screen.getByText('Staff PMs')).toBeInTheDocument();
+      expect(screen.getByText('Support Tickets')).toBeInTheDocument();
     });
 
     it('renders unknown conversation status with fallback class', () => {
@@ -1145,5 +1148,20 @@ describe('UserProfile', () => {
     renderWithProviders(<UserProfile />);
     expect(screen.getByText('Kind of Blue')).toBeInTheDocument();
     expect(screen.getByText('Miles Davis')).toBeInTheDocument();
+  });
+
+  it('displays community stats requests with expanded labels not abbreviations', () => {
+    renderWithProviders(<UserProfile />);
+    // Should contain "created / filled" text, not single-letter abbreviations like "0c / 0f"
+    expect(screen.queryByText(/\dc\s*\/\s*\df/)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/created/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/filled/i).length).toBeGreaterThan(0);
+  });
+
+  it('displays community stats forums with expanded labels not abbreviations', () => {
+    renderWithProviders(<UserProfile />);
+    expect(screen.queryByText(/\dt\s*\/\s*\dp/)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/topics/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/posts/i).length).toBeGreaterThan(0);
   });
 });

--- a/src/__tests__/top10/TopReleasesPage.integration.test.tsx
+++ b/src/__tests__/top10/TopReleasesPage.integration.test.tsx
@@ -74,7 +74,7 @@ describe('TopReleasesPage RTK Query integration', () => {
     const fetchMock = global.fetch as jest.Mock;
     const initialRequest = fetchMock.mock.calls[0][0] as Request;
     expect(initialRequest.url).toContain(
-      '/api/top10/releases?type=day&limit=10'
+      '/api/top10/releases?type=overall&limit=10'
     );
     expect(initialRequest.method).toBe('GET');
 

--- a/src/__tests__/top10/TopReleasesPage.test.tsx
+++ b/src/__tests__/top10/TopReleasesPage.test.tsx
@@ -74,7 +74,7 @@ describe('TopReleasesPage', () => {
     expect(screen.getAllByText('jazz').length).toBeGreaterThan(0);
   });
 
-  it('queries with default type=day and limit=10', () => {
+  it('queries with default type=overall and limit=10', () => {
     mockUseGetTopReleasesQuery.mockReturnValue({
       data: { items: [] },
       isLoading: false,
@@ -82,7 +82,7 @@ describe('TopReleasesPage', () => {
     });
     renderWithProviders(<TopReleasesPage />);
     expect(mockUseGetTopReleasesQuery).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'day', limit: 10 })
+      expect.objectContaining({ type: 'overall', limit: 10 })
     );
   });
 

--- a/src/__tests__/utils/utils.test.ts
+++ b/src/__tests__/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { formatDate, readableTime, formatBytes } from '../../utils';
+import { formatDate, readableTime, formatBytes, ordinalSuffix } from '../../utils';
 
 describe('formatDate', () => {
   it('returns empty string for undefined input', () => {
@@ -53,6 +53,42 @@ describe('readableTime', () => {
     ).toISOString();
     const result = readableTime(twoMonthsAgo);
     expect(result).toMatch(/\d{4}/);
+  });
+});
+
+describe('ordinalSuffix', () => {
+  it('uses st for 1, 21, 31', () => {
+    expect(ordinalSuffix(1)).toBe('1st');
+    expect(ordinalSuffix(21)).toBe('21st');
+    expect(ordinalSuffix(31)).toBe('31st');
+  });
+
+  it('uses nd for 2, 22, 32', () => {
+    expect(ordinalSuffix(2)).toBe('2nd');
+    expect(ordinalSuffix(22)).toBe('22nd');
+  });
+
+  it('uses rd for 3, 23, 33', () => {
+    expect(ordinalSuffix(3)).toBe('3rd');
+    expect(ordinalSuffix(23)).toBe('23rd');
+  });
+
+  it('uses th for 4-20 (including teens)', () => {
+    expect(ordinalSuffix(4)).toBe('4th');
+    expect(ordinalSuffix(11)).toBe('11th');
+    expect(ordinalSuffix(12)).toBe('12th');
+    expect(ordinalSuffix(13)).toBe('13th');
+    expect(ordinalSuffix(20)).toBe('20th');
+  });
+
+  it('uses th for 111, 112, 113 (teen rule takes priority)', () => {
+    expect(ordinalSuffix(111)).toBe('111th');
+    expect(ordinalSuffix(112)).toBe('112th');
+    expect(ordinalSuffix(113)).toBe('113th');
+  });
+
+  it('handles 100th correctly', () => {
+    expect(ordinalSuffix(100)).toBe('100th');
   });
 });
 

--- a/src/__tests__/utils/utils.test.ts
+++ b/src/__tests__/utils/utils.test.ts
@@ -1,4 +1,9 @@
-import { formatDate, readableTime, formatBytes, ordinalSuffix } from '../../utils';
+import {
+  formatDate,
+  readableTime,
+  formatBytes,
+  ordinalSuffix
+} from '../../utils';
 
 describe('formatDate', () => {
   it('returns empty string for undefined input', () => {

--- a/src/components/admin/ForumControlPanel.tsx
+++ b/src/components/admin/ForumControlPanel.tsx
@@ -47,10 +47,14 @@ const ForumEditRow = ({ forum, onDone }: EditRowProps) => {
         <form onSubmit={handleSave} className="space-y-3">
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
             <div className="sm:col-span-2">
-              <label className="block text-xs text-gray-400 mb-0.5">
+              <label
+                htmlFor={`fe-name-${forum.id}`}
+                className="block text-xs text-gray-400 mb-0.5"
+              >
                 Name *
               </label>
               <input
+                id={`fe-name-${forum.id}`}
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -59,8 +63,14 @@ const ForumEditRow = ({ forum, onDone }: EditRowProps) => {
               />
             </div>
             <div>
-              <label className="block text-xs text-gray-400 mb-0.5">Sort</label>
+              <label
+                htmlFor={`fe-sort-${forum.id}`}
+                className="block text-xs text-gray-400 mb-0.5"
+              >
+                Sort
+              </label>
               <input
+                id={`fe-sort-${forum.id}`}
                 type="number"
                 value={sort}
                 onChange={(e) => setSort(e.target.value)}
@@ -68,10 +78,14 @@ const ForumEditRow = ({ forum, onDone }: EditRowProps) => {
               />
             </div>
             <div>
-              <label className="block text-xs text-gray-400 mb-0.5">
+              <label
+                htmlFor={`fe-minread-${forum.id}`}
+                className="block text-xs text-gray-400 mb-0.5"
+              >
                 Min read
               </label>
               <input
+                id={`fe-minread-${forum.id}`}
                 type="number"
                 value={minRead}
                 onChange={(e) => setMinRead(e.target.value)}
@@ -79,10 +93,14 @@ const ForumEditRow = ({ forum, onDone }: EditRowProps) => {
               />
             </div>
             <div className="sm:col-span-2">
-              <label className="block text-xs text-gray-400 mb-0.5">
+              <label
+                htmlFor={`fe-desc-${forum.id}`}
+                className="block text-xs text-gray-400 mb-0.5"
+              >
                 Description
               </label>
               <input
+                id={`fe-desc-${forum.id}`}
                 type="text"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
@@ -90,10 +108,14 @@ const ForumEditRow = ({ forum, onDone }: EditRowProps) => {
               />
             </div>
             <div>
-              <label className="block text-xs text-gray-400 mb-0.5">
+              <label
+                htmlFor={`fe-minwrite-${forum.id}`}
+                className="block text-xs text-gray-400 mb-0.5"
+              >
                 Min write
               </label>
               <input
+                id={`fe-minwrite-${forum.id}`}
                 type="number"
                 value={minWrite}
                 onChange={(e) => setMinWrite(e.target.value)}
@@ -101,10 +123,14 @@ const ForumEditRow = ({ forum, onDone }: EditRowProps) => {
               />
             </div>
             <div>
-              <label className="block text-xs text-gray-400 mb-0.5">
+              <label
+                htmlFor={`fe-mincreate-${forum.id}`}
+                className="block text-xs text-gray-400 mb-0.5"
+              >
                 Min create topics
               </label>
               <input
+                id={`fe-mincreate-${forum.id}`}
                 type="number"
                 value={minCreate}
                 onChange={(e) => setMinCreate(e.target.value)}

--- a/src/components/admin/ForumControlPanel.tsx
+++ b/src/components/admin/ForumControlPanel.tsx
@@ -3,9 +3,136 @@ import { Link } from 'react-router-dom';
 import {
   useGetForumCategoriesQuery,
   useGetForumsQuery,
-  useCreateForumMutation
+  useCreateForumMutation,
+  useUpdateForumMutation,
+  useDeleteForumMutation
 } from '../../store/services/forumApi';
+import type { Forum } from '../../types';
 import Spinner from '../layout/Spinner';
+
+const inputCls =
+  'rounded bg-gray-700 border border-gray-600 text-white px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500';
+
+interface EditRowProps {
+  forum: Forum;
+  onDone: () => void;
+}
+
+const ForumEditRow = ({ forum, onDone }: EditRowProps) => {
+  const [updateForum, { isLoading }] = useUpdateForumMutation();
+  const [name, setName] = useState(forum.name);
+  const [description, setDescription] = useState(forum.description ?? '');
+  const [sort, setSort] = useState(String(forum.sort ?? 0));
+  const [minRead, setMinRead] = useState(String(forum.minClassRead ?? 0));
+  const [minWrite, setMinWrite] = useState(String(forum.minClassWrite ?? 0));
+  const [minCreate, setMinCreate] = useState(String(forum.minClassCreate ?? 0));
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await updateForum({
+      id: forum.id,
+      name,
+      description,
+      sort: parseInt(sort) || 0,
+      minClassRead: parseInt(minRead) || 0,
+      minClassWrite: parseInt(minWrite) || 0,
+      minClassCreate: parseInt(minCreate) || 0
+    });
+    onDone();
+  };
+
+  return (
+    <tr className="bg-indigo-950/30 border-t border-indigo-800/40">
+      <td colSpan={6} className="px-4 py-3">
+        <form onSubmit={handleSave} className="space-y-3">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            <div className="sm:col-span-2">
+              <label className="block text-xs text-gray-400 mb-0.5">
+                Name *
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                className={`${inputCls} w-full`}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-400 mb-0.5">Sort</label>
+              <input
+                type="number"
+                value={sort}
+                onChange={(e) => setSort(e.target.value)}
+                className={`${inputCls} w-full`}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-400 mb-0.5">
+                Min read
+              </label>
+              <input
+                type="number"
+                value={minRead}
+                onChange={(e) => setMinRead(e.target.value)}
+                className={`${inputCls} w-full`}
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs text-gray-400 mb-0.5">
+                Description
+              </label>
+              <input
+                type="text"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                className={`${inputCls} w-full`}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-400 mb-0.5">
+                Min write
+              </label>
+              <input
+                type="number"
+                value={minWrite}
+                onChange={(e) => setMinWrite(e.target.value)}
+                className={`${inputCls} w-full`}
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-400 mb-0.5">
+                Min create topics
+              </label>
+              <input
+                type="number"
+                value={minCreate}
+                onChange={(e) => setMinCreate(e.target.value)}
+                className={`${inputCls} w-full`}
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="px-3 py-1 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white text-xs rounded"
+            >
+              {isLoading ? 'Saving…' : 'Save'}
+            </button>
+            <button
+              type="button"
+              onClick={onDone}
+              className="px-3 py-1 text-gray-400 hover:text-white text-xs"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </td>
+    </tr>
+  );
+};
 
 const ForumControlPanel = () => {
   const {
@@ -19,6 +146,9 @@ const ForumControlPanel = () => {
     error: forumsError
   } = useGetForumsQuery();
   const [createForum, { isLoading: isCreating }] = useCreateForumMutation();
+  const [deleteForum] = useDeleteForumMutation();
+
+  const [editingId, setEditingId] = useState<number | null>(null);
 
   const [categoryId, setCategoryId] = useState('');
   const [name, setName] = useState('');
@@ -27,6 +157,11 @@ const ForumControlPanel = () => {
   const [minClassRead, setMinClassRead] = useState('');
   const [minClassWrite, setMinClassWrite] = useState('');
   const [minClassCreate, setMinClassCreate] = useState('');
+
+  const handleDelete = async (id: number, forumName: string) => {
+    if (!confirm(`Delete forum "${forumName}"? This cannot be undone.`)) return;
+    await deleteForum(id);
+  };
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -80,13 +215,14 @@ const ForumControlPanel = () => {
                 <th className="text-right px-4 py-2 font-semibold">Sort</th>
                 <th className="text-right px-4 py-2 font-semibold">Topics</th>
                 <th className="text-right px-4 py-2 font-semibold">Posts</th>
+                <th className="px-4 py-2 font-semibold"></th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-700/50">
               {!forums?.length ? (
                 <tr>
                   <td
-                    colSpan={5}
+                    colSpan={6}
                     className="px-4 py-6 text-center text-gray-500"
                   >
                     No forums yet.
@@ -94,31 +230,58 @@ const ForumControlPanel = () => {
                 </tr>
               ) : (
                 forums.map((f) => (
-                  <tr
-                    key={f.id}
-                    className="hover:bg-gray-700/30 transition-colors"
-                  >
-                    <td className="px-4 py-2 text-gray-200 font-medium">
-                      <Link
-                        to={`/private/forums/${f.id}`}
-                        className="hover:text-indigo-300 transition-colors"
-                      >
-                        {f.name}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2 text-gray-400">
-                      {f.forumCategory?.name ?? '—'}
-                    </td>
-                    <td className="px-4 py-2 text-gray-400 text-right">
-                      {f.sort}
-                    </td>
-                    <td className="px-4 py-2 text-gray-400 text-right">
-                      {f.numTopics}
-                    </td>
-                    <td className="px-4 py-2 text-gray-400 text-right">
-                      {f.numPosts}
-                    </td>
-                  </tr>
+                  <>
+                    <tr
+                      key={f.id}
+                      className="hover:bg-gray-700/30 transition-colors"
+                    >
+                      <td className="px-4 py-2 text-gray-200 font-medium">
+                        <Link
+                          to={`/private/forums/${f.id}`}
+                          className="hover:text-indigo-300 transition-colors"
+                        >
+                          {f.name}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2 text-gray-400">
+                        {f.forumCategory?.name ?? '—'}
+                      </td>
+                      <td className="px-4 py-2 text-gray-400 text-right">
+                        {f.sort}
+                      </td>
+                      <td className="px-4 py-2 text-gray-400 text-right">
+                        {f.numTopics}
+                      </td>
+                      <td className="px-4 py-2 text-gray-400 text-right">
+                        {f.numPosts}
+                      </td>
+                      <td className="px-4 py-2 text-right whitespace-nowrap">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setEditingId(editingId === f.id ? null : f.id)
+                          }
+                          className="text-xs text-indigo-400 hover:text-indigo-300 mr-3"
+                        >
+                          {editingId === f.id ? 'Cancel' : 'Edit'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(f.id, f.name)}
+                          className="text-xs text-red-400 hover:text-red-300"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                    {editingId === f.id && (
+                      <ForumEditRow
+                        key={`edit-${f.id}`}
+                        forum={f}
+                        onDone={() => setEditingId(null)}
+                      />
+                    )}
+                  </>
                 ))
               )}
             </tbody>

--- a/src/components/admin/RulesManager.tsx
+++ b/src/components/admin/RulesManager.tsx
@@ -121,10 +121,14 @@ const SubPageEditForm = ({
         className={`${inputClass} w-full font-mono`}
       />
       <div className="flex items-center gap-3">
-        <label className="text-sm text-gray-400 whitespace-nowrap">
+        <label
+          htmlFor={`spe-sort-${page.id}`}
+          className="text-sm text-gray-400 whitespace-nowrap"
+        >
           Sort order
         </label>
         <input
+          id={`spe-sort-${page.id}`}
           type="number"
           min={0}
           value={sortOrder}

--- a/src/components/admin/RulesManager.tsx
+++ b/src/components/admin/RulesManager.tsx
@@ -70,6 +70,88 @@ const MainPageEditor = ({ page }: { page: RulesPage | null }) => {
   );
 };
 
+const SubPageEditForm = ({
+  page,
+  onDone
+}: {
+  page: RulesPage;
+  onDone: () => void;
+}) => {
+  const dispatch = useDispatch();
+  const [updatePage, { isLoading }] = useUpdateRulesPageMutation();
+  const [title, setTitle] = useState(page.title);
+  const [body, setBody] = useState(page.body);
+  const [sortOrder, setSortOrder] = useState(page.sortOrder ?? 0);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await updatePage({ id: page.id, title, body, sortOrder }).unwrap();
+      dispatch(addAlert('Sub-page updated.', 'success'));
+      onDone();
+    } catch (err) {
+      dispatch(
+        addAlert(getApiErrorMessage(err) ?? 'Failed to update.', 'danger')
+      );
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="p-4 border-t border-gray-700 space-y-3 bg-indigo-950/20"
+    >
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-400">
+        Edit: {page.title}
+      </h4>
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Title"
+        required
+        className={`${inputClass} w-full`}
+      />
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Body"
+        rows={8}
+        required
+        className={`${inputClass} w-full font-mono`}
+      />
+      <div className="flex items-center gap-3">
+        <label className="text-sm text-gray-400 whitespace-nowrap">
+          Sort order
+        </label>
+        <input
+          type="number"
+          min={0}
+          value={sortOrder}
+          onChange={(e) => setSortOrder(Number(e.target.value))}
+          className={`${inputClass} w-24`}
+        />
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white px-4 py-2 rounded text-sm font-medium transition-colors"
+        >
+          {isLoading ? 'Saving…' : 'Save Changes'}
+        </button>
+        <button
+          type="button"
+          onClick={onDone}
+          className="text-gray-400 hover:text-gray-200 px-4 py-2 rounded text-sm transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};
+
 const SubPageForm = ({ onDone }: { onDone: () => void }) => {
   const dispatch = useDispatch();
   const [createPage, { isLoading }] = useCreateRulesPageMutation();
@@ -159,6 +241,7 @@ const RulesManager = () => {
   const dispatch = useDispatch();
   const [deletePage] = useDeleteRulesPageMutation();
   const [showNewForm, setShowNewForm] = useState(false);
+  const [editingPageId, setEditingPageId] = useState<number | null>(null);
 
   const handleDelete = async (id: number, title: string) => {
     if (!confirm(`Delete "${title}"? This cannot be undone.`)) return;
@@ -245,34 +328,57 @@ const RulesManager = () => {
                 </tr>
               ) : (
                 data.pages.map((page) => (
-                  <tr
-                    key={page.id}
-                    className="hover:bg-gray-700/30 transition-colors"
-                  >
-                    <td className="px-4 py-2 text-gray-200 font-medium">
-                      <Link
-                        to={`/private/rules/${page.slug}`}
-                        className="hover:text-indigo-400 transition-colors"
-                      >
-                        {page.title}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2 text-gray-400 font-mono text-xs">
-                      {page.slug}
-                    </td>
-                    <td className="px-4 py-2 text-gray-400">
-                      {page.sortOrder}
-                    </td>
-                    <td className="px-4 py-2 text-center">
-                      <button
-                        type="button"
-                        onClick={() => handleDelete(page.id, page.title)}
-                        className="text-red-400 hover:text-red-300 transition-colors text-sm"
-                      >
-                        Delete
-                      </button>
-                    </td>
-                  </tr>
+                  <>
+                    <tr
+                      key={page.id}
+                      className="hover:bg-gray-700/30 transition-colors"
+                    >
+                      <td className="px-4 py-2 text-gray-200 font-medium">
+                        <Link
+                          to={`/private/rules/${page.slug}`}
+                          className="hover:text-indigo-400 transition-colors"
+                        >
+                          {page.title}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2 text-gray-400 font-mono text-xs">
+                        {page.slug}
+                      </td>
+                      <td className="px-4 py-2 text-gray-400">
+                        {page.sortOrder}
+                      </td>
+                      <td className="px-4 py-2 text-right whitespace-nowrap">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setEditingPageId(
+                              editingPageId === page.id ? null : page.id
+                            )
+                          }
+                          className="text-indigo-400 hover:text-indigo-300 transition-colors text-sm mr-3"
+                        >
+                          {editingPageId === page.id ? 'Cancel' : 'Edit'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(page.id, page.title)}
+                          className="text-red-400 hover:text-red-300 transition-colors text-sm"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                    {editingPageId === page.id && (
+                      <tr key={`edit-${page.id}`}>
+                        <td colSpan={4} className="p-0">
+                          <SubPageEditForm
+                            page={page}
+                            onDone={() => setEditingPageId(null)}
+                          />
+                        </td>
+                      </tr>
+                    )}
+                  </>
                 ))
               )}
             </tbody>

--- a/src/components/admin/SiteSettingsPage.tsx
+++ b/src/components/admin/SiteSettingsPage.tsx
@@ -114,7 +114,7 @@ const SiteSettingsPage = () => {
             htmlFor="approved-domains"
             className="block text-sm text-gray-400 mb-1"
           >
-            Approved download domains{' '}
+            Approved contribution link domains{' '}
             <span className="text-gray-600 text-xs">(optional)</span>
           </label>
           <textarea

--- a/src/components/collages/CollageBrowse.tsx
+++ b/src/components/collages/CollageBrowse.tsx
@@ -6,6 +6,8 @@ import type { CollageOrderBy } from '../../types';
 import Spinner from '../layout/Spinner';
 import { selectCurrentUser } from '../../store/slices/authSlice';
 import { hasPermission } from '../../utils/permissions';
+import { parseBBCode } from '../../utils/bbcode';
+import DOMPurify from 'dompurify';
 
 const CATEGORIES = [
   { id: undefined, label: 'All' },
@@ -145,9 +147,12 @@ const CollageBrowse = () => {
                     </span>
                   )}
                 </div>
-                <p className="text-xs text-gray-400 line-clamp-1">
-                  {c.description}
-                </p>
+                <div
+                  className="text-xs text-gray-400 line-clamp-2 bbcode-content"
+                  dangerouslySetInnerHTML={{
+                    __html: DOMPurify.sanitize(parseBBCode(c.description))
+                  }}
+                />
                 {c.tags.length > 0 && (
                   <div className="flex gap-1 mt-1 flex-wrap">
                     {c.tags.map((tag) => (

--- a/src/components/forum/ForumTopicPage.tsx
+++ b/src/components/forum/ForumTopicPage.tsx
@@ -102,6 +102,12 @@ const ForumTopicPage = () => {
         <Link to="/private/forums" className="hover:text-gray-300">
           Forums
         </Link>
+        {forum.forumCategory && (
+          <>
+            {' › '}
+            <span>{forum.forumCategory.name}</span>
+          </>
+        )}
         {' › '}
         <Link to={`/private/forums/${fId}`} className="hover:text-gray-300">
           {forum.name}

--- a/src/components/forum/ForumTopicPost.tsx
+++ b/src/components/forum/ForumTopicPost.tsx
@@ -182,79 +182,79 @@ const ForumTopicPost = ({
         !editing &&
         new Date(lastEdit.editedAt).getTime() !==
           new Date(createdAt).getTime() && (
-        <div className="px-4 pb-4">
-          <div className="text-xs text-gray-500">
-            Last edited by{' '}
-            {lastEdit.editor ? (
-              <Link
-                to={`/private/user/${lastEdit.editor.username}`}
-                className="text-gray-400 hover:text-gray-200"
-              >
-                {lastEdit.editor.username}
-              </Link>
-            ) : (
-              'Unknown'
-            )}{' '}
-            <Time date={lastEdit.editedAt} />
-          </div>
-
-          {canModerate && (
-            <div className="mt-2">
-              <button
-                type="button"
-                onClick={toggleEditHistory}
-                className="text-xs text-gray-400 hover:text-gray-200"
-              >
-                {showEditHistory ? 'Hide edit history' : 'View edit history'}
-              </button>
-
-              {showEditHistory && (
-                <div className="mt-3 space-y-3 rounded border border-gray-800 bg-gray-950/60 p-3">
-                  {loadingEditHistory && (
-                    <div className="text-xs text-gray-500">
-                      Loading edit history…
-                    </div>
-                  )}
-                  {!loadingEditHistory && renderedEdits.length === 0 && (
-                    <div className="text-xs text-gray-500">
-                      No edit history available.
-                    </div>
-                  )}
-                  {!loadingEditHistory &&
-                    renderedEdits.map((edit, index) => (
-                      <div
-                        key={edit.id}
-                        className={
-                          index === renderedEdits.length - 1
-                            ? ''
-                            : 'border-b border-gray-800 pb-3'
-                        }
-                      >
-                        <div className="mb-2 text-xs text-gray-500">
-                          Edited by{' '}
-                          {edit.editor ? (
-                            <Link
-                              to={`/private/user/${edit.editor.username}`}
-                              className="text-gray-400 hover:text-gray-200"
-                            >
-                              {edit.editor.username}
-                            </Link>
-                          ) : (
-                            'Unknown'
-                          )}{' '}
-                          <Time date={edit.editedAt} />
-                        </div>
-                        <pre className="whitespace-pre-wrap break-words rounded bg-gray-900/80 p-3 text-sm text-gray-300">
-                          {edit.previousBody}
-                        </pre>
-                      </div>
-                    ))}
-                </div>
-              )}
+          <div className="px-4 pb-4">
+            <div className="text-xs text-gray-500">
+              Last edited by{' '}
+              {lastEdit.editor ? (
+                <Link
+                  to={`/private/user/${lastEdit.editor.username}`}
+                  className="text-gray-400 hover:text-gray-200"
+                >
+                  {lastEdit.editor.username}
+                </Link>
+              ) : (
+                'Unknown'
+              )}{' '}
+              <Time date={lastEdit.editedAt} />
             </div>
-          )}
-        </div>
-      )}
+
+            {canModerate && (
+              <div className="mt-2">
+                <button
+                  type="button"
+                  onClick={toggleEditHistory}
+                  className="text-xs text-gray-400 hover:text-gray-200"
+                >
+                  {showEditHistory ? 'Hide edit history' : 'View edit history'}
+                </button>
+
+                {showEditHistory && (
+                  <div className="mt-3 space-y-3 rounded border border-gray-800 bg-gray-950/60 p-3">
+                    {loadingEditHistory && (
+                      <div className="text-xs text-gray-500">
+                        Loading edit history…
+                      </div>
+                    )}
+                    {!loadingEditHistory && renderedEdits.length === 0 && (
+                      <div className="text-xs text-gray-500">
+                        No edit history available.
+                      </div>
+                    )}
+                    {!loadingEditHistory &&
+                      renderedEdits.map((edit, index) => (
+                        <div
+                          key={edit.id}
+                          className={
+                            index === renderedEdits.length - 1
+                              ? ''
+                              : 'border-b border-gray-800 pb-3'
+                          }
+                        >
+                          <div className="mb-2 text-xs text-gray-500">
+                            Edited by{' '}
+                            {edit.editor ? (
+                              <Link
+                                to={`/private/user/${edit.editor.username}`}
+                                className="text-gray-400 hover:text-gray-200"
+                              >
+                                {edit.editor.username}
+                              </Link>
+                            ) : (
+                              'Unknown'
+                            )}{' '}
+                            <Time date={edit.editedAt} />
+                          </div>
+                          <pre className="whitespace-pre-wrap break-words rounded bg-gray-900/80 p-3 text-sm text-gray-300">
+                            {edit.previousBody}
+                          </pre>
+                        </div>
+                      ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
     </div>
   );
 };

--- a/src/components/forum/ForumTopicPost.tsx
+++ b/src/components/forum/ForumTopicPost.tsx
@@ -178,7 +178,10 @@ const ForumTopicPost = ({
         </div>
       )}
 
-      {lastEdit && !editing && (
+      {lastEdit &&
+        !editing &&
+        new Date(lastEdit.editedAt).getTime() !==
+          new Date(createdAt).getTime() && (
         <div className="px-4 pb-4">
           <div className="text-xs text-gray-500">
             Last edited by{' '}

--- a/src/components/pages/private/PrivateHomepage.tsx
+++ b/src/components/pages/private/PrivateHomepage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { selectCurrentUser } from '../../../store/slices/authSlice';
 import { useGetAnnouncementsQuery } from '../../../store/services/announcementApi';
@@ -6,6 +7,7 @@ import { useGetSiteStatsQuery } from '../../../store/services/siteApi';
 import { Link } from 'react-router-dom';
 import Time from '../../layout/Time';
 import Spinner from '../../layout/Spinner';
+import DOMPurify from 'dompurify';
 
 const StatRow = ({
   label,
@@ -25,6 +27,7 @@ const PrivateHomepage = () => {
   const { data: announcements, isLoading } = useGetAnnouncementsQuery();
   const { data: stats } = useGetSiteStatsQuery();
   const { data: featured } = useGetHomepageFeaturedQuery();
+  const [expandedAnnouncement, setExpandedAnnouncement] = useState<number | null>(null);
 
   const blogPosts = announcements?.blogPosts ?? [];
   const aotm = featured?.albumOfTheMonth;
@@ -59,16 +62,34 @@ const PrivateHomepage = () => {
                 <p className="p-4 text-sm text-gray-500">No announcements.</p>
               ) : (
                 announcements.announcements.map((n) => (
-                  <div
-                    key={n.id}
-                    className="flex items-center justify-between px-4 py-3 hover:bg-gray-700/30 transition-colors"
-                  >
-                    <span className="font-medium text-gray-200 text-sm">
-                      {n.title}
-                    </span>
-                    <span className="text-xs text-gray-500 shrink-0 ml-4">
-                      <Time date={n.createdAt} />
-                    </span>
+                  <div key={n.id}>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setExpandedAnnouncement(
+                          expandedAnnouncement === n.id ? null : n.id
+                        )
+                      }
+                      className="w-full flex items-center justify-between px-4 py-3 hover:bg-gray-700/30 transition-colors text-left"
+                    >
+                      <span className="font-medium text-gray-200 text-sm">
+                        {n.title}
+                      </span>
+                      <span className="text-xs text-gray-500 shrink-0 ml-4 flex items-center gap-2">
+                        <Time date={n.createdAt} />
+                        <span className="text-gray-600">
+                          {expandedAnnouncement === n.id ? '▲' : '▼'}
+                        </span>
+                      </span>
+                    </button>
+                    {expandedAnnouncement === n.id && n.body && (
+                      <div
+                        className="px-4 pb-4 text-sm text-gray-300 border-t border-gray-700/50"
+                        dangerouslySetInnerHTML={{
+                          __html: DOMPurify.sanitize(n.body)
+                        }}
+                      />
+                    )}
                   </div>
                 ))
               )}

--- a/src/components/pages/private/PrivateHomepage.tsx
+++ b/src/components/pages/private/PrivateHomepage.tsx
@@ -27,7 +27,9 @@ const PrivateHomepage = () => {
   const { data: announcements, isLoading } = useGetAnnouncementsQuery();
   const { data: stats } = useGetSiteStatsQuery();
   const { data: featured } = useGetHomepageFeaturedQuery();
-  const [expandedAnnouncement, setExpandedAnnouncement] = useState<number | null>(null);
+  const [expandedAnnouncement, setExpandedAnnouncement] = useState<
+    number | null
+  >(null);
 
   const blogPosts = announcements?.blogPosts ?? [];
   const aotm = featured?.albumOfTheMonth;

--- a/src/components/pages/public/PublicLanding.tsx
+++ b/src/components/pages/public/PublicLanding.tsx
@@ -17,7 +17,7 @@ const PublicLanding = () => {
       <div className="landing-hero">
         <h1>Stellar</h1>
         <p className="lead">A curated community for music and media.</p>
-        <div className="landing-actions">
+        <div className="landing-actions flex gap-3">
           <Link to="/login" className="btn btn-primary">
             Sign In
           </Link>

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
+import { formatBytes, ordinalSuffix } from '../../utils';
 import DOMPurify from 'dompurify';
 import {
   useGetMyRatioStatsQuery,
@@ -51,17 +52,17 @@ const COLLAGE_CATEGORY_LABELS: Record<number, string> = {
   6: 'Other'
 };
 
-const formatCount = (value: number | string | null | undefined) => {
+const formatByteStat = (value: number | string | null | undefined) => {
   if (value === null || value === undefined) return 'Hidden';
-  if (typeof value === 'number') return value.toLocaleString();
   try {
-    return BigInt(value).toLocaleString();
+    return formatBytes(Number(BigInt(String(value))));
   } catch {
-    return value;
+    return formatBytes(Number(value));
   }
 };
 
-const formatPercentile = (percentile: number) => `${percentile}th percentile`;
+const formatPercentile = (percentile: number) =>
+  `${ordinalSuffix(percentile)} percentile`;
 
 const STAFF_PM_STATUS_CLASS: Record<string, string> = {
   Unanswered: 'bg-yellow-900/40 text-yellow-300 border border-yellow-800/50',
@@ -451,7 +452,7 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
 
           {staffPmOverview && (
             <div className={sectionClass}>
-              <div className={headClass}>Staff PMs</div>
+              <div className={headClass}>Support Tickets</div>
               <div className={`${bodyClass} space-y-3`}>
                 <div className="grid gap-2 sm:grid-cols-2">
                   <div className="rounded border border-gray-800 bg-gray-950 px-3 py-2 text-xs">
@@ -634,13 +635,15 @@ const StaffActionsPanel = ({ profileId }: { profileId: number }) => {
                   {isGrantingDonor ? 'Granting…' : 'Grant'}
                 </button>
               </div>
-              <button
-                onClick={handleRevokeDonor}
-                disabled={isRevokingDonor}
-                className="text-xs text-red-500 hover:text-red-400 disabled:opacity-50"
-              >
-                Revoke donor status
-              </button>
+              {profile?.isDonor && (
+                <button
+                  onClick={handleRevokeDonor}
+                  disabled={isRevokingDonor}
+                  className="text-xs text-red-500 hover:text-red-400 disabled:opacity-50"
+                >
+                  Revoke donor status
+                </button>
+              )}
             </div>
           </div>
           {/* Snatch list */}
@@ -916,13 +919,15 @@ const UserProfile = () => {
   const { id } = useParams<{ id: string }>();
   const currentUser = useSelector(selectCurrentUser);
   const { data: profile, isLoading, error } = useGetProfileByUserIdQuery(id!);
-  const isOwnProfile = currentUser?.id === Number(id);
+  // id may be a username string, so derive isOwnProfile from the loaded profile's id
+  const isOwnProfile =
+    !!currentUser && !!profile && currentUser.id === profile.id;
   const { data: myRatioStats } = useGetMyRatioStatsQuery(undefined, {
     skip: !isOwnProfile
   });
   const dispatch = useDispatch();
-  const { data: friendStatus } = useGetFriendStatusQuery(Number(id), {
-    skip: isOwnProfile || !currentUser
+  const { data: friendStatus } = useGetFriendStatusQuery(profile?.id ?? 0, {
+    skip: !profile || isOwnProfile || !currentUser
   });
   const [addFriend] = useAddFriendMutation();
   const [removeFriend] = useRemoveFriendMutation();
@@ -1305,7 +1310,7 @@ const UserProfile = () => {
           <div className="rounded border border-gray-700 bg-gray-900 overflow-hidden">
             <div className="bg-gray-800 border-b border-gray-700 px-4 py-2">
               <span className="text-sm font-semibold text-gray-200">
-                Recent Uploads
+                Recent Contributions
               </span>
             </div>
             {profile.recentContributions.length ? (
@@ -1461,11 +1466,11 @@ const UserProfile = () => {
               {profileIsDonor && <li className="text-pink-400">Donor ♥</li>}
               <li>
                 <span className="text-gray-500">Contributed:</span>{' '}
-                {formatCount(profileStats.contributed)}
+                {formatByteStat(profileStats.contributed)}
               </li>
               <li>
                 <span className="text-gray-500">Consumed:</span>{' '}
-                {formatCount(profileStats.consumed)}
+                {formatByteStat(profileStats.consumed)}
               </li>
               <li>
                 <span className="text-gray-500">Ratio:</span>{' '}
@@ -1473,7 +1478,7 @@ const UserProfile = () => {
               </li>
               <li>
                 <span className="text-gray-500">Buffer:</span>{' '}
-                {formatCount(profileStats.buffer)}
+                {formatByteStat(profileStats.buffer)}
               </li>
               {isOwnProfile && myRatioStats && (
                 <>
@@ -1518,8 +1523,8 @@ const UserProfile = () => {
                   Requests
                 </div>
                 <div className="mt-0.5 text-sm text-white">
-                  {activitySummary.requestsCreated}c /{' '}
-                  {activitySummary.requestsFilled}f
+                  {activitySummary.requestsCreated} created /{' '}
+                  {activitySummary.requestsFilled} filled
                 </div>
               </div>
               <div className="bg-gray-900 px-3 py-2 text-xs text-gray-300">
@@ -1527,7 +1532,8 @@ const UserProfile = () => {
                   Forums
                 </div>
                 <div className="mt-0.5 text-sm text-white">
-                  {activitySummary.forumTopics}t / {activitySummary.forumPosts}p
+                  {activitySummary.forumTopics} topics /{' '}
+                  {activitySummary.forumPosts} posts
                 </div>
               </div>
               <div className="bg-gray-900 px-3 py-2 text-xs text-gray-300">

--- a/src/components/profile/settings/Settings.tsx
+++ b/src/components/profile/settings/Settings.tsx
@@ -61,7 +61,8 @@ const Settings = () => {
 
   const { data: profile, isLoading } = useGetMyProfileQuery();
   const [updateProfile, { isLoading: isSaving }] = useUpdateMyProfileMutation();
-  const { register, handleSubmit, reset, watch, setValue } = useForm<ProfileForm>();
+  const { register, handleSubmit, reset, watch, setValue } =
+    useForm<ProfileForm>();
 
   useEffect(() => {
     if (profile) reset(toProfileForm(profile));

--- a/src/components/profile/settings/Settings.tsx
+++ b/src/components/profile/settings/Settings.tsx
@@ -30,7 +30,7 @@ type Tab = 'appearance' | 'privacy' | 'security' | 'donor';
 const PARANOIA_LABELS: Record<number, string> = {
   0: 'No restrictions — your profile is fully visible',
   1: 'Hide your email address and last-seen time',
-  2: 'Also hide your contributed/consumed (upload/download) stats',
+  2: 'Also hide your contributed/consumed stats',
   3: 'Also hide your ratio and buffer — nearly all activity stats are hidden'
 };
 
@@ -61,7 +61,7 @@ const Settings = () => {
 
   const { data: profile, isLoading } = useGetMyProfileQuery();
   const [updateProfile, { isLoading: isSaving }] = useUpdateMyProfileMutation();
-  const { register, handleSubmit, reset, watch } = useForm<ProfileForm>();
+  const { register, handleSubmit, reset, watch, setValue } = useForm<ProfileForm>();
 
   useEffect(() => {
     if (profile) reset(toProfileForm(profile));
@@ -344,8 +344,9 @@ const Settings = () => {
                   >
                     <input
                       type="radio"
-                      value={level}
-                      {...register('paranoia', { valueAsNumber: true })}
+                      value={String(level)}
+                      checked={paranoiaValue === level}
+                      onChange={() => setValue('paranoia', level)}
                       className="mt-0.5 accent-indigo-500"
                     />
                     <span className="text-sm text-gray-300">

--- a/src/components/staff/AlbumOfMonthPage.tsx
+++ b/src/components/staff/AlbumOfMonthPage.tsx
@@ -12,6 +12,7 @@ const AlbumOfMonthPage = () => {
   const [groupId, setGroupId] = useState('');
   const [threadId, setThreadId] = useState('');
   const [title, setTitle] = useState('');
+  const [image, setImage] = useState('');
   const [started, setStarted] = useState('');
   const [ended, setEnded] = useState('');
   const [formError, setFormError] = useState('');
@@ -39,12 +40,14 @@ const AlbumOfMonthPage = () => {
         groupId: gId,
         threadId: tId,
         title: title.trim(),
+        image: image.trim(),
         started: new Date(started).toISOString(),
         ended: new Date(ended).toISOString()
       }).unwrap();
       setGroupId('');
       setThreadId('');
       setTitle('');
+      setImage('');
       setStarted('');
       setEnded('');
     } catch {
@@ -90,6 +93,13 @@ const AlbumOfMonthPage = () => {
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="Title"
+            className="col-span-2 rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+          <input
+            type="url"
+            value={image}
+            onChange={(e) => setImage(e.target.value)}
+            placeholder="Cover image URL (optional — overrides release image)"
             className="col-span-2 rounded bg-gray-700 border border-gray-600 text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
           <div className="flex flex-col gap-1">

--- a/src/components/staff/LoginWatchPage.tsx
+++ b/src/components/staff/LoginWatchPage.tsx
@@ -95,7 +95,9 @@ const LoginWatchPage = () => {
                     colSpan={6}
                     className="px-4 py-6 text-center text-gray-500"
                   >
-                    No sessions found.
+                    {userId
+                      ? 'No sessions found for this user.'
+                      : 'Enter a user ID above to search sessions.'}
                   </td>
                 </tr>
               ) : (

--- a/src/components/staffInbox/TicketQueuePage.tsx
+++ b/src/components/staffInbox/TicketQueuePage.tsx
@@ -169,15 +169,17 @@ const TicketQueuePage = () => {
                     />
                   </td>
                   <td className="py-2 pr-3">
+                    <div className="flex items-center gap-1">
+                      {ticket.status === 'Unanswered' && (
+                        <span className="text-yellow-400 text-xs" aria-label="Unread">●</span>
+                      )}
                     <Link
                       to={`/private/staff/tickets/${ticket.id}`}
                       className="hover:underline text-blue-400"
                     >
-                      {ticket.status === 'Unanswered' && (
-                        <span className="mr-1 text-yellow-400">●</span>
-                      )}
                       {ticket.subject}
                     </Link>
+                    </div>
                   </td>
                   <td className="py-2 pr-3 text-gray-300">
                     {ticket.user?.username ?? '—'}

--- a/src/components/staffInbox/TicketQueuePage.tsx
+++ b/src/components/staffInbox/TicketQueuePage.tsx
@@ -171,14 +171,19 @@ const TicketQueuePage = () => {
                   <td className="py-2 pr-3">
                     <div className="flex items-center gap-1">
                       {ticket.status === 'Unanswered' && (
-                        <span className="text-yellow-400 text-xs" aria-label="Unread">●</span>
+                        <span
+                          className="text-yellow-400 text-xs"
+                          aria-label="Unread"
+                        >
+                          ●
+                        </span>
                       )}
-                    <Link
-                      to={`/private/staff/tickets/${ticket.id}`}
-                      className="hover:underline text-blue-400"
-                    >
-                      {ticket.subject}
-                    </Link>
+                      <Link
+                        to={`/private/staff/tickets/${ticket.id}`}
+                        className="hover:underline text-blue-400"
+                      >
+                        {ticket.subject}
+                      </Link>
                     </div>
                   </td>
                   <td className="py-2 pr-3 text-gray-300">

--- a/src/components/top10/TopReleasesPage.tsx
+++ b/src/components/top10/TopReleasesPage.tsx
@@ -38,7 +38,7 @@ const selectCls =
   'bg-gray-800 border border-gray-700 text-gray-200 text-sm rounded px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-indigo-500';
 
 const TopReleasesPage = () => {
-  const [type, setType] = useState<NonNullable<ReleaseType>>('day');
+  const [type, setType] = useState<NonNullable<ReleaseType>>('overall');
   const [limit, setLimit] = useState<LimitValue>(10);
   const [excludeTags, setExcludeTags] = useState('');
   const [format, setFormat] = useState('');

--- a/src/store/services/adminApi.ts
+++ b/src/store/services/adminApi.ts
@@ -101,6 +101,7 @@ export interface FeaturedAlbumItem {
   groupId: number;
   threadId: number;
   title: string;
+  image: string;
   started: string;
   ended: string;
 }
@@ -333,6 +334,7 @@ export const adminApi = api.injectEndpoints({
         groupId: number;
         threadId: number;
         title: string;
+        image?: string;
         started: string;
         ended: string;
       }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -26,3 +26,14 @@ export const formatBytes = (bytes?: number): string => {
   const i = Math.floor(Math.log(bytes) / Math.log(1024));
   return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${sizes[i]}`;
 };
+
+export const ordinalSuffix = (n: number): string => {
+  const v = n % 100;
+  if (v >= 11 && v <= 13) return `${n}th`;
+  switch (n % 10) {
+    case 1: return `${n}st`;
+    case 2: return `${n}nd`;
+    case 3: return `${n}rd`;
+    default: return `${n}th`;
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -31,9 +31,13 @@ export const ordinalSuffix = (n: number): string => {
   const v = n % 100;
   if (v >= 11 && v <= 13) return `${n}th`;
   switch (n % 10) {
-    case 1: return `${n}st`;
-    case 2: return `${n}nd`;
-    case 3: return `${n}rd`;
-    default: return `${n}th`;
+    case 1:
+      return `${n}st`;
+    case 2:
+      return `${n}nd`;
+    case 3:
+      return `${n}rd`;
+    default:
+      return `${n}th`;
   }
 };


### PR DESCRIPTION
## Summary

Fixes 26 issues found during a manual end-to-end walkthrough of the application as both a regular user and a staff/admin user. Changes span the UI (label corrections, logic fixes, new affordances) and API (report source URLs, FeaturedAlbum image field).

### User-facing fixes
- **Recent Contributions** label (was "Recent Uploads")
- **Profile byte stats** now formatted (e.g. `5.10 GB`) instead of raw integers
- **Community stats** expanded from single-letter abbreviations (`0c / 0f`) to `0 created / 0 filled`
- **isOwnProfile** detection fixed for username-based profile URLs — friend/report buttons no longer appear on your own profile
- **Privacy radio buttons** now pre-select the saved paranoia level on page load
- **"Last edited" annotation** suppressed on posts where `editedAt === createdAt` (unedited seed posts)
- **Forum topic breadcrumb** now includes the category level (`Forums › Community › The Lounge › Topic`)
- **Public landing CTAs** have a flex gap so "Sign In" and "Request Access" render as separate buttons
- **Collage description previews** render BBCode via `parseBBCode` + DOMPurify instead of showing raw tags
- **Announcements** are now expandable — click to reveal the full body inline
- **Top 10** defaults to All Time instead of Past Day (which always showed empty)
- **Login Watch** empty state distinguishes "no filter applied" from "no results found"
- **Ticket queue unread dot** moved outside the link element for clean a11y text
- **"Support Tickets"** replaces "Staff PMs" as the section heading on user profiles
- **Ordinal suffixes** corrected (1st, 2nd, 3rd, 11th, 21st — not "1th", "63th")
- **"Revoke donor status"** button now only visible when the user has an active donor rank
- **"Approved contribution link domains"** replaces "Approved download domains" in site settings

### Staff/admin fixes
- **Forum Manager**: inline Edit row (name, sort, description, min-class levels) and Delete with confirmation added to each forum
- **Rules Manager**: inline Edit form added to sub-pages alongside existing Delete
- **Album of the Month**: optional cover image URL field lets staff specify a cover without editing the release; image override wired through the home endpoint

### Infra
- `ordinalSuffix` extracted to `utils/index.ts` and exported
- Commit workflow in `CLAUDE.md` updated: format → lint → type-check → test, with note that format must precede lint

## Test plan

- [ ] All 1133 unit/spec tests pass (`npm run test --no-coverage`)
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [ ] No new ESLint errors (`npm run lint`)
- [ ] Verify profile stats show formatted bytes on `/private/user/:username`
- [ ] Verify own profile has no Add to Friends / Report buttons
- [ ] Verify privacy tab radio pre-selects the saved level
- [ ] Verify forum breadcrumb shows category in topic pages
- [ ] Verify unedited forum posts have no "Last edited" note
- [ ] Verify Top 10 loads with data on first visit
- [ ] Verify Forum Manager edit/delete rows work
- [ ] Verify Rules Manager sub-page edit form works
- [ ] **Requires `db:migrate`** in stellar-api before Album of Month image field is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)