### PR TITLE
docs: changelog v0.5.3 + manifest bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to stellar-ui are documented here.
 
 ---
 
+## [0.5.3] — 2026-06-01
+
+### Added
+- User stylesheet selection in Settings → Appearance — dropdown of available themes (Sublime, Kuro, Layer Cake, Proton, Postmod, Dark Ambient), replacing the free-text input
+- Live theme injection via `StylesheetInjector` — the selected stylesheet's CSS is applied without a page reload; a custom `externalStylesheet` URL overrides the named theme
+- `StylesheetManager` admin page (admin-gated via `AdminGate` / `hasStrictAdmin`) showing per-stylesheet user counts and a Set Default action
+- Per-theme header logos resolved at runtime via `THEME_LOGOS` in `PrivateHeader`, keyed by the active theme with a kuro fallback
+- Four new themes shipped with fonts and images: Layer Cake, Proton, Postmod, Dark Ambient
+
+### Changed
+- Bump `package.json` version `0.5.0` → `0.5.3` to resolve manifest drift against the tag scheme
+
+---
+
 ## [0.5.2.1] — 2026-06-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/ui",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "description": "",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
Phase 5 of the post-merge housekeeping sweep.

- Adds the **[0.5.3]** CHANGELOG entry for the stylesheet feature (selection, live theme injection, admin manager, four new themes, per-theme logos)
- Bumps `package.json` `0.5.0 → 0.5.3` to resolve **manifest drift** — the version was lagging two releases behind the tag scheme (tags at `v0.5.2.1`)

No code changes; docs + manifest only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)