### PR TITLE
ci: multi-env branch support (staging, develop)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,12 +2,16 @@ name: Publish packages to GHCR
 on:
   push:
     branches:
-      - 'main'
+      - main
+      - staging
+      - develop
     tags:
       - 'v*'
   pull_request:
     branches:
-      - 'main'
+      - main
+      - staging
+      - develop
   workflow_dispatch:
 
 env:
@@ -61,7 +65,9 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/staging' }}
+            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
       - name: Build and push image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:


### PR DESCRIPTION
## Summary

- Extends CI triggers to run on `main`, `staging`, and `develop` branches
- Docker images tagged `:latest` (main), `:staging`, or `:develop` based on triggering branch

## Test plan

- [ ] CI passes on this PR
- [ ] Verify `publish.yml` triggers on push to `develop` after merge
- [ ] Confirm Docker image is tagged `:develop` on next push to `develop`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)