### PR TITLE
Promote: contribution form + a11y + version pinning (linear, supersedes #69)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,10 @@ module.exports = {
           'dompurify',
           '^@reduxjs/toolkit/query$',
           '^@reduxjs/toolkit/query/react$',
-          'recharts'
+          'recharts',
+          // exports-field package the node resolver can't parse (e2e isn't in
+          // the typescript-resolver tsconfig); same treatment as the above.
+          '^@axe-core/playwright$'
         ]
       }
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,32 @@ All notable changes to stellar-ui are documented here.
 ## [Unreleased]
 
 ### Added
+
 - Bundled default avatar (`/static/common/avatars/default.png`) served from `src/static`, replacing the Gravatar-derived avatars removed API-side to stop leaking email hashes
 - Seeded test users render a distinct avatar (`/static/common/avatars/seeded.jpg`) so generated accounts are visually obvious
 - `utils/avatar.ts` — `avatarSrc()` (null/empty-safe) and `onAvatarError()` (swaps to default when a stored URL 404s)
+- Legacy-parity **contribution form** — release type, record label, catalogue №, edition info, bitrate/media, and scene/log/cue, with WCAG 2.1 AA semantics (sectioned fieldsets, `aria-required`, a live error region, and add/remove-artist focus management) plus a disabled MusicBrainz "Find info" stub; covered by a Playwright e2e + `@axe-core/playwright` accessibility scan [#72]
+- Bitrate/media enum `<select>`s on the add-to-release contribution form
 
 ### Changed
+
 - Avatar render sites (`UserProfile`, `ForumTopicPost`) use the shared fallback helper, hardening against empty-string and broken-URL avatars
+- Resynced generated `src/types/api.ts` with stellar-api main (bitrate/media enums, nullable release artist, Edition tier)
+
+### Removed
+
+- Dead `isEdition` release-edit control and phantom "Edition" display — whether a release is an edition is now modelled by the separate `Edition` entity [#72]
+
+### Fixed
+
+- Footer version is now derived from the manifest (`__APP_VERSION__` via webpack `DefinePlugin`) instead of a hardcoded `v0.5` literal, so it tracks releases and can't drift
 
 ---
 
 ## [0.5.3] — 2026-06-01
 
 ### Added
+
 - User stylesheet selection in Settings → Appearance — dropdown of available themes (Sublime, Kuro, Layer Cake, Proton, Postmod, Dark Ambient), replacing the free-text input
 - Live theme injection via `StylesheetInjector` — the selected stylesheet's CSS is applied without a page reload; a custom `externalStylesheet` URL overrides the named theme
 - `StylesheetManager` admin page (admin-gated via `AdminGate` / `hasStrictAdmin`) showing per-stylesheet user counts and a Set Default action
@@ -26,6 +40,7 @@ All notable changes to stellar-ui are documented here.
 - Four new themes shipped with fonts and images: Layer Cake, Proton, Postmod, Dark Ambient
 
 ### Changed
+
 - Bump `package.json` version `0.5.0` → `0.5.3` to resolve manifest drift against the tag scheme
 
 ---
@@ -33,5 +48,6 @@ All notable changes to stellar-ui are documented here.
 ## [0.5.2.1] — 2026-06-01
 
 ### Changed
+
 - Replace "Stellar" gradient text logo in `PrivateHeader` with kuro logo image (`kuro-logo.png` / `kuro-logo-hover.png`), with mouse-over swap
 - Add `declare module '*.png'` to `globals.d.ts` for typed PNG imports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,18 @@
 # CLAUDE.md — stellar-ui
 
-React / TypeScript frontend for the Stellar platform. Uses Vite, RTK Query, React Router, Tailwind CSS.
+React / TypeScript frontend for the Stellar platform. Uses Webpack, RTK Query, React Router, Tailwind CSS.
 
 ## Commands
 
 ```bash
-npm run dev              # Webpack dev server on :9000 (proxies /api → STELLAR_API_URL, default :8080)
+npm start                # Webpack dev server on :9000 (proxies /api → STELLAR_API_URL, default :8080)
 npm run build            # Production build
 npm run typecheck        # tsc --noEmit
 npm run lint             # ESLint
 npm run format           # Prettier --write src
 npm test                 # Jest unit tests (--runInBand)
 npm run test:e2e         # Playwright E2E (requires running API + UI — see below)
+npm run api:generate     # Export openapi.json from stellar-api, regenerate src/types/api.ts, run Prettier
 ```
 
 ## Environment variables
@@ -56,7 +57,7 @@ src/
       subscriptionApi.ts      # Forum topic + comment subscriptions
       profileApi.ts           # Profile read/write
       announcementApi.ts      # Announcements
-      siteApi.ts              # SiteStats, Stylesheets, SiteSettings
+      siteApi.ts              # SiteStats, Stylesheets (CRUD + stats), SiteSettings
       messagesApi.ts          # Private messages (inbox, sent, compose)
       staffInboxApi.ts        # Support tickets + staff inbox + canned responses
       reportsApi.ts           # User-facing reports + staff queue
@@ -64,15 +65,29 @@ src/
   types/
     index.ts                  # Re-exports from generated api.ts + handwritten types
     api.ts                    # Generated from stellar-api openapi.json (do not edit by hand)
+  types/
+    globals.d.ts              # Declare __SENTRY_DSN__, *.png, *.jpg module types
   utils/
-    permissions.ts            # hasPermission, hasAnyPermission, isStaffUser
+    permissions.ts            # hasPermission, hasAnyPermission, isStaffUser, canSeeModBar, hasStrictAdmin
+    avatar.ts                 # avatarSrc(avatar?) → string; onAvatarError handler; SEEDED_AVATAR_SENTINEL
+  stylesheets/                # Bundled CSS themes served at /stylesheets — do not import directly
+    kuro/                     # Dark theme
+    layer-cake/               # Default Stellar theme
+    postmod/                  # WCD-era theme
+    proton/                   # Light theme
+    sublime/                  # Empty (base Tailwind only)
   components/
-    admin/                    # Staff toolbox, user rank manager, news, user create
+    admin/                    # User rank manager, forum/community controls, news, stylesheet manager
+    staff/                    # Staff pages + registry
+      staffToolRegistry.tsx   # Central registry of all staff tool routes + permission gates
+      staffAffordances.ts     # canSeeModBar, canAccessStaffQueue, canUseReportActions, etc.
+      StaffPage.tsx           # /private/staff — staff landing
+      (+ ~20 other staff pages — see staffToolRegistry for full list)
     auth/                     # Login, Register, Install pages
     forum/                    # Forum pages and post components
     communities/              # Community, release, artist pages
     profile/                  # User profile, settings
-    layout/                   # Navbar, Sidebar, UserMenu, Spinner, PostBox, etc.
+    layout/                   # Navbar, Sidebar, UserMenu, Spinner, PostBox, StylesheetInjector, etc.
 ```
 
 ## Types
@@ -110,16 +125,41 @@ Access error details as `err.data?.msg` (single message) or `err.data?.errors` (
 
 `src/utils/permissions.ts` exports:
 ```ts
-hasPermission(user, 'admin')           // boolean
+hasPermission(user, 'admin')                    // boolean; admin bypasses all checks
 hasAnyPermission(user, ['staff', 'admin'])
-isStaffUser(user)                      // any staff/admin permission present
+isStaffUser(user)                               // any staff/admin permission present
+canSeeModBar(user)                              // requires 'staff'
+hasStrictAdmin(user)                            // literal 'admin' only — staff alone does not pass
 ```
 
-The 14 valid backend permissions: `forums_read`, `forums_post`, `forums_moderate`, `forums_manage`, `communities_manage`, `collages_manage`, `collages_moderate`, `news_manage`, `invites_manage`, `users_edit`, `users_warn`, `users_disable`, `staff`, `admin`.
+`src/components/staff/staffAffordances.ts` exports role-specific checks that combine permission keys:
+```ts
+canAccessStaffQueue(user)     // 'staff_inbox_manage'
+canUseReportActions(user)     // 'reports_manage' | 'staff'
+canUseTicketStaffActions(user)// 'staff_inbox_manage' | 'staff'
+canUseRequestModeration(user) // 'requests_moderate' | 'staff'
+canSeeTop10History(user)      // 'staff'
+```
 
-## Toolbox link policy
+Valid backend permissions are defined in `stellar-api/src/lib/rankPermissions.ts` and exported as `VALID_PERMISSIONS` (~42 keys across 11 groups). The `Permission` type is derived from the OpenAPI spec — use `components['schemas']['PermissionKey']` in the UI. Key groups:
 
-`Toolbox.tsx` shows links filtered by user permissions. Only add links for routes that are actually implemented. Do not add placeholder links for planned features.
+| Group | Example keys |
+|---|---|
+| Discovery | `advanced_search`, `users_search` |
+| Forums | `forums_read`, `forums_post`, `forums_moderate`, `forums_manage` |
+| Communities | `communities_manage`, `contributions_manage`, `dnc_manage` |
+| Collages | `collages_create`, `collages_manage`, `collages_moderate` |
+| Requests | `requests_create`, `requests_moderate` |
+| Wiki | `wiki_edit`, `wiki_manage` |
+| Content | `news_manage`, `rules_manage`, `tags_manage`, `reports_manage`, `staff_inbox_manage` |
+| Users | `users_edit`, `users_warn`, `users_disable`, `users_view_ips`, `users_view_email`, `recovery_manage`, `invites_manage`, `ratio_policy_manage` |
+| Operations | `site_history_manage`, `ip_bans_manage`, `email_blacklist_manage`, `donor_ranks_manage`, `donation_log_view`, `messages_mass_pm` |
+| Staff Tools | `login_watch_view`, `duplicate_ips_view`, `registration_log_view`, `staff` |
+| Administration | `rank_permissions_manage`, `staff_groups_manage`, `admin` |
+
+## Toolbox / staff tool registry
+
+`Toolbox.tsx` renders links driven by `staffToolRegistry.tsx`. Each registered tool declares its `path`, `label`, `section`, and required `permissions[]`. `Toolbox` filters by `hasAnyPermission` — only add entries for routes that are actually implemented. Do not add placeholder links for planned features.
 
 ## Commit workflow
 
@@ -128,10 +168,18 @@ Run every step before committing. All must pass clean on new/changed files.
 1. `npm run format` — format **all** of `src/` (not just changed files — confirms nothing else drifted)
 2. `npm run lint` — must be clean on new/changed files; pre-existing errors in untouched files are acceptable
 3. `npx tsc --noEmit` — must be clean
-4. `npm run test --no-coverage` — full suite must pass
+4. `npm test -- --no-coverage` — full suite must pass (unit + integration tests together via Jest)
 5. Commit with descriptive message following existing log style
 
 > Order matters: format before lint (Prettier violations are ESLint errors), and lint before type-check.
+
+## Testing
+
+`src/__tests__/` contains two test flavors:
+- **Unit tests** (`*.test.tsx` / `*.test.ts`): mock RTK Query, run with Jest + jsdom, fast.
+- **Integration tests** (`*.integration.test.tsx`): hit real RTK Query hooks against a mock server or rendered tree; same Jest run, slower. Both run via `npm test`.
+
+E2E tests live in `e2e/` and run via Playwright (`npm run test:e2e`). Current coverage: smoke, auth paths, messaging, releases, reports, tickets.
 
 ## Audit history
 
@@ -143,7 +191,7 @@ Five rounds of audit remediation applied. Key items:
 - `artistApi` field names aligned to backend: `similarArtistId`, `redirectId`, `tagId`
 - `votePoll` requires `topicId` and invalidates `ForumTopic` (not all `Forum`)
 - `forumApi` has `updateForum`, `deleteForum`, `deleteTopic` mutations
-- `UserRankFormPage` uses 14 backend VALID_PERMISSIONS
+- `UserRankFormPage` uses backend VALID_PERMISSIONS from OpenAPI spec (`PermissionKey`)
 - `Toolbox` stripped to implemented links only, permission-filtered per user
 - 403 removed from logout trigger (403 = insufficient permissions, not invalid session)
 - `NewUserForm` logout hack removed; navigates to toolbox on success
@@ -166,14 +214,10 @@ Do not add frontend code, OpenAPI paths, or Toolbox links for these until the ba
 
 ## Regenerating api.ts
 
-When stellar-api's OpenAPI spec changes:
+When stellar-api's OpenAPI spec changes, run from the stellar-ui directory:
 ```bash
-# In stellar-api:
-npm run openapi:export       # writes openapi.json to repo root
-
-# In stellar-ui (must run from the stellar-ui directory):
-npx openapi-typescript /path/to/stellar-api/openapi.json -o src/types/api.ts
-npx tsc --noEmit             # verify no type regressions
+npm run api:generate     # exports openapi.json from ../stellar-api, regenerates src/types/api.ts, runs Prettier
+npm run typecheck        # verify no type regressions
 ```
 
 This is a manual step before every PR that touches API response shapes.

--- a/e2e/contribute.spec.ts
+++ b/e2e/contribute.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Contribution form E2E — legacy-parity fields + accessibility
+ *
+ * P-08a  Submit a Music release exercising the new legacy-parity fields
+ *        (release type, record label, catalogue №, bitrate, media, edition,
+ *        scene/log/cue) via the standalone contribute form.
+ * P-08b  Axe accessibility scan of the contribute form (WCAG 2.0/2.1 A & AA).
+ * P-08c  Keyboard operability: add/remove artist rows move focus correctly.
+ *
+ * Complements release.spec.ts P-07a (basic add-to-release submission).
+ * Requires a seeded community and the regular test user (see global.setup.ts).
+ */
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { AUTH_USER } from './auth-paths';
+
+test.describe('contribute form (as regular user)', () => {
+  test.use({ storageState: AUTH_USER });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/private/contribute');
+    // Wait for communities to load (first real option populated).
+    await expect(
+      page.locator('#contribute-community option').nth(1)
+    ).toBeVisible();
+  });
+
+  test('P-08a: submit a Music release with full legacy-parity metadata', async ({
+    page
+  }) => {
+    const albumTitle = `E2E Parity Album ${Date.now()}`;
+    const downloadUrl = `https://example.com/e2e-parity/${Date.now()}.flac`;
+
+    await page.locator('#contribute-community').selectOption({ index: 1 });
+
+    // Release identity
+    await page.locator('#contribute-category').selectOption('EP');
+    await page.getByPlaceholder(/artist name/i).fill('E2E Parity Artist');
+    await page.locator('#contribute-album').fill(albumTitle);
+    await page.locator('#contribute-label').fill('Blue Note');
+    await page.locator('#contribute-catno').fill('BN-1577');
+
+    // Edition
+    await page.locator('#contribute-edition-toggle').check();
+    await page.locator('#contribute-edition-title').fill('Deluxe Edition');
+    await page.locator('#contribute-edition-year').fill('2015');
+    await page.locator('#contribute-remaster').check();
+
+    // File information
+    await page.locator('#contribute-filetype').selectOption('flac');
+    await page.locator('#contribute-bitrate').selectOption('Lossless');
+    await page.locator('#contribute-media').selectOption('CD');
+    await page.locator('#contribute-size').fill('512.5');
+    await page.locator('#contribute-url').fill(downloadUrl);
+    await page.locator('#contribute-scene').check();
+    await page.locator('#contribute-haslog').check();
+    await page.locator('#contribute-hascue').check();
+
+    await page.getByRole('button', { name: /contribute release/i }).click();
+
+    await page.waitForURL('**/contribute/list**');
+    await expect(page).toHaveURL(/\/private\/contribute\/list/);
+  });
+
+  test('P-08b: contribute form has no axe accessibility violations', async ({
+    page
+  }) => {
+    // Scan the default (Music) layout, then re-scan with the edition section
+    // expanded so the conditionally-rendered fields are covered too.
+    const scan = async () =>
+      new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        .analyze();
+
+    let results = await scan();
+    expect(results.violations).toEqual([]);
+
+    await page.locator('#contribute-edition-toggle').check();
+    results = await scan();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('P-08c: adding and removing artist rows manages focus', async ({
+    page
+  }) => {
+    const addArtist = page.getByRole('button', { name: /add artist/i });
+
+    // Adding a row focuses the new row's name input.
+    await addArtist.click();
+    const secondRow = page.getByLabel(/artist name 2/i);
+    await expect(secondRow).toBeFocused();
+
+    // The remove control is keyboard-reachable and labelled per row.
+    const removeSecond = page.getByRole('button', { name: /remove artist 2/i });
+    await expect(removeSecond).toBeVisible();
+    await removeSecond.click();
+
+    // Back to a single artist row.
+    await expect(page.getByPlaceholder(/artist name/i)).toHaveCount(1);
+
+    // The MusicBrainz stub is present but disabled (visual parity, no action).
+    await expect(
+      page.getByRole('button', { name: /find info/i })
+    ).toBeDisabled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stellar/ui",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stellar/ui",
-      "version": "0.5.0",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.6",
@@ -33,6 +33,7 @@
         "tailwindcss": "^4.2.4"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@babel/core": "^7.22.9",
         "@babel/eslint-parser": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
@@ -185,6 +186,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -6366,10 +6380,11 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
+      "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "tailwindcss": "^4.2.4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@babel/core": "^7.22.9",
     "@babel/eslint-parser": "^7.22.9",
     "@babel/preset-env": "^7.22.9",

--- a/src/__tests__/communities/AddContributionForm.test.tsx
+++ b/src/__tests__/communities/AddContributionForm.test.tsx
@@ -152,8 +152,8 @@ describe('AddContributionForm', () => {
     );
     await user.clear(screen.getByLabelText(/file size/i));
     await user.type(screen.getByLabelText(/file size/i), '500');
-    await user.type(screen.getByLabelText(/bitrate/i), '320');
-    await user.type(screen.getByLabelText(/media/i), 'CD');
+    await user.selectOptions(screen.getByLabelText(/bitrate/i), 'Kbps320');
+    await user.selectOptions(screen.getByLabelText(/media/i), 'CD');
     await user.click(screen.getByLabelText(/has log/i));
     await user.click(screen.getByLabelText(/has cue/i));
     await user.click(screen.getByLabelText(/scene release/i));
@@ -166,7 +166,7 @@ describe('AddContributionForm', () => {
         expect.objectContaining({
           communityId: 3,
           releaseId: 7,
-          bitrate: '320',
+          bitrate: 'Kbps320',
           media: 'CD',
           hasLog: true,
           hasCue: true,
@@ -182,8 +182,8 @@ describe('AddContributionForm', () => {
     renderWithProviders(<AddContributionForm />);
 
     // Fill in audio fields while type is mp3 (default)
-    await user.type(screen.getByLabelText(/bitrate/i), '320');
-    await user.type(screen.getByLabelText(/media/i), 'CD');
+    await user.selectOptions(screen.getByLabelText(/bitrate/i), 'Kbps320');
+    await user.selectOptions(screen.getByLabelText(/media/i), 'CD');
     await user.click(screen.getByLabelText(/has log/i));
 
     // Switch to non-audio type — audio fields disappear

--- a/src/__tests__/contribute/ContributeForm.test.tsx
+++ b/src/__tests__/contribute/ContributeForm.test.tsx
@@ -114,10 +114,34 @@ describe('ContributeForm', () => {
     expect(screen.getByLabelText(/content type/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/year/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/album title/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/file type/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/format/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/file size/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/download url/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/artist name/i)).toBeInTheDocument();
+  });
+
+  it('renders the new Music metadata fields (release type, label, catalogue №, bitrate, media)', () => {
+    renderWithProviders(<ContributeForm />);
+    expect(screen.getByLabelText(/release type/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/record label/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/catalogue number/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/bitrate/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^media/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/scene release/i)).toBeInTheDocument();
+  });
+
+  it('renders a disabled MusicBrainz "Find info" stub', () => {
+    renderWithProviders(<ContributeForm />);
+    expect(screen.getByRole('button', { name: /find info/i })).toBeDisabled();
+  });
+
+  it('hides Music-only fields for non-Music types', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ContributeForm />);
+    await user.selectOptions(screen.getByLabelText(/content type/i), 'EBooks');
+    expect(screen.queryByLabelText(/release type/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/bitrate/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/edition information/i)).not.toBeInTheDocument();
   });
 
   it('shows release description field for Music type', () => {
@@ -147,9 +171,17 @@ describe('ContributeForm', () => {
     const user = userEvent.setup();
     renderWithProviders(<ContributeForm />);
     await user.click(screen.getByRole('button', { name: /add artist/i }));
-    const removeBtn = screen.getByRole('button', { name: '✕' });
+    const removeBtn = screen.getByRole('button', { name: /remove artist 2/i });
     await user.click(removeBtn);
     expect(screen.getAllByPlaceholderText(/artist name/i).length).toBe(1);
+  });
+
+  it('moves focus to the new artist row when one is added', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ContributeForm />);
+    await user.click(screen.getByRole('button', { name: /add artist/i }));
+    const inputs = screen.getAllByPlaceholderText(/artist name/i);
+    expect(inputs[1]).toHaveFocus();
   });
 
   it('submits with correct payload for Music type', async () => {
@@ -256,7 +288,7 @@ describe('ContributeForm', () => {
       screen.getByDisplayValue('Main artist'),
       'Remixer'
     );
-    await user.selectOptions(screen.getByLabelText(/file type/i), 'flac');
+    await user.selectOptions(screen.getByLabelText(/format/i), 'flac');
     expect(
       (screen.getByDisplayValue('Remixer') as HTMLSelectElement).value
     ).toBe('Remixer');
@@ -351,7 +383,7 @@ describe('ContributeForm', () => {
     const user = userEvent.setup();
     renderWithProviders(<ContributeForm />);
     await user.selectOptions(screen.getByLabelText(/content type/i), 'EBooks');
-    const titleInput = screen.getByLabelText(/title \*/i);
+    const titleInput = screen.getByLabelText(/^title/i);
     await user.type(titleInput, 'My EBook');
     expect((titleInput as HTMLInputElement).value).toBe('My EBook');
   });
@@ -369,5 +401,90 @@ describe('ContributeForm', () => {
     expect(
       screen.getByRole('link', { name: /submit a request/i })
     ).toBeInTheDocument();
+  });
+
+  it('reveals edition fields when the edition checkbox is ticked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ContributeForm />);
+    expect(screen.queryByLabelText(/edition title/i)).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText(/this is a specific edition/i));
+    expect(screen.getByLabelText(/edition title/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/edition year/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/this edition is a remaster/i)
+    ).toBeInTheDocument();
+  });
+
+  it('submits the full legacy-parity payload for a Music release', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ContributeForm />);
+
+    await fillMusicForm(user);
+    await user.selectOptions(screen.getByLabelText(/release type/i), 'EP');
+    fireEvent.change(screen.getByLabelText(/record label/i), {
+      target: { value: 'Blue Note' }
+    });
+    fireEvent.change(screen.getByLabelText(/catalogue number/i), {
+      target: { value: 'BN-1577' }
+    });
+    await user.selectOptions(screen.getByLabelText(/bitrate/i), 'Lossless');
+    await user.selectOptions(screen.getByLabelText(/^media/i), 'CD');
+    await user.click(screen.getByLabelText(/scene release/i));
+    await user.click(screen.getByLabelText(/includes a rip log/i));
+
+    await user.click(screen.getByLabelText(/this is a specific edition/i));
+    fireEvent.change(screen.getByLabelText(/edition title/i), {
+      target: { value: 'Deluxe Edition' }
+    });
+    fireEvent.change(screen.getByLabelText(/edition year/i), {
+      target: { value: '2015' }
+    });
+    await user.click(screen.getByLabelText(/this edition is a remaster/i));
+
+    await user.click(
+      screen.getByRole('button', { name: /contribute release/i })
+    );
+
+    await waitFor(() => {
+      expect(mockCreateContribution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'Music',
+          releaseCategory: 'EP',
+          recordLabel: 'Blue Note',
+          catalogueNumber: 'BN-1577',
+          bitrate: 'Lossless',
+          media: 'CD',
+          isScene: true,
+          hasLog: true,
+          editionTitle: 'Deluxe Edition',
+          editionYear: 2015,
+          isRemaster: true,
+          collaborators: expect.arrayContaining([
+            expect.objectContaining({
+              artist: 'Miles Davis',
+              importance: 'Main artist'
+            })
+          ])
+        })
+      );
+    });
+  });
+
+  it('does not send Music-only fields for a non-Music submission', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ContributeForm />);
+    await user.selectOptions(screen.getByLabelText(/content type/i), 'EBooks');
+    fireEvent.submit(document.querySelector('form')!);
+    await waitFor(() => {
+      expect(mockCreateContribution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'EBooks',
+          releaseCategory: undefined,
+          recordLabel: undefined,
+          bitrate: undefined,
+          isRemaster: undefined
+        })
+      );
+    });
   });
 });

