### PR TITLE
chore: bump version manifest to 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/ui",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "description": "",
   "author": "ayan4m1 <andrew@bulletlogic.com>, Kyle O'Brien <obrienk@webbhost.net>",
   "license": "MIT",


### PR DESCRIPTION
Bumps `package.json` `version` to `0.5.3` so develop matches the latest release tag (`v0.5.3`); develop had drifted behind at `0.5.0` while `main` already carried `0.5.3`.

Surfaced by an end-of-sprint Mr. Robot housekeeping sweep. Manifest-only change.