### PR TITLE
feat(footer): derive version from package.json instead of a hardcoded literal

### DIFF
--- a/src/components/pages/private/layout/PrivateFooter.tsx
+++ b/src/components/pages/private/layout/PrivateFooter.tsx
@@ -13,7 +13,7 @@ const PrivateFooter = () => (
           CHANGELOG
         </a>
       </div>
-      <span>Powered by Stellar v0.5</span>
+      <span>Powered by Stellar v{__APP_VERSION__}</span>
     </div>
   </footer>
 );

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,4 +1,5 @@
 declare const __SENTRY_DSN__: string;
+declare const __APP_VERSION__: string;
 declare module '*.png' {
   const src: string;
   export default src;

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -10,6 +10,8 @@ import { CleanWebpackPlugin as CleanPlugin } from 'clean-webpack-plugin';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import CopyPlugin from 'copy-webpack-plugin';
 
+import pkg from './package.json';
+
 dotenv.config();
 dotenv.config({ path: '.env.local', override: true });
 
@@ -18,7 +20,8 @@ const apiUrl = process.env.STELLAR_API_URL || 'http://localhost:8080';
 
 const plugins = [
   new webpack.DefinePlugin({
-    __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || '')
+    __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || ''),
+    __APP_VERSION__: JSON.stringify(pkg.version)
   }),
   new CleanPlugin(),
   new StylelintPlugin({


### PR DESCRIPTION
## What

The private footer read `Powered by Stellar v0.5` — a hardcoded string. Releases moved to **v0.5.3** while the footer sat three releases stale, because nothing in the release flow touches it.

## Change

Inject the manifest version at build time via webpack `DefinePlugin` (`__APP_VERSION__`), mirroring the existing `__SENTRY_DSN__` wiring, and render `Powered by Stellar v{__APP_VERSION__}` in the footer. The footer now tracks every release automatically — no manual bump, no drift.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅ (footer + globals)
- `npm run build` ✅ — confirmed bundle renders `Powered by Stellar v0.5.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)