### PR TITLE
test(avatar): lock the seeded-avatar contract (UI half)

### DIFF
--- a/src/__tests__/utils/avatar.test.ts
+++ b/src/__tests__/utils/avatar.test.ts
@@ -1,0 +1,33 @@
+import { avatarSrc, SEEDED_AVATAR_SENTINEL } from '../../utils/avatar';
+
+// Locks the UI half of the seeded-avatar cross-repo contract. The bug this
+// guards: stellar-api's devTools generator and this sentinel drifted (the API
+// stored null while the UI still expected 'seeded'), so seeded test users
+// rendered the shared default instead of the distinct seeded asset.
+//
+// Note: jest maps every image import to '' (src/__tests__/fileMock.js), so the
+// seeded vs default *assets* can't be distinguished here — these tests lock the
+// sentinel value + mapping behaviour, not the rendered pixels.
+describe('avatarSrc', () => {
+  it('keeps the seeded sentinel value in sync with the API', () => {
+    // Must equal SEEDED_AVATAR in stellar-api devTools generators/users.ts.
+    expect(SEEDED_AVATAR_SENTINEL).toBe('seeded');
+  });
+
+  it('maps the seeded sentinel to an asset, not a raw <img src="seeded">', () => {
+    // The original bug rendered the sentinel verbatim as a broken image src.
+    expect(avatarSrc(SEEDED_AVATAR_SENTINEL)).not.toBe(SEEDED_AVATAR_SENTINEL);
+  });
+
+  it('passes a real avatar URL through unchanged', () => {
+    const url = 'https://cdn.example.com/me.png';
+    expect(avatarSrc(url)).toBe(url);
+  });
+
+  it('falls back to the default for null, undefined, empty, and whitespace', () => {
+    const fallback = avatarSrc(null);
+    expect(avatarSrc(undefined)).toBe(fallback);
+    expect(avatarSrc('')).toBe(fallback);
+    expect(avatarSrc('   ')).toBe(fallback);
+  });
+});


### PR DESCRIPTION
The UI half of the seeded-avatar fix (stellar-api PR #114). Adds the missing unit test for `utils/avatar.ts`, locking the contract that drifted:

- `SEEDED_AVATAR_SENTINEL === 'seeded'` (must match stellar-api's `SEEDED_AVATAR`)
- the sentinel is **mapped to an asset**, not returned as a raw `<img src="seeded">` (the original broken-image symptom)
- real URLs pass through; null/empty/whitespace → default

Note: jest maps image imports to `''` (`fileMock.js`), so the seeded vs default *assets* aren't distinguishable here — these lock the sentinel/mapping behaviour, not rendered pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)