### PR TITLE
feat(contribute): human-friendly file-size input (value + unit)

### DIFF
--- a/src/__tests__/communities/AddContributionForm.test.tsx
+++ b/src/__tests__/communities/AddContributionForm.test.tsx
@@ -207,6 +207,45 @@ describe('AddContributionForm', () => {
     });
   });
 
+  it('derives sizeInBytes from the value field and unit selector', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AddContributionForm />);
+    await user.type(
+      screen.getByLabelText(/download url/i),
+      'https://example.com/file.flac'
+    );
+    await user.type(screen.getByLabelText(/file size/i), '4.5');
+    await user.selectOptions(screen.getByLabelText(/size unit/i), 'GiB');
+    await user.click(screen.getByRole('button', { name: /add contribution/i }));
+    await waitFor(() => {
+      expect(mockAddContribution).toHaveBeenCalledWith(
+        expect.objectContaining({ sizeInBytes: Math.round(4.5 * 1024 ** 3) })
+      );
+    });
+  });
+
+  it('blocks submit and shows an error when the size is invalid', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AddContributionForm />);
+    await user.type(
+      screen.getByLabelText(/download url/i),
+      'https://example.com/file.flac'
+    );
+    await user.type(screen.getByLabelText(/file size/i), 'abc');
+    await user.click(screen.getByRole('button', { name: /add contribution/i }));
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            msg: expect.stringMatching(/valid file size/i),
+            alertType: 'danger'
+          })
+        })
+      );
+    });
+    expect(mockAddContribution).not.toHaveBeenCalled();
+  });
+
   it('dispatches danger alert with API message on failure', async () => {
     mockAddContribution.mockReturnValue({
       unwrap: () => Promise.reject({ data: { msg: 'Duplicate format.' } })

--- a/src/__tests__/contribute/ContributeForm.test.tsx
+++ b/src/__tests__/contribute/ContributeForm.test.tsx
@@ -470,6 +470,44 @@ describe('ContributeForm', () => {
     });
   });
 
+  it('submits sizeInBytes derived from the value field and unit selector', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ContributeForm />);
+
+    await fillMusicForm(user);
+    fireEvent.change(screen.getByLabelText(/file size/i), {
+      target: { value: '4.5' }
+    });
+    await user.selectOptions(screen.getByLabelText(/size unit/i), 'GiB');
+
+    await user.click(
+      screen.getByRole('button', { name: /contribute release/i })
+    );
+
+    await waitFor(() => {
+      expect(mockCreateContribution).toHaveBeenCalledWith(
+        expect.objectContaining({ sizeInBytes: Math.round(4.5 * 1024 ** 3) })
+      );
+    });
+  });
+
+  it('blocks submit and shows an error when the size is invalid', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ContributeForm />);
+
+    await fillMusicForm(user);
+    fireEvent.change(screen.getByLabelText(/file size/i), {
+      target: { value: 'abc' }
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: /contribute release/i })
+    );
+
+    expect(await screen.findByText(/valid file size/i)).toBeInTheDocument();
+    expect(mockCreateContribution).not.toHaveBeenCalled();
+  });
+
   it('does not send Music-only fields for a non-Music submission', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ContributeForm />);

