### PR TITLE
chore(lint): run stylelint --fix on .scss in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
       "eslint --fix",
       "prettier --write"
     ],
-    "*.{json,md,scss,css}": [
+    "*.scss": [
+      "stylelint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md,css}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
## What

Splits the `.scss` glob out of the prettier-only lint-staged rule so staged `.scss` files get `stylelint --fix` before commit:

```
"*.scss": ["stylelint --fix", "prettier --write"],
"*.{json,md,css}": ["prettier --write"]
```

stylelint (`^15.10.2`) + `.stylelintrc` are already configured and pass on the existing `src/index.scss`; this just wires them into the pre-commit path. Salvaged from a stranded local stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)