--- a/src/components/communities/AddContributionForm.tsx
+++ b/src/components/communities/AddContributionForm.tsx
@@ -46,6 +46,34 @@ const AUDIO_FILE_TYPES: FileType[] = [
   'm4a'
 ];
 
+// Encoding / bitrate + source media — values mirror the API enums.
+const BITRATES = [
+  { value: 'Lossless', label: 'Lossless' },
+  { value: 'Lossless24', label: 'Lossless (24-bit)' },
+  { value: 'Kbps320', label: '320 kbps' },
+  { value: 'Kbps256', label: '256 kbps' },
+  { value: 'KbpsV0', label: 'V0 (VBR)' },
+  { value: 'Kbps192', label: '192 kbps' },
+  { value: 'KbpsV2', label: 'V2 (VBR)' },
+  { value: 'Kbps128', label: '128 kbps' },
+  { value: 'Other', label: 'Other' }
+] as const;
+type Bitrate = (typeof BITRATES)[number]['value'];
+
+const MEDIA = [
+  { value: 'CD', label: 'CD' },
+  { value: 'WEB', label: 'WEB' },
+  { value: 'Vinyl', label: 'Vinyl' },
+  { value: 'SACD', label: 'SACD' },
+  { value: 'DVD', label: 'DVD' },
+  { value: 'Cassette', label: 'Cassette' },
+  { value: 'BluRay', label: 'Blu-ray' },
+  { value: 'DAT', label: 'DAT' },
+  { value: 'Soundboard', label: 'Soundboard' },
+  { value: 'Other', label: 'Other' }
+] as const;
+type ReleaseMedia = (typeof MEDIA)[number]['value'];
+
 const inputClass =
   'w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-indigo-500';
 const labelClass = 'block text-sm text-gray-400 mb-1';