--- a/src/__tests__/utils/utils.test.ts
+++ b/src/__tests__/utils/utils.test.ts
@@ -2,7 +2,9 @@ import {
   formatDate,
   readableTime,
   formatBytes,
-  ordinalSuffix
+  ordinalSuffix,
+  parseSize,
+  formatSize
 } from '../../utils';
 
 describe('formatDate', () => {
@@ -121,4 +123,89 @@ describe('formatBytes', () => {
   it('formats gigabytes', () => {
     expect(formatBytes(1073741824)).toBe('1.00 GB');
   });
+});
+
+describe('parseSize', () => {
+  it('returns null for empty or whitespace input', () => {
+    expect(parseSize('')).toBeNull();
+    expect(parseSize('   ')).toBeNull();
+  });
+
+  it('interprets a bare number as the default unit', () => {
+    expect(parseSize('500', 'MiB')).toBe(500 * 1024 ** 2);
+    expect(parseSize('2', 'GiB')).toBe(2 * 1024 ** 3);
+  });
+
+  it('defaults to bytes when no unit is given or selected', () => {
+    expect(parseSize('1024')).toBe(1024);
+  });
+
+  it('parses a natural string, overriding the default unit', () => {
+    expect(parseSize('4.5 GiB', 'MiB')).toBe(Math.round(4.5 * 1024 ** 3));
+    expect(parseSize('85.4 MiB')).toBe(Math.round(85.4 * 1024 ** 2));
+  });
+
+  it('is case-insensitive and tolerates missing space', () => {
+    expect(parseSize('1gib')).toBe(1024 ** 3);
+    expect(parseSize('1 TIB')).toBe(1024 ** 4);
+  });
+
+  it('treats SI shorthand (KB/MB/GB/TB) as binary', () => {
+    expect(parseSize('1 MB')).toBe(1024 ** 2);
+    expect(parseSize('1 GB')).toBe(1024 ** 3);
+  });
+
+  it('returns null for malformed input', () => {
+    expect(parseSize('abc')).toBeNull();
+    expect(parseSize('1.2.3 GiB')).toBeNull();
+    expect(parseSize('-5 MiB')).toBeNull();
+  });
+
+  it('returns null for an unrecognized unit', () => {
+    expect(parseSize('5 PB')).toBeNull();
+  });
+
+  it('returns null when the result exceeds Number.MAX_SAFE_INTEGER', () => {
+    expect(parseSize('999999 TiB')).toBeNull();
+    expect(parseSize(`${Number.MAX_SAFE_INTEGER} B`)).toBe(
+      Number.MAX_SAFE_INTEGER
+    );
+    expect(parseSize(`${Number.MAX_SAFE_INTEGER + 1} B`)).toBeNull();
+  });
+});
+
+describe('formatSize', () => {
+  it('returns "0 B" for falsy or negative input', () => {
+    expect(formatSize(undefined)).toBe('0 B');
+    expect(formatSize(null)).toBe('0 B');
+    expect(formatSize(0)).toBe('0 B');
+    expect(formatSize(-5)).toBe('0 B');
+  });
+
+  it('keeps sub-KiB values in whole bytes', () => {
+    expect(formatSize(512)).toBe('512 B');
+  });
+
+  it('uses binary unit labels', () => {
+    expect(formatSize(1024)).toBe('1 KiB');
+    expect(formatSize(1024 ** 2)).toBe('1 MiB');
+    expect(formatSize(1024 ** 3)).toBe('1 GiB');
+    expect(formatSize(1024 ** 4)).toBe('1 TiB');
+  });
+
+  it('trims trailing zeros', () => {
+    expect(formatSize(Math.round(4.5 * 1024 ** 3))).toBe('4.5 GiB');
+    expect(formatSize(2 * 1024 ** 2)).toBe('2 MiB');
+  });
+});
+
+describe('parseSize / formatSize round-trips', () => {
+  it.each(['4.5 GiB', '85.4 MiB', '1 TiB', '512 B', '2 GiB'])(
+    'round-trips %s',
+    (input) => {
+      const bytes = parseSize(input);
+      expect(bytes).not.toBeNull();
+      expect(formatSize(bytes)).toBe(input);
+    }
+  );
 });

--- a/src/components/communities/AddContributionForm.tsx
+++ b/src/components/communities/AddContributionForm.tsx
@@ -7,7 +7,9 @@ import {
 } from '../../store/services/communityApi';
 import { addAlert } from '../../store/slices/alertSlice';
 import { getApiErrorMessage } from '../../utils/apiError';
+import { parseSize, SIZE_INPUT_UNITS } from '../../utils';
 import Spinner from '../layout/Spinner';
+import type { BinarySizeUnit } from '../../utils';
 
 const FILE_TYPES = [
   'mp3',
@@ -100,7 +102,8 @@ const AddContributionForm = () => {
 
   const [fileType, setFileType] = useState<FileType>('mp3');
   const [downloadUrl, setDownloadUrl] = useState('');
-  const [sizeMB, setSizeMB] = useState('');
+  const [sizeValue, setSizeValue] = useState('');
+  const [sizeUnit, setSizeUnit] = useState<BinarySizeUnit>('MiB');
   const [releaseDescription, setReleaseDescription] = useState('');
   const [bitrate, setBitrate] = useState<Bitrate | ''>('');
   const [media, setMedia] = useState<ReleaseMedia | ''>('');
@@ -110,17 +113,29 @@ const AddContributionForm = () => {
 
   const isAudio = AUDIO_FILE_TYPES.includes(fileType);
 
+  const trimmedSize = sizeValue.trim();
+  const sizeInBytes = trimmedSize
+    ? parseSize(trimmedSize, sizeUnit)
+    : undefined;
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (trimmedSize && sizeInBytes === null) {
+      dispatch(
+        addAlert(
+          'Enter a valid file size (e.g. 85.4 MiB or 4.5 GiB).',
+          'danger'
+        )
+      );
+      return;
+    }
     try {
       await addContribution({
         communityId: cId,
         releaseId: rId,
         fileType,
         downloadUrl,
-        sizeInBytes: sizeMB
-          ? Math.round(parseFloat(sizeMB) * 1_048_576)
-          : undefined,
+        sizeInBytes: sizeInBytes ?? undefined,
         releaseDescription: releaseDescription || undefined,
         ...(isAudio && {
           bitrate: bitrate || undefined,
@@ -221,19 +236,32 @@ const AddContributionForm = () => {
         </div>
 
         <div>
-          <label htmlFor="add-size-mb" className={labelClass}>
-            File size (MB, optional)
+          <label htmlFor="add-size" className={labelClass}>
+            File size (optional)
           </label>
-          <input
-            id="add-size-mb"
-            type="number"
-            min="0"
-            step="0.01"
-            value={sizeMB}
-            onChange={(e) => setSizeMB(e.target.value)}
-            placeholder="e.g. 85.4"
-            className={inputClass}
-          />
+          <div className="flex gap-2">
+            <input
+              id="add-size"
+              type="text"
+              inputMode="decimal"
+              value={sizeValue}
+              onChange={(e) => setSizeValue(e.target.value)}
+              placeholder="e.g. 85.4 or 4.5 GiB"
+              className={inputClass}
+            />
+            <select
+              aria-label="Size unit"
+              value={sizeUnit}
+              onChange={(e) => setSizeUnit(e.target.value as BinarySizeUnit)}
+              className={inputClass + ' w-24'}
+            >
+              {SIZE_INPUT_UNITS.map((u) => (
+                <option key={u} value={u}>
+                  {u}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
         {/* Rip-specific fields — audio only */}

--- a/src/components/communities/CommunityPage.tsx
+++ b/src/components/communities/CommunityPage.tsx
@@ -17,7 +17,7 @@ import Spinner from '../layout/Spinner';
 import DownloadButton from './DownloadButton';
 import LinkStatusBadge from './LinkStatusBadge';
 import ReportContributionModal from './ReportContributionModal';
-import { formatBytes } from '../../utils';
+import { formatSize } from '../../utils';
 import type { LinkHealthStatus } from '../../types';
 
 interface ContributionRow {
@@ -348,7 +348,7 @@ const CommunityPage = () => {
                             </span>
                             <span className="text-xs text-gray-500 w-20 shrink-0">
                               {c.sizeInBytes
-                                ? formatBytes(Number(c.sizeInBytes))
+                                ? formatSize(Number(c.sizeInBytes))
                                 : '—'}
                             </span>
                             <Link

--- a/src/components/communities/ReleasePage.tsx
+++ b/src/components/communities/ReleasePage.tsx
@@ -14,7 +14,7 @@ import Time from '../layout/Time';
 import DownloadButton from './DownloadButton';
 import LinkStatusBadge from './LinkStatusBadge';
 import ReportContributionModal from './ReportContributionModal';
-import { formatBytes } from '../../utils';
+import { formatSize } from '../../utils';
 import type { LinkHealthStatus } from '../../types';
 import { useReleaseWorkbench } from './useReleaseWorkbench';
 
@@ -251,7 +251,7 @@ const ReleasePage = () => {
                         </td>
                         <td className="px-4 py-2 text-gray-400 text-xs whitespace-nowrap">
                           {c.sizeInBytes
-                            ? formatBytes(Number(c.sizeInBytes))
+                            ? formatSize(Number(c.sizeInBytes))
                             : '—'}
                         </td>
                         <td className="px-4 py-2">

--- a/src/components/contribute/ContributeForm.tsx
+++ b/src/components/contribute/ContributeForm.tsx
@@ -9,8 +9,10 @@ import {
 import { selectCurrentUser } from '../../store/slices/authSlice';
 import { addAlert } from '../../store/slices/alertSlice';
 import { getApiErrorMessage } from '../../utils/apiError';
+import { parseSize, SIZE_INPUT_UNITS } from '../../utils';
 import Spinner from '../layout/Spinner';
 import type { Collaborator } from '../../types';
+import type { BinarySizeUnit } from '../../utils';
 
 const ARTIST_TYPES = [
   'Main artist',
@@ -151,7 +153,8 @@ const ContributeForm = () => {
   const [bitrate, setBitrate] = useState<BitrateValue | ''>('');
   const [media, setMedia] = useState<MediaValue | ''>('');
   const [downloadUrl, setDownloadUrl] = useState('');
-  const [sizeMB, setSizeMB] = useState('');
+  const [sizeValue, setSizeValue] = useState('');
+  const [sizeUnit, setSizeUnit] = useState<BinarySizeUnit>('MiB');
   const [title, setTitle] = useState('');
   const [album, setAlbum] = useState('');
   const [recordLabel, setRecordLabel] = useState('');
@@ -228,10 +231,19 @@ const ContributeForm = () => {
     setCollaborators(updated);
   };
 
+  const trimmedSize = sizeValue.trim();
+  const sizeInBytes = trimmedSize
+    ? parseSize(trimmedSize, sizeUnit)
+    : undefined;
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user) return;
     setSubmitError(null);
+    if (trimmedSize && sizeInBytes === null) {
+      setSubmitError('Enter a valid file size (e.g. 85.4 MiB or 4.5 GiB).');
+      return;
+    }
     try {
       await createContribution({
         communityId: parseInt(community),
@@ -240,9 +252,7 @@ const ContributeForm = () => {
         year: parseInt(year, 10),
         fileType,
         downloadUrl,
-        sizeInBytes: sizeMB
-          ? Math.round(parseFloat(sizeMB) * 1_048_576)
-          : undefined,
+        sizeInBytes: sizeInBytes ?? undefined,
         tags,
         image,
         description,
@@ -771,21 +781,36 @@ const ContributeForm = () => {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className={fieldWrap}>
               <label htmlFor="contribute-size" className={labelClass}>
-                File size (MB)
+                File size
                 <RequiredMark />
               </label>
-              <input
-                id="contribute-size"
-                type="number"
-                min="0.01"
-                step="0.01"
-                value={sizeMB}
-                onChange={(e) => setSizeMB(e.target.value)}
-                placeholder="e.g. 85.4"
-                required
-                aria-required="true"
-                className={inputClass}
-              />
+              <div className="flex gap-2">
+                <input
+                  id="contribute-size"
+                  type="text"
+                  inputMode="decimal"
+                  value={sizeValue}
+                  onChange={(e) => setSizeValue(e.target.value)}
+                  placeholder="e.g. 85.4 or 4.5 GiB"
+                  required
+                  aria-required="true"
+                  className={inputClass}
+                />
+                <select
+                  aria-label="Size unit"
+                  value={sizeUnit}
+                  onChange={(e) =>
+                    setSizeUnit(e.target.value as BinarySizeUnit)
+                  }
+                  className={inputClass + ' w-24'}
+                >
+                  {SIZE_INPUT_UNITS.map((u) => (
+                    <option key={u} value={u}>
+                      {u}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
 
             <div className={fieldWrap}>

--- a/src/components/contribute/ContributionsPage.tsx
+++ b/src/components/contribute/ContributionsPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useGetContributionsQuery } from '../../store/services/communityApi';
-import { formatBytes } from '../../utils';
+import { formatSize } from '../../utils';
 import Spinner from '../layout/Spinner';
 
 const ContributionsPage = () => {
@@ -71,7 +71,7 @@ const ContributionsPage = () => {
                   </td>
                   <td className="px-4 py-2 text-gray-400 text-xs">{c.type}</td>
                   <td className="px-4 py-2 text-gray-400 text-xs whitespace-nowrap">
-                    {c.sizeInBytes ? formatBytes(Number(c.sizeInBytes)) : '—'}
+                    {c.sizeInBytes ? formatSize(Number(c.sizeInBytes)) : '—'}
                   </td>
                   <td className="px-4 py-2 text-gray-400">
                     {c.collaborators.length

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,6 +27,75 @@ export const formatBytes = (bytes?: number): string => {
   return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${sizes[i]}`;
 };
 
+// Binary (1024-based) size units, smallest to largest.
+export const BINARY_SIZE_UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB'] as const;
+export type BinarySizeUnit = (typeof BINARY_SIZE_UNITS)[number];
+
+// Units offered in the contribution form's unit selector (bytes is too granular
+// to type by hand — the natural-string parser still accepts a bare "B").
+export const SIZE_INPUT_UNITS: BinarySizeUnit[] = ['KiB', 'MiB', 'GiB', 'TiB'];
+
+// Multipliers for every unit token parseSize recognizes. SI shorthands (KB, MB,
+// …) are treated as binary too, since that's what users usually mean here.
+const SIZE_UNIT_MULTIPLIERS: Record<string, number> = {
+  b: 1,
+  k: 1024,
+  kb: 1024,
+  kib: 1024,
+  m: 1024 ** 2,
+  mb: 1024 ** 2,
+  mib: 1024 ** 2,
+  g: 1024 ** 3,
+  gb: 1024 ** 3,
+  gib: 1024 ** 3,
+  t: 1024 ** 4,
+  tb: 1024 ** 4,
+  tib: 1024 ** 4
+};
+
+/**
+ * Parse a human-entered size into a byte count.
+ *
+ * Accepts a bare number (interpreted as `defaultUnit`) or a value with a unit
+ * suffix, e.g. `"4.5 GiB"`. A unit in the string overrides `defaultUnit`.
+ * Returns `null` when the input is empty, malformed, negative, has an
+ * unrecognized unit, or exceeds `Number.MAX_SAFE_INTEGER` (the backend Zod cap).
+ */
+export const parseSize = (
+  input: string,
+  defaultUnit: BinarySizeUnit = 'B'
+): number | null => {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([a-zA-Z]+)?$/);
+  if (!match) return null;
+  const value = parseFloat(match[1]);
+  if (!Number.isFinite(value) || value < 0) return null;
+  const unitToken = (match[2] ?? defaultUnit).toLowerCase();
+  const multiplier = SIZE_UNIT_MULTIPLIERS[unitToken];
+  if (multiplier === undefined) return null;
+  const bytes = Math.round(value * multiplier);
+  if (bytes > Number.MAX_SAFE_INTEGER) return null;
+  return bytes;
+};
+
+/**
+ * Format a byte count as a human-readable binary string, e.g. `"4.5 GiB"`.
+ * Trailing zeros are trimmed (`2 GiB`, not `2.00 GiB`); sub-KiB values stay in
+ * whole bytes.
+ */
+export const formatSize = (bytes?: number | null): string => {
+  if (!bytes || bytes < 0) return '0 B';
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    BINARY_SIZE_UNITS.length - 1
+  );
+  if (i === 0) return `${bytes} B`;
+  const value = bytes / Math.pow(1024, i);
+  const formatted = value.toFixed(2).replace(/\.?0+$/, '');
+  return `${formatted} ${BINARY_SIZE_UNITS[i]}`;
+};
+
 export const ordinalSuffix = (n: number): string => {
   const v = n % 100;
   if (v >= 11 && v <= 13) return `${n}th`;


### PR DESCRIPTION
## What

Replaces the raw "File size (MB)" number input on both contribution forms (`ContributeForm`, `AddContributionForm`) with a **value field + binary unit selector** (KiB/MiB/GiB/TiB). Users no longer hand-compute MB.

- Type a value and pick a unit (`4.5` + `GiB`), or type a natural string (`"4.5 GiB"`) which overrides the selected unit.
- Invalid input blocks submit with a clear message.
- **Bytes stay canonical** — `parseSize` guards negatives and the `Number.MAX_SAFE_INTEGER` cap (matching the API's Zod limit); the API contract (`sizeInBytes: number`) is unchanged.
- `formatSize` renders bytes back as binary units; the community / release / contributions size columns use it for unit-consistent display.

## Tests (TDD)

- New `parseSize`/`formatSize` unit suite (parsing, caps, round-trips).
- Form integration via RED→GREEN: value+unit → correct `sizeInBytes`, and invalid-size-blocks-submit, on both forms.
- Full suite green: **121 suites / 1173 tests**. format · lint · typecheck clean.

Closes #65.
Refs orphic-inc/stellar-api#81 (the BigInt canonical-store half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)