@@ -74,8 +102,8 @@ const AddContributionForm = () => {
   const [downloadUrl, setDownloadUrl] = useState('');
   const [sizeMB, setSizeMB] = useState('');
   const [releaseDescription, setReleaseDescription] = useState('');
-  const [bitrate, setBitrate] = useState('');
-  const [media, setMedia] = useState('');
+  const [bitrate, setBitrate] = useState<Bitrate | ''>('');
+  const [media, setMedia] = useState<ReleaseMedia | ''>('');
   const [hasLog, setHasLog] = useState(false);
   const [hasCue, setHasCue] = useState(false);
   const [isScene, setIsScene] = useState(false);
@@ -219,27 +247,39 @@ const AddContributionForm = () => {
                 <label htmlFor="add-bitrate" className={labelClass}>
                   Bitrate
                 </label>
-                <input
+                <select
                   id="add-bitrate"
-                  type="text"
                   value={bitrate}
-                  onChange={(e) => setBitrate(e.target.value)}
-                  placeholder="e.g. 320, V0, Lossless"
+                  onChange={(e) => setBitrate(e.target.value as Bitrate | '')}
                   className={inputClass}
-                />
+                >
+                  <option value="">—</option>
+                  {BITRATES.map((b) => (
+                    <option key={b.value} value={b.value}>
+                      {b.label}
+                    </option>
+                  ))}
+                </select>
               </div>
               <div>
                 <label htmlFor="add-media" className={labelClass}>
                   Media
                 </label>
-                <input
+                <select
                   id="add-media"
-                  type="text"
                   value={media}
-                  onChange={(e) => setMedia(e.target.value)}
-                  placeholder="e.g. CD, Vinyl, WEB"
+                  onChange={(e) =>
+                    setMedia(e.target.value as ReleaseMedia | '')
+                  }
                   className={inputClass}
-                />
+                >
+                  <option value="">—</option>
+                  {MEDIA.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
             <div className="flex gap-6">

--- a/src/components/communities/ReleasePage.tsx
+++ b/src/components/communities/ReleasePage.tsx
@@ -22,9 +22,7 @@ const FIELD_LABELS: Record<string, string> = {
   title: 'Title',
   description: 'Description',
   image: 'Cover art',
-  year: 'Year',
-  isEdition: 'Edition',
-  edition: 'Edition data'
+  year: 'Year'
 };
 
 const formatFieldValue = (field: string, value: unknown): string => {
@@ -32,7 +30,6 @@ const formatFieldValue = (field: string, value: unknown): string => {
   if (field === 'description' && typeof value === 'string') {
     return value.length > 120 ? value.slice(0, 120) + '…' : value;
   }
-  if (field === 'isEdition') return value ? 'Yes' : 'No';
   if (typeof value === 'string' || typeof value === 'number')
     return String(value);
   return JSON.stringify(value);
@@ -647,24 +644,6 @@ const ReleasePage = () => {
                   <span className="text-gray-300">{release.year}</span>
                 </li>
               )}
-              {(release as { isEdition?: boolean }).isEdition && (
-                <li className="flex justify-between px-3 py-1.5">
-                  <span className="text-gray-500">Edition</span>
-                  <span className="text-gray-300">
-                    {(() => {
-                      const ed = (release as { edition?: unknown }).edition;
-                      if (ed && typeof ed === 'object') {
-                        const { title, year } = ed as {
-                          title?: string;
-                          year?: number;
-                        };
-                        return [title, year].filter(Boolean).join(' ');
-                      }
-                      return typeof ed === 'string' ? ed : 'Yes';
-                    })()}
-                  </span>
-                </li>
-              )}
             </ul>
           </div>
         </div>
@@ -733,20 +712,6 @@ const ReleasePage = () => {
                     }
                     className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-1.5 text-sm text-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-500"
                   />
-                </label>
-                <label className="flex items-center gap-2 mt-5 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={editForm.isEdition}
-                    onChange={(e) =>
-                      setEditForm((f) => ({
-                        ...f,
-                        isEdition: e.target.checked
-                      }))
-                    }
-                    className="accent-indigo-500 w-4 h-4"
-                  />
-                  <span className="text-xs text-gray-300">Edition</span>
                 </label>
               </div>
               <label className="block">

--- a/src/components/communities/useReleaseWorkbench.ts
+++ b/src/components/communities/useReleaseWorkbench.ts
@@ -24,7 +24,6 @@ type ReleaseWithVote = {
   voteAggregate?: VoteAggregate | null;
   releaseTags?: ReleaseTag[];
   isContributor?: boolean;
-  isEdition?: boolean;
   title?: string;
   description?: string;
   year?: number;
@@ -56,7 +55,6 @@ export const useReleaseWorkbench = ({
     description: '',
     year: 0,
     image: '',
-    isEdition: false,
     editSummary: ''
   });
   const [editError, setEditError] = useState<string | null>(null);
@@ -143,7 +141,6 @@ export const useReleaseWorkbench = ({
       description: releaseView?.description ?? '',
       year: releaseView?.year ?? new Date().getFullYear(),
       image: releaseView?.image ?? '',
-      isEdition: Boolean(releaseView?.isEdition),
       editSummary: ''
     });
     setEditError(null);
@@ -160,7 +157,6 @@ export const useReleaseWorkbench = ({
         description: editForm.description.trim() || undefined,
         year: editForm.year || undefined,
         image: editForm.image.trim() || undefined,
-        isEdition: editForm.isEdition,
         editSummary: editForm.editSummary.trim() || undefined
       }).unwrap();
       dispatch(addAlert('Release updated.', 'success'));

--- a/src/components/contribute/ContributeForm.tsx
+++ b/src/components/contribute/ContributeForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useId } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import {
@@ -19,8 +19,11 @@ const ARTIST_TYPES = [
   'Composer',
   'Conductor',
   'DJ',
-  'Producer'
+  'Producer',
+  'Arranger'
 ];
+const CREATOR_TYPES = ['Creator', 'Contributor', 'Editor'];
+
 const CONTENT_TYPES = [
   'Music',
   'Applications',
@@ -31,6 +34,7 @@ const CONTENT_TYPES = [
   'Comics'
 ] as const;
 type ContentType = (typeof CONTENT_TYPES)[number];
+
 const FILE_TYPES = [
   'mp3',
   'flac',
@@ -59,10 +63,76 @@ const FILE_TYPES = [
 ] as const;
 type FileType = (typeof FILE_TYPES)[number];
 
+// Release identity categories — values mirror the API ReleaseCategory enum;
+// labels are humanised for the dropdown.
+const RELEASE_CATEGORIES = [
+  { value: 'Album', label: 'Album' },
+  { value: 'Single', label: 'Single' },
+  { value: 'EP', label: 'EP' },
+  { value: 'Anthology', label: 'Anthology' },
+  { value: 'Compilation', label: 'Compilation' },
+  { value: 'DJMix', label: 'DJ Mix' },
+  { value: 'Live', label: 'Live album' },
+  { value: 'Remix', label: 'Remix' },
+  { value: 'Bootleg', label: 'Bootleg' },
+  { value: 'Interview', label: 'Interview' },
+  { value: 'Mixtape', label: 'Mixtape' },
+  { value: 'Demo', label: 'Demo' },
+  { value: 'ConcertRecording', label: 'Concert recording' },
+  { value: 'Unknown', label: 'Unknown' }
+] as const;
+type ReleaseCategoryValue = (typeof RELEASE_CATEGORIES)[number]['value'];
+
+// Encoding / bitrate — values mirror the API Bitrate enum.
+const BITRATES = [
+  { value: 'Lossless', label: 'Lossless' },
+  { value: 'Lossless24', label: 'Lossless (24-bit)' },
+  { value: 'Kbps320', label: '320 kbps' },
+  { value: 'Kbps256', label: '256 kbps' },
+  { value: 'KbpsV0', label: 'V0 (VBR)' },
+  { value: 'Kbps192', label: '192 kbps' },
+  { value: 'KbpsV2', label: 'V2 (VBR)' },
+  { value: 'Kbps128', label: '128 kbps' },
+  { value: 'Other', label: 'Other' }
+] as const;
+type BitrateValue = (typeof BITRATES)[number]['value'];
+
+// Source media — values mirror the API ReleaseMedia enum.
+const MEDIA = [
+  { value: 'CD', label: 'CD' },
+  { value: 'WEB', label: 'WEB' },
+  { value: 'Vinyl', label: 'Vinyl' },
+  { value: 'SACD', label: 'SACD' },
+  { value: 'DVD', label: 'DVD' },
+  { value: 'Cassette', label: 'Cassette' },
+  { value: 'BluRay', label: 'Blu-ray' },
+  { value: 'DAT', label: 'DAT' },
+  { value: 'Soundboard', label: 'Soundboard' },
+  { value: 'Other', label: 'Other' }
+] as const;
+type MediaValue = (typeof MEDIA)[number]['value'];
+
 const inputClass =
   'w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-indigo-500';
 const labelClass = 'block text-sm font-medium text-gray-300 mb-1';
 const fieldWrap = 'space-y-1';
+const fieldsetClass =
+  'border border-gray-700/70 rounded-lg p-4 space-y-5 min-w-0';
+const legendClass = 'px-2 text-sm font-semibold text-gray-100 uppercase';
+const helpClass = 'text-xs text-gray-500';
+const checkboxRowClass = 'flex items-start gap-2';
+const checkboxLabelClass = 'text-sm text-gray-300';
+const srOnly = 'sr-only';
+
+// Visual-only required mark; requirement is conveyed to assistive tech via the
+// input's `required` / `aria-required`, so the asterisk is hidden from the a11y
+// tree to avoid "Title star" announcements.
+const RequiredMark = () => (
+  <span className="text-red-500" aria-hidden="true">
+    {' '}
+    *
+  </span>
+);
 
 const ContributeForm = () => {
   const navigate = useNavigate();
@@ -74,19 +144,43 @@ const ContributeForm = () => {
 
   const [community, setCommunity] = useState('');
   const [type, setType] = useState<ContentType>('Music');
+  const [releaseCategory, setReleaseCategory] =
+    useState<ReleaseCategoryValue>('Album');
   const [year, setYear] = useState(new Date().getFullYear().toString());
   const [fileType, setFileType] = useState<FileType>('mp3');
+  const [bitrate, setBitrate] = useState<BitrateValue | ''>('');
+  const [media, setMedia] = useState<MediaValue | ''>('');
   const [downloadUrl, setDownloadUrl] = useState('');
   const [sizeMB, setSizeMB] = useState('');
   const [title, setTitle] = useState('');
   const [album, setAlbum] = useState('');
+  const [recordLabel, setRecordLabel] = useState('');
+  const [catalogueNumber, setCatalogueNumber] = useState('');
   const [tags, setTags] = useState('');
   const [image, setImage] = useState('');
   const [description, setDescription] = useState('');
   const [releaseDescription, setReleaseDescription] = useState('');
+  const [isScene, setIsScene] = useState(false);
+  const [hasLog, setHasLog] = useState(false);
+  const [hasCue, setHasCue] = useState(false);
+  const [editionEnabled, setEditionEnabled] = useState(false);
+  const [editionTitle, setEditionTitle] = useState('');
+  const [editionYear, setEditionYear] = useState('');
+  const [isRemaster, setIsRemaster] = useState(false);
   const [collaborators, setCollaborators] = useState<Collaborator[]>([
     { artist: '', importance: 'Main artist' }
   ]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Refs to each artist-name input so focus can follow add/remove operations.
+  const artistInputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const pendingFocus = useRef<number | null>(null);
+
+  const isMusic = type === 'Music';
+  const errorId = useId();
+  const mbHintId = useId();
+  const albumGuidanceId = useId();
+  const urlHelpId = useId();
 
   const { data: dncList } = useGetDncListQuery(
     community ? parseInt(community, 10) : 0,
@@ -101,16 +195,26 @@ const ContributeForm = () => {
     }
   }, [type]);
 
+  // Move focus to the row requested by the last add/remove action.
+  useEffect(() => {
+    if (pendingFocus.current === null) return;
+    const target = artistInputRefs.current[pendingFocus.current];
+    target?.focus();
+    pendingFocus.current = null;
+  }, [collaborators]);
+
   const addCollaborator = (e: React.MouseEvent) => {
     e.preventDefault();
+    pendingFocus.current = collaborators.length;
     setCollaborators([
       ...collaborators,
-      { artist: '', importance: 'Main artist' }
+      { artist: '', importance: isMusic ? 'Main artist' : 'Creator' }
     ]);
   };
 
   const removeCollaborator = (e: React.MouseEvent, index: number) => {
     e.preventDefault();
+    pendingFocus.current = Math.max(0, index - 1);
     setCollaborators(collaborators.filter((_, i) => i !== index));
   };
 
@@ -127,11 +231,12 @@ const ContributeForm = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user) return;
+    setSubmitError(null);
     try {
       await createContribution({
         communityId: parseInt(community),
         type,
-        title: type === 'Music' ? album : title,
+        title: isMusic ? album : title,
         year: parseInt(year, 10),
         fileType,
         downloadUrl,
@@ -141,22 +246,38 @@ const ContributeForm = () => {
         tags,
         image,
         description,
-        releaseDescription: type === 'Music' ? releaseDescription : undefined,
-        collaborators
+        releaseDescription: isMusic ? releaseDescription : undefined,
+        collaborators,
+        releaseCategory: isMusic ? releaseCategory : undefined,
+        recordLabel: isMusic ? recordLabel || undefined : undefined,
+        catalogueNumber: isMusic ? catalogueNumber || undefined : undefined,
+        bitrate: isMusic ? bitrate || undefined : undefined,
+        media: isMusic ? media || undefined : undefined,
+        isScene,
+        hasLog: isMusic ? hasLog : undefined,
+        hasCue: isMusic ? hasCue : undefined,
+        editionTitle:
+          isMusic && editionEnabled ? editionTitle || undefined : undefined,
+        editionYear:
+          isMusic && editionEnabled && editionYear
+            ? parseInt(editionYear, 10)
+            : undefined,
+        isRemaster: isMusic && editionEnabled ? isRemaster : undefined
       }).unwrap();
       navigate('/private/contribute/list');
     } catch (err) {
-      dispatch(
-        addAlert(
-          getApiErrorMessage(err) ??
-            'Failed to submit contribution. Please try again.',
-          'danger'
-        )
-      );
+      const message =
+        getApiErrorMessage(err) ??
+        'Failed to submit contribution. Please try again.';
+      setSubmitError(message);
+      dispatch(addAlert(message, 'danger'));
     }
   };
 
   if (loadingCommunities) return <Spinner />;
+
+  const roleOptions = isMusic ? ARTIST_TYPES : CREATOR_TYPES;
+  const creatorWord = isMusic ? 'artist' : 'creator';
 
   return (
     <div>
@@ -164,116 +285,152 @@ const ContributeForm = () => {
         Upload a release
       </h2>
 
-      <form onSubmit={handleSubmit} className="space-y-5">
-        <div className={fieldWrap}>
-          <label htmlFor="contribute-community" className={labelClass}>
-            Community <span className="text-red-500">*</span>
-          </label>
-          <select
-            id="contribute-community"
-            value={community}
-            onChange={(e) => setCommunity(e.target.value)}
-            required
-            className={inputClass}
-          >
-            <option value="">Select a community</option>
-            {communities?.data?.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-          </select>
-          <p className="text-xs text-gray-500">
-            Can&apos;t find your community?{' '}
-            <Link
-              to="/private/requests"
-              className="text-indigo-400 hover:text-indigo-300"
-            >
-              Submit a request.
-            </Link>
-          </p>
+      <p className={helpClass + ' mb-4'}>
+        Fields marked <span className="text-red-500">*</span> are required.
+      </p>
+
+      {submitError && (
+        <div
+          id={errorId}
+          role="alert"
+          aria-live="assertive"
+          className="mb-5 rounded-lg border border-red-600/50 bg-red-900/20 p-3 text-sm text-red-300"
+        >
+          {submitError}
         </div>
+      )}
 
-        {dncList && dncList.length > 0 && (
-          <div className="rounded-lg border border-yellow-600/50 bg-yellow-900/20 p-4 space-y-2">
-            <h3 className="text-sm font-semibold text-yellow-400 uppercase tracking-wider">
-              Do Not Contribute List
-            </h3>
-            <p className="text-xs text-yellow-300/80">
-              The following artists, labels, and releases must not be
-              contributed to this community:
-            </p>
-            <ul className="space-y-1">
-              {dncList.map((entry) => (
-                <li key={entry.id} className="flex flex-wrap gap-x-2 text-sm">
-                  <span className="text-yellow-200 font-medium">
-                    {entry.name}
-                  </span>
-                  {entry.comment && (
-                    <span className="text-yellow-300/60 text-xs self-center">
-                      — {entry.comment}
-                    </span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
+      <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+        {/* ─── Release information ─────────────────────────────────────── */}
+        <fieldset className={fieldsetClass}>
+          <legend className={legendClass}>Release information</legend>
 
-        <div className="grid grid-cols-2 gap-4">
           <div className={fieldWrap}>
-            <label htmlFor="contribute-type" className={labelClass}>
-              Content type <span className="text-red-500">*</span>
+            <label htmlFor="contribute-community" className={labelClass}>
+              Community
+              <RequiredMark />
             </label>
             <select
-              id="contribute-type"
-              value={type}
-              onChange={(e) => setType(e.target.value as ContentType)}
+              id="contribute-community"
+              value={community}
+              onChange={(e) => setCommunity(e.target.value)}
+              required
+              aria-required="true"
               className={inputClass}
             >
-              {CONTENT_TYPES.map((t) => (
-                <option key={t} value={t}>
-                  {t}
+              <option value="">Select a community</option>
+              {communities?.data?.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
                 </option>
               ))}
             </select>
+            <p className={helpClass}>
+              Can&apos;t find your community?{' '}
+              <Link
+                to="/private/requests"
+                className="text-indigo-400 hover:text-indigo-300"
+              >
+                Submit a request.
+              </Link>
+            </p>
           </div>
 
-          <div className={fieldWrap}>
-            <label htmlFor="contribute-year" className={labelClass}>
-              Year <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="contribute-year"
-              type="number"
-              min="1900"
-              max="2100"
-              value={year}
-              onChange={(e) => setYear(e.target.value)}
-              required
-              className={inputClass}
-            />
-          </div>
-        </div>
+          {dncList && dncList.length > 0 && (
+            <div
+              role="alert"
+              aria-live="polite"
+              className="rounded-lg border border-yellow-600/50 bg-yellow-900/20 p-4 space-y-2"
+            >
+              <h3 className="text-sm font-semibold text-yellow-400 uppercase tracking-wider">
+                Do Not Contribute List
+              </h3>
+              <p className="text-xs text-yellow-300/80">
+                The following artists, labels, and releases must not be
+                contributed to this community:
+              </p>
+              <ul className="space-y-1">
+                {dncList.map((entry) => (
+                  <li key={entry.id} className="flex flex-wrap gap-x-2 text-sm">
+                    <span className="text-yellow-200 font-medium">
+                      {entry.name}
+                    </span>
+                    {entry.comment && (
+                      <span className="text-yellow-300/60 text-xs self-center">
+                        — {entry.comment}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
-        <div className={fieldWrap}>
-          <label className={labelClass}>
-            {type === 'Music' ? 'Artist(s)' : 'Creator(s)'}{' '}
-            <span className="text-red-500">*</span>
-          </label>
-          <div className="space-y-2">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className={fieldWrap}>
+              <label htmlFor="contribute-type" className={labelClass}>
+                Content type
+                <RequiredMark />
+              </label>
+              <select
+                id="contribute-type"
+                value={type}
+                onChange={(e) => setType(e.target.value as ContentType)}
+                className={inputClass}
+              >
+                {CONTENT_TYPES.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {isMusic && (
+              <div className={fieldWrap}>
+                <label htmlFor="contribute-category" className={labelClass}>
+                  Release type
+                  <RequiredMark />
+                </label>
+                <select
+                  id="contribute-category"
+                  value={releaseCategory}
+                  onChange={(e) =>
+                    setReleaseCategory(e.target.value as ReleaseCategoryValue)
+                  }
+                  className={inputClass}
+                >
+                  {RELEASE_CATEGORIES.map((c) => (
+                    <option key={c.value} value={c.value}>
+                      {c.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+
+          {/* Artists / creators */}
+          <fieldset className="space-y-2 min-w-0">
+            <legend className={labelClass}>
+              {isMusic ? 'Artist(s)' : 'Creator(s)'}
+              <RequiredMark />
+            </legend>
             {collaborators.map((c, i) => (
               <div key={i} className="flex gap-2 items-center">
                 <input
+                  ref={(el) => {
+                    artistInputRefs.current[i] = el;
+                  }}
                   type="text"
                   value={c.artist}
                   onChange={(e) =>
                     updateCollaborator(i, 'artist', e.target.value)
                   }
-                  placeholder={
-                    type === 'Music' ? 'Artist name' : 'Creator name'
-                  }
+                  placeholder={isMusic ? 'Artist name' : 'Creator name'}
+                  aria-label={`${isMusic ? 'Artist' : 'Creator'} name ${i + 1}`}
                   required
+                  aria-required="true"
                   className="flex-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-indigo-500"
                 />
                 <select
@@ -281,12 +438,10 @@ const ContributeForm = () => {
                   onChange={(e) =>
                     updateCollaborator(i, 'importance', e.target.value)
                   }
+                  aria-label={`Role for ${creatorWord} ${i + 1}`}
                   className="px-2 py-2 bg-gray-800 border border-gray-700 rounded text-sm text-gray-200 focus:outline-none focus:border-indigo-500"
                 >
-                  {(type === 'Music'
-                    ? ARTIST_TYPES
-                    : ['Creator', 'Contributor', 'Editor']
-                  ).map((t) => (
+                  {roleOptions.map((t) => (
                     <option key={t} value={t}>
                       {t}
                     </option>
@@ -296,9 +451,10 @@ const ContributeForm = () => {
                   <button
                     type="button"
                     onClick={(e) => removeCollaborator(e, i)}
+                    aria-label={`Remove ${creatorWord} ${i + 1}`}
                     className="text-gray-500 hover:text-red-400 text-sm px-1"
                   >
-                    ✕
+                    <span aria-hidden="true">✕</span>
                   </button>
                 )}
               </div>
@@ -308,142 +464,404 @@ const ContributeForm = () => {
               onClick={addCollaborator}
               className="text-indigo-400 hover:text-indigo-300 text-sm"
             >
-              + Add {type === 'Music' ? 'artist' : 'creator'}
+              + Add {creatorWord}
             </button>
-          </div>
-        </div>
+          </fieldset>
 
-        <div className={fieldWrap}>
-          <label htmlFor="contribute-album" className={labelClass}>
-            {type === 'Music' ? 'Album title' : 'Title'}{' '}
-            <span className="text-red-500">*</span>
-          </label>
-          <input
-            id="contribute-album"
-            type="text"
-            value={type === 'Music' ? album : title}
-            onChange={(e) =>
-              type === 'Music'
-                ? setAlbum(e.target.value)
-                : setTitle(e.target.value)
-            }
-            required
-            className={inputClass}
-          />
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
           <div className={fieldWrap}>
-            <label htmlFor="contribute-filetype" className={labelClass}>
-              File type <span className="text-red-500">*</span>
+            <label htmlFor="contribute-album" className={labelClass}>
+              {isMusic ? 'Album title' : 'Title'}
+              <RequiredMark />
             </label>
-            <select
-              id="contribute-filetype"
-              value={fileType}
-              onChange={(e) => setFileType(e.target.value as FileType)}
-              className={inputClass}
-            >
-              {FILE_TYPES.map((value) => (
-                <option key={value} value={value}>
-                  {value}
-                </option>
-              ))}
-            </select>
+            <div className="flex gap-2 items-start">
+              <input
+                id="contribute-album"
+                type="text"
+                value={isMusic ? album : title}
+                onChange={(e) =>
+                  isMusic ? setAlbum(e.target.value) : setTitle(e.target.value)
+                }
+                required
+                aria-required="true"
+                aria-describedby={isMusic ? albumGuidanceId : undefined}
+                className={inputClass}
+              />
+              {isMusic && (
+                <button
+                  type="button"
+                  disabled
+                  aria-disabled="true"
+                  title="Coming soon"
+                  aria-describedby={mbHintId}
+                  className="whitespace-nowrap px-3 py-2 bg-gray-700 text-gray-400 text-sm rounded cursor-not-allowed"
+                >
+                  Find info
+                  <span id={mbHintId} className={srOnly}>
+                    MusicBrainz lookup — coming soon
+                  </span>
+                </button>
+              )}
+            </div>
+            {isMusic && (
+              <p id={albumGuidanceId} className={helpClass}>
+                Don&apos;t include remaster, re-issue, edition or
+                country-specific info here — use the Edition fields below.
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className={fieldWrap}>
+              <label htmlFor="contribute-year" className={labelClass}>
+                Year
+                <RequiredMark />
+              </label>
+              <input
+                id="contribute-year"
+                type="number"
+                min="1900"
+                max="2100"
+                value={year}
+                onChange={(e) => setYear(e.target.value)}
+                required
+                aria-required="true"
+                className={inputClass}
+              />
+            </div>
+
+            {isMusic && (
+              <>
+                <div className={fieldWrap}>
+                  <label htmlFor="contribute-label" className={labelClass}>
+                    Record label
+                  </label>
+                  <input
+                    id="contribute-label"
+                    type="text"
+                    value={recordLabel}
+                    onChange={(e) => setRecordLabel(e.target.value)}
+                    className={inputClass}
+                  />
+                </div>
+                <div className={fieldWrap}>
+                  <label htmlFor="contribute-catno" className={labelClass}>
+                    Catalogue number
+                  </label>
+                  <input
+                    id="contribute-catno"
+                    type="text"
+                    value={catalogueNumber}
+                    onChange={(e) => setCatalogueNumber(e.target.value)}
+                    className={inputClass}
+                  />
+                </div>
+              </>
+            )}
           </div>
 
           <div className={fieldWrap}>
-            <label htmlFor="contribute-size" className={labelClass}>
-              File size (MB) <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="contribute-size"
-              type="number"
-              min="0.01"
-              step="0.01"
-              value={sizeMB}
-              onChange={(e) => setSizeMB(e.target.value)}
-              placeholder="e.g. 85.4"
-              required
-              className={inputClass}
-            />
-          </div>
-        </div>
-
-        <div className={fieldWrap}>
-          <label htmlFor="contribute-url" className={labelClass}>
-            Download URL <span className="text-red-500">*</span>
-          </label>
-          <input
-            id="contribute-url"
-            type="url"
-            value={downloadUrl}
-            onChange={(e) => setDownloadUrl(e.target.value)}
-            placeholder="https://example.com/files/my-release.zip"
-            required
-            className={inputClass}
-          />
-          <p className="text-xs text-gray-500">
-            Link to where the file is hosted (e.g. GitHub, Google Drive, your
-            own server)
-          </p>
-        </div>
-
-        <div className={fieldWrap}>
-          <label htmlFor="contribute-tags" className={labelClass}>
-            Tags
-          </label>
-          <input
-            id="contribute-tags"
-            type="text"
-            value={tags}
-            onChange={(e) => setTags(e.target.value)}
-            placeholder="rock, jazz, ambient (comma-separated)"
-            className={inputClass}
-          />
-        </div>
-
-        <div className={fieldWrap}>
-          <label htmlFor="contribute-image" className={labelClass}>
-            Cover image URL (optional)
-          </label>
-          <input
-            id="contribute-image"
-            type="text"
-            value={image}
-            onChange={(e) => setImage(e.target.value)}
-            className={inputClass}
-          />
-        </div>
-
-        {type === 'Music' ? (
-          <div className={fieldWrap}>
-            <label htmlFor="contribute-reldesc" className={labelClass}>
-              Release description (optional)
+            <label htmlFor="contribute-tags" className={labelClass}>
+              Tags
             </label>
             <input
-              id="contribute-reldesc"
+              id="contribute-tags"
               type="text"
-              value={releaseDescription}
-              onChange={(e) => setReleaseDescription(e.target.value)}
-              placeholder="e.g. 24-bit remaster, limited edition…"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              placeholder="rock, jazz, ambient (comma-separated)"
               className={inputClass}
             />
           </div>
-        ) : (
+
           <div className={fieldWrap}>
-            <label htmlFor="contribute-desc" className={labelClass}>
-              Description <span className="text-red-500">*</span>
+            <label htmlFor="contribute-image" className={labelClass}>
+              Cover image URL (optional)
             </label>
-            <textarea
-              id="contribute-desc"
-              rows={5}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              required
-              className={inputClass + ' resize-y'}
+            <input
+              id="contribute-image"
+              type="text"
+              value={image}
+              onChange={(e) => setImage(e.target.value)}
+              className={inputClass}
             />
           </div>
+
+          {isMusic ? (
+            <div className={fieldWrap}>
+              <label htmlFor="contribute-reldesc" className={labelClass}>
+                Release description (optional)
+              </label>
+              <input
+                id="contribute-reldesc"
+                type="text"
+                value={releaseDescription}
+                onChange={(e) => setReleaseDescription(e.target.value)}
+                placeholder="e.g. 24-bit remaster, limited edition…"
+                className={inputClass}
+              />
+            </div>
+          ) : (
+            <div className={fieldWrap}>
+              <label htmlFor="contribute-desc" className={labelClass}>
+                Description
+                <RequiredMark />
+              </label>
+              <textarea
+                id="contribute-desc"
+                rows={5}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                required
+                aria-required="true"
+                className={inputClass + ' resize-y'}
+              />
+            </div>
+          )}
+        </fieldset>
+
+        {/* ─── Edition information (Music only) ────────────────────────── */}
+        {isMusic && (
+          <fieldset className={fieldsetClass}>
+            <legend className={legendClass}>Edition information</legend>
+
+            <div className={checkboxRowClass}>
+              <input
+                id="contribute-edition-toggle"
+                type="checkbox"
+                checked={editionEnabled}
+                onChange={(e) => setEditionEnabled(e.target.checked)}
+                className="mt-0.5"
+              />
+              <label
+                htmlFor="contribute-edition-toggle"
+                className={checkboxLabelClass}
+              >
+                This is a specific edition (remaster, reissue, special or
+                country-specific edition).
+              </label>
+            </div>
+
+            {editionEnabled && (
+              <div className="space-y-5 pl-6">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className={fieldWrap}>
+                    <label
+                      htmlFor="contribute-edition-title"
+                      className={labelClass}
+                    >
+                      Edition title
+                    </label>
+                    <input
+                      id="contribute-edition-title"
+                      type="text"
+                      value={editionTitle}
+                      onChange={(e) => setEditionTitle(e.target.value)}
+                      placeholder="e.g. Deluxe Edition"
+                      className={inputClass}
+                    />
+                  </div>
+                  <div className={fieldWrap}>
+                    <label
+                      htmlFor="contribute-edition-year"
+                      className={labelClass}
+                    >
+                      Edition year
+                    </label>
+                    <input
+                      id="contribute-edition-year"
+                      type="number"
+                      min="1900"
+                      max="2100"
+                      value={editionYear}
+                      onChange={(e) => setEditionYear(e.target.value)}
+                      className={inputClass}
+                    />
+                  </div>
+                </div>
+                <div className={checkboxRowClass}>
+                  <input
+                    id="contribute-remaster"
+                    type="checkbox"
+                    checked={isRemaster}
+                    onChange={(e) => setIsRemaster(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <label
+                    htmlFor="contribute-remaster"
+                    className={checkboxLabelClass}
+                  >
+                    This edition is a remaster.
+                  </label>
+                </div>
+              </div>
+            )}
+          </fieldset>
         )}
+
+        {/* ─── File information ────────────────────────────────────────── */}
+        <fieldset className={fieldsetClass}>
+          <legend className={legendClass}>File information</legend>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className={fieldWrap}>
+              <label htmlFor="contribute-filetype" className={labelClass}>
+                {isMusic ? 'Format' : 'File type'}
+                <RequiredMark />
+              </label>
+              <select
+                id="contribute-filetype"
+                value={fileType}
+                onChange={(e) => setFileType(e.target.value as FileType)}
+                className={inputClass}
+              >
+                {FILE_TYPES.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {isMusic && (
+              <>
+                <div className={fieldWrap}>
+                  <label htmlFor="contribute-bitrate" className={labelClass}>
+                    Bitrate
+                  </label>
+                  <select
+                    id="contribute-bitrate"
+                    value={bitrate}
+                    onChange={(e) =>
+                      setBitrate(e.target.value as BitrateValue | '')
+                    }
+                    className={inputClass}
+                  >
+                    <option value="">—</option>
+                    {BITRATES.map((b) => (
+                      <option key={b.value} value={b.value}>
+                        {b.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className={fieldWrap}>
+                  <label htmlFor="contribute-media" className={labelClass}>
+                    Media
+                  </label>
+                  <select
+                    id="contribute-media"
+                    value={media}
+                    onChange={(e) =>
+                      setMedia(e.target.value as MediaValue | '')
+                    }
+                    className={inputClass}
+                  >
+                    <option value="">—</option>
+                    {MEDIA.map((m) => (
+                      <option key={m.value} value={m.value}>
+                        {m.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className={fieldWrap}>
+              <label htmlFor="contribute-size" className={labelClass}>
+                File size (MB)
+                <RequiredMark />
+              </label>
+              <input
+                id="contribute-size"
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={sizeMB}
+                onChange={(e) => setSizeMB(e.target.value)}
+                placeholder="e.g. 85.4"
+                required
+                aria-required="true"
+                className={inputClass}
+              />
+            </div>
+
+            <div className={fieldWrap}>
+              <label htmlFor="contribute-url" className={labelClass}>
+                Download URL
+                <RequiredMark />
+              </label>
+              <input
+                id="contribute-url"
+                type="url"
+                value={downloadUrl}
+                onChange={(e) => setDownloadUrl(e.target.value)}
+                placeholder="https://example.com/files/my-release.zip"
+                required
+                aria-required="true"
+                aria-describedby={urlHelpId}
+                className={inputClass}
+              />
+              <p id={urlHelpId} className={helpClass}>
+                Link to where the file is hosted (e.g. GitHub, Google Drive,
+                your own server).
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className={checkboxRowClass}>
+              <input
+                id="contribute-scene"
+                type="checkbox"
+                checked={isScene}
+                onChange={(e) => setIsScene(e.target.checked)}
+                className="mt-0.5"
+              />
+              <label htmlFor="contribute-scene" className={checkboxLabelClass}>
+                This is a Scene release. If you ripped it yourself, it is{' '}
+                <strong>not</strong> a Scene release.
+              </label>
+            </div>
+
+            {isMusic && (
+              <>
+                <div className={checkboxRowClass}>
+                  <input
+                    id="contribute-haslog"
+                    type="checkbox"
+                    checked={hasLog}
+                    onChange={(e) => setHasLog(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <label
+                    htmlFor="contribute-haslog"
+                    className={checkboxLabelClass}
+                  >
+                    Includes a rip log.
+                  </label>
+                </div>
+                <div className={checkboxRowClass}>
+                  <input
+                    id="contribute-hascue"
+                    type="checkbox"
+                    checked={hasCue}
+                    onChange={(e) => setHasCue(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <label
+                    htmlFor="contribute-hascue"
+                    className={checkboxLabelClass}
+                  >
+                    Includes a cue sheet.
+                  </label>
+                </div>
+              </>
+            )}
+          </div>
+        </fieldset>
 
         <div className="flex gap-3 pt-2">
           <button

--- a/src/components/releases/ReleaseBrowsePage.tsx
+++ b/src/components/releases/ReleaseBrowsePage.tsx
@@ -121,8 +121,8 @@ const ReleaseBrowsePage = () => {
     type: type as never,
     releaseType: releaseType as never,
     format: format as never,
-    bitrate,
-    media,
+    bitrate: bitrate as never,
+    media: media as never,
     hasLog,
     hasCue,
     isScene,
@@ -560,13 +560,17 @@ const ReleaseBrowsePage = () => {
                             {r.title}
                           </span>
                         )}
-                        <span className="text-gray-500 mx-1">—</span>
-                        <Link
-                          to={`/private/artists/${r.artist.id}`}
-                          className="text-gray-400 hover:text-gray-200"
-                        >
-                          {r.artist.name}
-                        </Link>
+                        {r.artist && (
+                          <>
+                            <span className="text-gray-500 mx-1">—</span>
+                            <Link
+                              to={`/private/artists/${r.artist.id}`}
+                              className="text-gray-400 hover:text-gray-200"
+                            >
+                              {r.artist.name}
+                            </Link>
+                          </>
+                        )}
                       </td>
                       <td className="py-2 pr-4 text-gray-400">{r.year}</td>
                       <td className="py-2 pr-4 text-gray-400">

--- a/src/store/services/communityApi.ts
+++ b/src/store/services/communityApi.ts
@@ -116,10 +116,7 @@ export const communityApi = api.injectEndpoints({
       ReleaseResponse,
       ReleaseArgs &
         Partial<
-          Pick<
-            ReleaseResponse,
-            'title' | 'description' | 'image' | 'year' | 'isEdition' | 'edition'
-          >
+          Pick<ReleaseResponse, 'title' | 'description' | 'image' | 'year'>
         > & { editSummary?: string }
     >({
       query: ({ communityId, releaseId, ...data }) => ({

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -748,7 +748,7 @@ export interface paths {
             profileTitle?: string;
             profileInfo?: string;
             siteAppearance?: string;
-            externalStylesheet?: string;
+            externalStylesheet?: string | '';
             styledTooltips?: boolean;
             paranoia?: number | null;
             /** @enum {string} */
@@ -3487,6 +3487,61 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/communities/{id}/health': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Community link-health pulse */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['CommunityHealthPulse'];
+          };
+        };
+        /** @description Not a member of this community */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+        /** @description Not found */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['MsgResponse'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/communities/{id}/releases': {
     parameters: {
       query?: never;
@@ -3896,8 +3951,29 @@ export interface paths {
             downloadUrl: string;
             sizeInBytes?: number;
             releaseDescription?: string;
-            bitrate?: string;
-            media?: string;
+            /** @enum {string} */
+            bitrate?:
+              | 'Lossless'
+              | 'Lossless24'
+              | 'Kbps320'
+              | 'Kbps256'
+              | 'KbpsV0'
+              | 'Kbps192'
+              | 'KbpsV2'
+              | 'Kbps128'
+              | 'Other';
+            /** @enum {string} */
+            media?:
+              | 'CD'
+              | 'WEB'
+              | 'Vinyl'
+              | 'SACD'
+              | 'DVD'
+              | 'Cassette'
+              | 'BluRay'
+              | 'DAT'
+              | 'Soundboard'
+              | 'Other';
             /** @default false */
             hasLog?: boolean;
             /** @default false */
@@ -4029,8 +4105,51 @@ export interface paths {
             image?: string | '';
             description?: string;
             releaseDescription?: string;
-            bitrate?: string;
-            media?: string;
+            /** @enum {string} */
+            bitrate?:
+              | 'Lossless'
+              | 'Lossless24'
+              | 'Kbps320'
+              | 'Kbps256'
+              | 'KbpsV0'
+              | 'Kbps192'
+              | 'KbpsV2'
+              | 'Kbps128'
+              | 'Other';
+            /** @enum {string} */
+            media?:
+              | 'CD'
+              | 'WEB'
+              | 'Vinyl'
+              | 'SACD'
+              | 'DVD'
+              | 'Cassette'
+              | 'BluRay'
+              | 'DAT'
+              | 'Soundboard'
+              | 'Other';
+            /** @enum {string} */
+            releaseCategory?:
+              | 'Album'
+              | 'Single'
+              | 'EP'
+              | 'Anthology'
+              | 'Compilation'
+              | 'DJMix'
+              | 'Live'
+              | 'Remix'
+              | 'Bootleg'
+              | 'Interview'
+              | 'Mixtape'
+              | 'Demo'
+              | 'ConcertRecording'
+              | 'Unknown';
+            recordLabel?: string;
+            catalogueNumber?: string;
+            editionTitle?: string;
+            editionYear?: number;
+            /** @default false */
+            isRemaster?: boolean;
             /** @default false */
             hasLog?: boolean;
             /** @default false */
@@ -8940,6 +9059,7 @@ export interface paths {
             groupId: number;
             threadId: number;
             title: string;
+            image?: string | '';
             /** Format: date-time */
             started: string;
             /** Format: date-time */
@@ -9958,8 +10078,27 @@ export interface paths {
             | 'png'
             | 'gif'
             | 'txt';
-          bitrate?: string;
-          media?: string;
+          bitrate?:
+            | 'Lossless'
+            | 'Lossless24'
+            | 'Kbps320'
+            | 'Kbps256'
+            | 'KbpsV0'
+            | 'Kbps192'
+            | 'KbpsV2'
+            | 'Kbps128'
+            | 'Other';
+          media?:
+            | 'CD'
+            | 'WEB'
+            | 'Vinyl'
+            | 'SACD'
+            | 'DVD'
+            | 'Cassette'
+            | 'BluRay'
+            | 'DAT'
+            | 'Soundboard'
+            | 'Other';
           hasLog?: boolean | null;
           hasCue?: boolean | null;
           isScene?: boolean | null;
@@ -9985,15 +10124,12 @@ export interface paths {
                 type: string;
                 releaseType: string;
                 communityId: number | null;
-                catalogueNumber: string | null;
-                recordLabel: string | null;
                 description: string;
                 createdAt: string;
                 artist: {
                   id: number;
                   name: string;
-                  vanityHouse: boolean;
-                };
+                } | null;
                 tags: {
                   id: number;
                   name: string;
@@ -11491,6 +11627,11 @@ export interface components {
       isDefault: boolean;
       createdAt: string;
     };
+    StylesheetStat: {
+      id: number;
+      name: string;
+      userCount: number;
+    };
     GlobalNotice: {
       id: number;
       message: string;
@@ -11501,11 +11642,6 @@ export interface components {
         id: number;
         username: string;
       };
-    };
-    StylesheetStat: {
-      id: number;
-      name: string;
-      userCount: number;
     };
     Forum: {
       id: number;
@@ -11711,6 +11847,9 @@ export interface components {
       type: string;
       downloadUrl: string;
       sizeInBytes?: number | null;
+      /** @enum {string} */
+      linkStatus: 'UNKNOWN' | 'PASS' | 'WARN' | 'FAIL';
+      linkCheckedAt?: string | null;
       collaborators: {
         id: number;
         name: string;
@@ -11741,8 +11880,6 @@ export interface components {
       description: string;
       image: string | null;
       year: number;
-      isEdition: boolean;
-      edition?: unknown;
       tagIds: number[];
       tagNames: string[];
     };
@@ -11779,10 +11916,8 @@ export interface components {
       releaseType?: string | null;
       image?: string | null;
       description?: string | null;
-      isEdition?: boolean;
-      edition?: unknown;
       createdAt?: string;
-      artist?: components['schemas']['ReleaseArtist'];
+      artist?: components['schemas']['ReleaseArtist'] & unknown;
       tags?: components['schemas']['ReleaseTag'][];
       releaseTags?: components['schemas']['ReleaseTagEnriched'][];
       /** @enum {string|null} */
@@ -12289,6 +12424,18 @@ export interface components {
         id: number;
         username: string;
       } | null;
+    };
+    CommunityHealthPulse: {
+      pass: number;
+      warn: number;
+      fail: number;
+      unknown: number;
+      total: number;
+      checked: number;
+      coverage: number | null;
+      pulse: number | null;
+      /** @enum {string} */
+      status: 'Healthy' | 'Ailing' | 'Critical' | 'Unknown';
     };
   };
   responses: never;

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -21,6 +21,7 @@ const apiUrl = process.env.STELLAR_API_URL || 'http://localhost:8080';
 const plugins = [
   new webpack.DefinePlugin({
     __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || ''),
+    // Footer version surface — pinned to the manifest so it can't drift.
     __APP_VERSION__: JSON.stringify(pkg.version)
   }),
   new CleanPlugin(),


### PR DESCRIPTION
Linear single-commit re-do of #69. The original promoted fork `main` directly, which carries merge commits — and this repo is **rebase-only + `required_linear_history`**, so "Rebase and merge" couldn't replay it ("this branch can't be rebased"). This branch squashes the same work into one linear commit that rebase-merges cleanly.

Same content as #69 (contribution form + a11y + Playwright/axe e2e, api.ts resync, footer version pin, Codacy lint fix). Green on the fork: typecheck, lint, 1140 tests.

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)